### PR TITLE
Allow specifying chem resource files instead of hardcoding them

### DIFF
--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -151,6 +151,7 @@ contains
     type (GEOS_ChemGridComp), pointer :: myState   ! private, that is
     type (GEOS_ChemGridComp_Wrap)     :: wrap
     type(Chem_Registry)               :: chemReg
+    character(len=ESMF_MAXSTR) :: chem_gridcomp_rc_file
 
 !=============================================================================
 
@@ -182,11 +183,14 @@ contains
 !   -------------------------
     call ESMF_UserCompSetInternalState ( GC, 'GEOSchem_GridComp_State', wrap, STATUS )
     _VERIFY(STATUS)
+
+    call ESMF_ConfigGetAttribute(cf, chem_gridcomp_rc_file, label = "GEOS_ChemGridComp_RC_File:", &
+         default = "GEOS_ChemGridComp.rc", __RC__)
   
 ! Choose children to birth and which children not to conceive
 ! -----------------------------------------------------------
     myCF = ESMF_ConfigCreate(__RC__)
-    call ESMF_ConfigLoadFile ( myCF, 'GEOS_ChemGridComp.rc', __RC__ )
+    call ESMF_ConfigLoadFile ( myCF, chem_gridcomp_rc_file, __RC__ )
     call ESMF_ConfigGetAttribute(myCF,      myState%enable_PCHEM, Default=.FALSE., Label="ENABLE_PCHEM:",       __RC__ )
     call ESMF_ConfigGetAttribute(myCF,      myState%enable_ACHEM, Default=.FALSE., Label="ENABLE_ACHEM:",       __RC__ )
     call ESMF_ConfigGetAttribute(myCF,     myState%enable_GOCART, Default=.FALSE., Label="ENABLE_GOCART:",      __RC__ )

--- a/GOCART_GridComp/GOCART_GridCompMod.F90
+++ b/GOCART_GridComp/GOCART_GridCompMod.F90
@@ -124,6 +124,7 @@ CONTAINS
     real                            :: DEFVAL_CO2
 
     character(len=ESMF_MAXSTR)      :: field_name
+    character(len=ESMF_MAXSTR)      :: chem_registry_file
 
 !                              ------------
 
@@ -151,7 +152,10 @@ CONTAINS
         state%chemReg = Chem_RegistryCreate(STATUS, rcfile='GOCARTdata_AerRegistry.rc')
         _VERIFY(STATUS)
     else
-        state%chemReg = Chem_RegistryCreate(STATUS, rcfile='Chem_Registry.rc')
+       call ESMF_ConfigGetAttribute(cf, chem_registry_file, label = "Chem_Registry_File:", &
+            default = "Chem_Registry.rc", rc = status)
+       _VERIFY(status)
+       state%chemReg = Chem_RegistryCreate(STATUS, rcfile=chem_registry_file)
         _VERIFY(STATUS)
     end if    
 


### PR DESCRIPTION
This is another require feature for my 'over-the-wire' ctm. It allows the two models to use different chemistry resource files at the same time; one for the ctm and one for the agcm.