### PR TITLE
Feature/mmanyin/setup fixes

### DIFF
--- a/Shared/Chem_Base/CCMI_REF-C1/Chem_Registry.rc
+++ b/Shared/Chem_Base/CCMI_REF-C1/Chem_Registry.rc
@@ -20,8 +20,15 @@
 #         default configuration. For the complete list of TR tracers, see 
 #         Chem_MieRegistry.rc.
 #
-#         XX lists GMIchem's non-transported species.  See Chem_MieRegistry.rc
-#         for Stratchem's XX (inferred) species list.
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
 #
 # !REVISION HISTORY:
 #
@@ -62,26 +69,29 @@ doing_TR:  yes  # &YesNo run passive tracers?
 # for each of the constituents. Note nbins>1 may not be
 # supported by some constituents
 # ----------------------------------------------------
-nbins_H2O:  1   # water vapor
-nbins_O3:   1   # ozone
-nbins_CO:   1   # carbon monoxide
-nbins_CO2:  1   # carbon dioxide
-nbins_DU:   5   # mineral dust
-nbins_SS:   5   # sea salt
-nbins_SU:   8   # sulfates
-nbins_CFC:  2   # CFCs
-nbins_BC:   2   # black carbon
-nbins_OC:   2   # organic carbon
-nbins_BRC:  2   # brown carbon
-nbins_NI:   5   # nitrate
-nbins_Rn:   1   # radon
-nbins_CH4: 15   # methane
-nbins_SC:  52   # stratospheric chemistry
-nbins_XX:  48   # generic tracer
-nbins_PC:   1   # parameterized chemistry (GEOS-5)
-nbins_GMI: 72   # GMI chemistry (GEOS-5)
-nbins_OCS:  1   # ACHEM chemistry (OCS)
-nbins_TR:  21   # passive tracers
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:       1   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       8   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:     15   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_GMI:     72   # GMI chemistry (GEOS-5)
+nbins_XX_GMI:  48   # GMI non-transported species
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+nbins_TR:      21   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -229,7 +239,7 @@ NO3an2     'kg kg-1'    Nitrate size bin 002
 NO3an3     'kg kg-1'    Nitrate size bin 003
 ::
 
-variable_table_SC::
+variable_table_SC_f::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -285,6 +295,112 @@ HFC152A    'mol mol-1'  CH2CHF2
 CO2B       'mol mol-1'  Lat-depedent CO2  
 SF6B       'mol mol-1'  Sulfur hexafluoride
 AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2B       'mol mol-1'  Lat-depedent CO2
+SF6B       'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
 variable_table_GMI::
@@ -365,7 +481,7 @@ N2          cm-3        Molecular nitrogen
 HNO3COND   'mol mol-1'  Condensed nitric acid
 ::
 
-variable_table_XX::
+variable_table_XX_GMI::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -412,7 +528,7 @@ ROH        'mol mol-1'  C2 alcohols
 RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
 VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
 VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl Sulfide in GMI
+OCSg       'mol mol-1'  Carbonyl sulfide in GMI
 ACET       'mol mol-1'  Acetone
 O2          cm-3        Molecular oxygen
 NUMDENS     cm-3        Total number density

--- a/Shared/Chem_Base/CCMI_REF-C2/Chem_Registry.rc
+++ b/Shared/Chem_Base/CCMI_REF-C2/Chem_Registry.rc
@@ -20,8 +20,15 @@
 #         default configuration. For the complete list of TR tracers, see 
 #         Chem_MieRegistry.rc.
 #
-#         XX lists GMIchem's non-transported species.  See Chem_MieRegistry.rc
-#         for Stratchem's XX (inferred) species list.
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
 #
 # !REVISION HISTORY:
 #
@@ -62,26 +69,29 @@ doing_TR:  yes  # &YesNo run passive tracers?
 # for each of the constituents. Note nbins>1 may not be
 # supported by some constituents
 # ----------------------------------------------------
-nbins_H2O:  1   # water vapor
-nbins_O3:   1   # ozone
-nbins_CO:   1   # carbon monoxide
-nbins_CO2:  1   # carbon dioxide
-nbins_DU:   5   # mineral dust
-nbins_SS:   5   # sea salt
-nbins_SU:   8   # sulfates
-nbins_CFC:  2   # CFCs
-nbins_BC:   2   # black carbon
-nbins_OC:   2   # organic carbon
-nbins_BRC:  2   # brown carbon
-nbins_NI:   5   # nitrate
-nbins_Rn:   1   # radon
-nbins_CH4: 15   # methane
-nbins_SC:  52   # stratospheric chemistry
-nbins_XX:  48   # generic tracer
-nbins_PC:   1   # parameterized chemistry (GEOS-5)
-nbins_GMI: 72   # GMI chemistry (GEOS-5)
-nbins_OCS:  1   # ACHEM chemistry (OCS)
-nbins_TR:  21   # passive tracers
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:       1   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       8   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:     15   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_GMI:     72   # GMI chemistry (GEOS-5)
+nbins_XX_GMI:  48   # GMI non-transported species
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+nbins_TR:      21   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -229,7 +239,7 @@ NO3an2     'kg kg-1'    Nitrate size bin 002
 NO3an3     'kg kg-1'    Nitrate size bin 003
 ::
 
-variable_table_SC::
+variable_table_SC_f::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -285,6 +295,112 @@ HFC152A    'mol mol-1'  CH2CHF2
 CO2B       'mol mol-1'  Lat-depedent CO2  
 SF6B       'mol mol-1'  Sulfur hexafluoride
 AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2B       'mol mol-1'  Lat-depedent CO2
+SF6B       'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
 variable_table_GMI::
@@ -365,7 +481,7 @@ N2          cm-3        Molecular nitrogen
 HNO3COND   'mol mol-1'  Condensed nitric acid
 ::
 
-variable_table_XX::
+variable_table_XX_GMI::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -412,7 +528,7 @@ ROH        'mol mol-1'  C2 alcohols
 RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
 VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
 VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl Sulfide in GMI
+OCSg       'mol mol-1'  Carbonyl sulfide in GMI
 ACET       'mol mol-1'  Acetone
 O2          cm-3        Molecular oxygen
 NUMDENS     cm-3        Total number density

--- a/Shared/Chem_Base/CMIP/Chem_Registry.rc
+++ b/Shared/Chem_Base/CMIP/Chem_Registry.rc
@@ -20,8 +20,15 @@
 #         default configuration. For the complete list of TR tracers, see 
 #         Chem_MieRegistry.rc.
 #
-#         XX lists GMIchem's non-transported species.  See Chem_MieRegistry.rc
-#         for Stratchem's XX (inferred) species list.
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
 #
 # !REVISION HISTORY:
 #
@@ -62,26 +69,29 @@ doing_TR:  yes  # &YesNo run passive tracers?
 # for each of the constituents. Note nbins>1 may not be
 # supported by some constituents
 # ----------------------------------------------------
-nbins_H2O:  1   # water vapor
-nbins_O3:   1   # ozone
-nbins_CO:   1   # carbon monoxide
-nbins_CO2:  1   # carbon dioxide
-nbins_DU:   5   # mineral dust
-nbins_SS:   5   # sea salt
-nbins_SU:   4   # sulfates
-nbins_CFC:  2   # CFCs
-nbins_BC:   2   # black carbon
-nbins_OC:   2   # organic carbon
-nbins_BRC:  2   # brown carbon
-nbins_NI:   5   # nitrate
-nbins_Rn:   1   # radon
-nbins_CH4: 15   # methane
-nbins_SC:  52   # stratospheric chemistry
-nbins_XX:  48   # generic tracer
-nbins_PC:   1   # parameterized chemistry (GEOS-5)
-nbins_GMI: 72   # GMI chemistry (GEOS-5)
-nbins_OCS:  1   # ACHEM chemistry (OCS)
-nbins_TR:   4   # passive tracers
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:       1   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       4   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:     15   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_GMI:     72   # GMI chemistry (GEOS-5)
+nbins_XX_GMI:  48   # GMI non-transported species
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+nbins_TR:       4   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -229,7 +239,7 @@ NO3an2     'kg kg-1'    Nitrate size bin 002
 NO3an3     'kg kg-1'    Nitrate size bin 003
 ::
 
-variable_table_SC::
+variable_table_SC_f::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -285,6 +295,112 @@ HFC152A    'mol mol-1'  CH2CHF2
 CO2B       'mol mol-1'  Lat-depedent CO2  
 SF6B       'mol mol-1'  Sulfur hexafluoride
 AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2B       'mol mol-1'  Lat-depedent CO2
+SF6B       'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
 variable_table_GMI::
@@ -365,7 +481,7 @@ N2          cm-3        Molecular nitrogen
 HNO3COND   'mol mol-1'  Condensed nitric acid
 ::
 
-variable_table_XX::
+variable_table_XX_GMI::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -412,7 +528,7 @@ ROH        'mol mol-1'  C2 alcohols
 RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
 VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
 VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl Sulfide in GMI
+OCSg       'mol mol-1'  Carbonyl sulfide in GMI
 ACET       'mol mol-1'  Acetone
 O2          cm-3        Molecular oxygen
 NUMDENS     cm-3        Total number density

--- a/Shared/Chem_Base/Chem_Registry.rc
+++ b/Shared/Chem_Base/Chem_Registry.rc
@@ -20,8 +20,15 @@
 #         default configuration. For the complete list of TR tracers, see 
 #         Chem_MieRegistry.rc.
 #
-#         XX lists GMIchem's non-transported species.  See Chem_MieRegistry.rc
-#         for Stratchem's XX (inferred) species list.
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
 #
 # !REVISION HISTORY:
 #
@@ -62,26 +69,29 @@ doing_TR:  yes  # &YesNo run passive tracers?
 # for each of the constituents. Note nbins>1 may not be
 # supported by some constituents
 # ----------------------------------------------------
-nbins_H2O:  1   # water vapor
-nbins_O3:   1   # ozone
-nbins_CO:  10   # carbon monoxide
-nbins_CO2:  1   # carbon dioxide
-nbins_DU:   5   # mineral dust
-nbins_SS:   5   # sea salt
-nbins_SU:   4   # sulfates
-nbins_CFC:  2   # CFCs
-nbins_BC:   2   # black carbon
-nbins_OC:   2   # organic carbon
-nbins_BRC:  2   # brown carbon
-nbins_NI:   5   # nitrate
-nbins_Rn:   1   # radon
-nbins_CH4: 15   # methane
-nbins_SC:  52   # stratospheric chemistry
-nbins_XX:  48   # generic tracer
-nbins_PC:   1   # parameterized chemistry (GEOS-5)
-nbins_GMI: 72   # GMI chemistry (GEOS-5)
-nbins_OCS:  1   # ACHEM chemistry (OCS)
-nbins_TR:   4   # passive tracers
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:      10   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       4   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:     15   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_GMI:     72   # GMI chemistry (GEOS-5)
+nbins_XX_GMI:  48   # generic tracer
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+nbins_TR:       4   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -229,7 +239,7 @@ NO3an2     'kg kg-1'    Nitrate size bin 002
 NO3an3     'kg kg-1'    Nitrate size bin 003
 ::
 
-variable_table_SC::
+variable_table_SC_f::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -285,6 +295,112 @@ HFC152A    'mol mol-1'  CH2CHF2
 CO2B       'mol mol-1'  Lat-depedent CO2  
 SF6B       'mol mol-1'  Sulfur hexafluoride
 AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2B       'mol mol-1'  Lat-depedent CO2
+SF6B       'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
 variable_table_GMI::
@@ -365,7 +481,7 @@ N2          cm-3        Molecular nitrogen
 HNO3COND   'mol mol-1'  Condensed nitric acid
 ::
 
-variable_table_XX::
+variable_table_XX_GMI::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------

--- a/Shared/Chem_Base/MERRA2-DD/Chem_Registry.rc
+++ b/Shared/Chem_Base/MERRA2-DD/Chem_Registry.rc
@@ -20,8 +20,15 @@
 #         default configuration. For the complete list of TR tracers, see 
 #         Chem_MieRegistry.rc.
 #
-#         XX lists GMIchem's non-transported species.  See Chem_MieRegistry.rc
-#         for Stratchem's XX (inferred) species list.
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
 #
 # !REVISION HISTORY:
 #
@@ -62,26 +69,29 @@ doing_TR:  yes  # &YesNo run passive tracers?
 # for each of the constituents. Note nbins>1 may not be
 # supported by some constituents
 # ----------------------------------------------------
-nbins_H2O:  1   # water vapor
-nbins_O3:   1   # ozone
-nbins_CO:   1   # carbon monoxide
-nbins_CO2:  1   # carbon dioxide
-nbins_DU:   5   # mineral dust
-nbins_SS:   5   # sea salt
-nbins_SU:   4   # sulfates
-nbins_CFC:  2   # CFCs
-nbins_BC:   2   # black carbon
-nbins_OC:   2   # organic carbon
-nbins_BRC:  2   # brown carbon
-nbins_NI:   5   # nitrate
-nbins_Rn:   1   # radon
-nbins_CH4: 15   # methane
-nbins_SC:  52   # stratospheric chemistry
-nbins_XX:  48   # generic tracer
-nbins_PC:   1   # parameterized chemistry (GEOS-5)
-nbins_GMI: 72   # GMI chemistry (GEOS-5)
-nbins_OCS:  1   # ACHEM chemistry (OCS)
-nbins_TR:   4   # passive tracers
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:       1   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       4   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:     15   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_GMI:     72   # GMI chemistry (GEOS-5)
+nbins_XX_GMI:  48   # GMI non-transported species
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+nbins_TR:       4   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -229,7 +239,7 @@ NO3an2     'kg kg-1'    Nitrate size bin 002
 NO3an3     'kg kg-1'    Nitrate size bin 003
 ::
 
-variable_table_SC::
+variable_table_SC_f::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -285,6 +295,112 @@ HFC152A    'mol mol-1'  CH2CHF2
 CO2B       'mol mol-1'  Lat-depedent CO2  
 SF6B       'mol mol-1'  Sulfur hexafluoride
 AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2B       'mol mol-1'  Lat-depedent CO2
+SF6B       'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
 variable_table_GMI::
@@ -365,7 +481,7 @@ N2          cm-3        Molecular nitrogen
 HNO3COND   'mol mol-1'  Condensed nitric acid
 ::
 
-variable_table_XX::
+variable_table_XX_GMI::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -412,7 +528,7 @@ ROH        'mol mol-1'  C2 alcohols
 RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
 VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
 VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl Sulfide in GMI
+OCSg       'mol mol-1'  Carbonyl sulfide in GMI
 ACET       'mol mol-1'  Acetone
 O2          cm-3        Molecular oxygen
 NUMDENS     cm-3        Total number density

--- a/Shared/Chem_Base/MERRA2/Chem_Registry.rc
+++ b/Shared/Chem_Base/MERRA2/Chem_Registry.rc
@@ -20,8 +20,15 @@
 #         default configuration. For the complete list of TR tracers, see 
 #         Chem_MieRegistry.rc.
 #
-#         XX lists GMIchem's non-transported species.  See Chem_MieRegistry.rc
-#         for Stratchem's XX (inferred) species list.
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
 #
 # !REVISION HISTORY:
 #
@@ -62,26 +69,29 @@ doing_TR:  yes  # &YesNo run passive tracers?
 # for each of the constituents. Note nbins>1 may not be
 # supported by some constituents
 # ----------------------------------------------------
-nbins_H2O:  1   # water vapor
-nbins_O3:   1   # ozone
-nbins_CO:   1   # carbon monoxide
-nbins_CO2:  1   # carbon dioxide
-nbins_DU:   5   # mineral dust
-nbins_SS:   5   # sea salt
-nbins_SU:   4   # sulfates
-nbins_CFC:  2   # CFCs
-nbins_BC:   2   # black carbon
-nbins_OC:   2   # organic carbon
-nbins_BRC:  2   # brown carbon
-nbins_NI:   5   # nitrate
-nbins_Rn:   1   # radon
-nbins_CH4: 15   # methane
-nbins_SC:  52   # stratospheric chemistry
-nbins_XX:  48   # generic tracer
-nbins_PC:   1   # parameterized chemistry (GEOS-5)
-nbins_GMI: 72   # GMI chemistry (GEOS-5)
-nbins_OCS:  1   # ACHEM chemistry (OCS)
-nbins_TR:   4   # passive tracers
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:       1   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       4   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:     15   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_GMI:     72   # GMI chemistry (GEOS-5)
+nbins_XX_GMI:  48   # GMI non-transported species
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+nbins_TR:       4   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -229,7 +239,7 @@ NO3an2     'kg kg-1'    Nitrate size bin 002
 NO3an3     'kg kg-1'    Nitrate size bin 003
 ::
 
-variable_table_SC::
+variable_table_SC_f::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -285,6 +295,112 @@ HFC152A    'mol mol-1'  CH2CHF2
 CO2B       'mol mol-1'  Lat-depedent CO2  
 SF6B       'mol mol-1'  Sulfur hexafluoride
 AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2B       'mol mol-1'  Lat-depedent CO2
+SF6B       'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
 variable_table_GMI::
@@ -365,7 +481,7 @@ N2          cm-3        Molecular nitrogen
 HNO3COND   'mol mol-1'  Condensed nitric acid
 ::
 
-variable_table_XX::
+variable_table_XX_GMI::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -412,7 +528,7 @@ ROH        'mol mol-1'  C2 alcohols
 RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
 VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
 VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl Sulfide in GMI
+OCSg       'mol mol-1'  Carbonyl sulfide in GMI
 ACET       'mol mol-1'  Acetone
 O2          cm-3        Molecular oxygen
 NUMDENS     cm-3        Total number density

--- a/Shared/Chem_Base/NR/Chem_Registry.rc
+++ b/Shared/Chem_Base/NR/Chem_Registry.rc
@@ -20,8 +20,15 @@
 #         default configuration. For the complete list of TR tracers, see 
 #         Chem_MieRegistry.rc.
 #
-#         XX lists GMIchem's non-transported species.  See Chem_MieRegistry.rc
-#         for Stratchem's XX (inferred) species list.
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
 #
 # !REVISION HISTORY:
 #
@@ -62,26 +69,29 @@ doing_TR:  yes  # &YesNo run passive tracers?
 # for each of the constituents. Note nbins>1 may not be
 # supported by some constituents
 # ----------------------------------------------------
-nbins_H2O:  1   # water vapor
-nbins_O3:   1   # ozone
-nbins_CO:   1   # carbon monoxide
-nbins_CO2:  1   # carbon dioxide
-nbins_DU:   5   # mineral dust
-nbins_SS:   5   # sea salt
-nbins_SU:   4   # sulfates
-nbins_CFC:  2   # CFCs
-nbins_BC:   2   # black carbon
-nbins_OC:   2   # organic carbon
-nbins_BRC:  2   # brown carbon
-nbins_NI:   5   # nitrate
-nbins_Rn:   1   # radon
-nbins_CH4: 15   # methane
-nbins_SC:  52   # stratospheric chemistry
-nbins_XX:  48   # generic tracer
-nbins_PC:   1   # parameterized chemistry (GEOS-5)
-nbins_GMI: 72   # GMI chemistry (GEOS-5)
-nbins_OCS:  1   # ACHEM chemistry (OCS)
-nbins_TR:   4   # passive tracers
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:       1   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       4   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:     15   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_GMI:     72   # GMI chemistry (GEOS-5)
+nbins_XX_GMI:  48   # GMI non-transported species
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+nbins_TR:       4   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -229,7 +239,7 @@ NO3an2     'kg kg-1'    Nitrate size bin 002
 NO3an3     'kg kg-1'    Nitrate size bin 003
 ::
 
-variable_table_SC::
+variable_table_SC_f::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -285,6 +295,112 @@ HFC152A    'mol mol-1'  CH2CHF2
 CO2B       'mol mol-1'  Lat-depedent CO2  
 SF6B       'mol mol-1'  Sulfur hexafluoride
 AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2B       'mol mol-1'  Lat-depedent CO2
+SF6B       'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
 variable_table_GMI::
@@ -365,7 +481,7 @@ N2          cm-3        Molecular nitrogen
 HNO3COND   'mol mol-1'  Condensed nitric acid
 ::
 
-variable_table_XX::
+variable_table_XX_GMI::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -412,7 +528,7 @@ ROH        'mol mol-1'  C2 alcohols
 RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
 VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
 VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl Sulfide in GMI
+OCSg       'mol mol-1'  Carbonyl sulfide in GMI
 ACET       'mol mol-1'  Acetone
 O2          cm-3        Molecular oxygen
 NUMDENS     cm-3        Total number density

--- a/Shared/Chem_Base/PIESA/Chem_Registry.rc
+++ b/Shared/Chem_Base/PIESA/Chem_Registry.rc
@@ -20,8 +20,15 @@
 #         default configuration. For the complete list of TR tracers, see 
 #         Chem_MieRegistry.rc.
 #
-#         XX lists GMIchem's non-transported species.  See Chem_MieRegistry.rc
-#         for Stratchem's XX (inferred) species list.
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
 #
 # !REVISION HISTORY:
 #
@@ -62,26 +69,29 @@ doing_TR:  yes  # &YesNo run passive tracers?
 # for each of the constituents. Note nbins>1 may not be
 # supported by some constituents
 # ----------------------------------------------------
-nbins_H2O:  1   # water vapor
-nbins_O3:   1   # ozone
-nbins_CO:   1   # carbon monoxide
-nbins_CO2:  1   # carbon dioxide
-nbins_DU:   5   # mineral dust
-nbins_SS:   5   # sea salt
-nbins_SU:   4   # sulfates
-nbins_CFC:  2   # CFCs
-nbins_BC:   2   # black carbon
-nbins_OC:   2   # organic carbon
-nbins_BRC:  2   # brown carbon
-nbins_NI:   5   # nitrate
-nbins_Rn:   1   # radon
-nbins_CH4: 15   # methane
-nbins_SC:  52   # stratospheric chemistry
-nbins_XX:  48   # generic tracer
-nbins_PC:   1   # parameterized chemistry (GEOS-5)
-nbins_GMI: 72   # GMI chemistry (GEOS-5)
-nbins_OCS:  1   # ACHEM chemistry (OCS)
-nbins_TR:   4   # passive tracers
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:       1   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       4   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:     15   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_GMI:     72   # GMI chemistry (GEOS-5)
+nbins_XX_GMI:  48   # GMI non-transported species
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+nbins_TR:       4   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -229,7 +239,7 @@ NO3an2     'kg kg-1'    Nitrate size bin 002
 NO3an3     'kg kg-1'    Nitrate size bin 003
 ::
 
-variable_table_SC::
+variable_table_SC_f::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -285,6 +295,112 @@ HFC152A    'mol mol-1'  CH2CHF2
 CO2B       'mol mol-1'  Lat-depedent CO2  
 SF6B       'mol mol-1'  Sulfur hexafluoride
 AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2B       'mol mol-1'  Lat-depedent CO2
+SF6B       'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
 variable_table_GMI::
@@ -365,7 +481,7 @@ N2          cm-3        Molecular nitrogen
 HNO3COND   'mol mol-1'  Condensed nitric acid
 ::
 
-variable_table_XX::
+variable_table_XX_GMI::
 
 # Name     Units        Long Name
 # -----    ------       --------------------------------
@@ -412,7 +528,7 @@ ROH        'mol mol-1'  C2 alcohols
 RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
 VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
 VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl Sulfide in GMI
+OCSg       'mol mol-1'  Carbonyl sulfide in GMI
 ACET       'mol mol-1'  Acetone
 O2          cm-3        Molecular oxygen
 NUMDENS     cm-3        Total number density

--- a/StratChem_GridComp/CMakeLists.txt
+++ b/StratChem_GridComp/CMakeLists.txt
@@ -1,5 +1,6 @@
 esma_set_this ()
 
+option(STRATCHEM_REDUCED_MECHANISM "reduces the number of chem species" OFF)
 
 set (subsrcs
   SC_GridCompMod.F90
@@ -76,6 +77,10 @@ include_directories (${include_GMAO_mpeu})
 set (dependencies Chem_Shared MAPL_Base MAPL_cfio_r4 GMAO_mpeu)
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies})
 target_include_directories (${this} PUBLIC ${INC_NETCDF})
+
+if (STRATCHEM_REDUCED_MECHANISM)
+   target_compile_definitions(${this} PRIVATE REDUCED)
+endif ()
 
 string (REPLACE "_GridComp" "" name ${this})
 


### PR DESCRIPTION
The reduced StratChem mechanism is now implemented properly in the CMake setting.
This involves files in both  GEOSchem_GridComp and GEOSgcm_App.
At the same time I simplified the work required in the setup, by including a few new variable tables in Chem_Registry.