### PR TITLE
Fixes #21. Fixes for GNU compiler.

### DIFF
--- a/GEOSCHEMchem_GridComp/GEOSCHEMchem_GridCompMod.F90
+++ b/GEOSCHEMchem_GridComp/GEOSCHEMchem_GridCompMod.F90
@@ -242,8 +242,8 @@ MODULE GEOSCHEMchem_GridCompMod
                                       58.0,   58.0,  180.0,  180.0 ,     &
                                      180.0,  180.0,  132.0                /)
 
-  CHARACTER(LEN=15), PARAMETER :: COLLIST(8) = (/ 'NO2', 'O3',   'CH4', 'CO', &
-                                                  'BrO', 'CH2O', 'SO2', 'IO'  /)
+  CHARACTER(LEN=15), PARAMETER :: COLLIST(8) = (/ 'NO2 ', 'O3  ', 'CH4 ', 'CO  ', &
+                                                  'BrO ', 'CH2O', 'SO2 ', 'IO  '  /)
 #endif
  
   ! Pointers to import, export and internal state data. Declare them as 
@@ -4216,7 +4216,7 @@ CONTAINS
                 IF ( PerturbO3 ) THEN
                    IF ( FIXPERT < 0.0 ) THEN
                       CALL RANDOM_NUMBER(Harvest=Rnd)
-                      IF ( Rnd(2) >= 0.5 ) Rnd(1) = Rnd(1) * -1.0
+                      IF ( Rnd(2) >= 0.5 ) Rnd(1) = Rnd(1) * (-1.0)
                       Rnd(1) = 1.0 + ( Rnd(1) * MAXPERT )
                    ENDIF
                    Ptr3DA(I,J,L) = Ptr3DA(I,J,L) * Rnd(1)
@@ -4226,7 +4226,7 @@ CONTAINS
                 IF ( PerturbCO ) THEN
                    IF ( FIXPERT < 0.0 ) THEN
                       CALL RANDOM_NUMBER(Harvest=Rnd)
-                      IF ( Rnd(2) >= 0.5 ) Rnd(1) = Rnd(1) * -1.0
+                      IF ( Rnd(2) >= 0.5 ) Rnd(1) = Rnd(1) * (-1.0)
                       Rnd(1) = 1.0 + ( Rnd(1) * MAXPERT )
                    ENDIF
                    Ptr3DB(I,J,L) = Ptr3DB(I,J,L) * Rnd(1)

--- a/GEOSCHEMchem_GridComp/gc_column/GIGC/gigc_providerservices_mod.F90
+++ b/GEOSCHEMchem_GridComp/gc_column/GIGC/gigc_providerservices_mod.F90
@@ -128,8 +128,8 @@ MODULE gigc_providerservices_mod
                                       58.0,   58.0,  180.0,  180.0 ,     &
                                      180.0,  180.0,  132.0                /)
 
-  CHARACTER(LEN=15), PARAMETER :: COLLIST(8) = (/ 'NO2', 'O3',   'CH4', 'CO', &
-                                                  'BrO', 'CH2O', 'SO2', 'IO'  /)
+  CHARACTER(LEN=15), PARAMETER :: COLLIST(8) = (/ 'NO2 ', 'O3  ', 'CH4 ', 'CO  ', &
+                                                  'BrO ', 'CH2O', 'SO2 ', 'IO  '  /)
 
   ! Pointers for RATS and analysis OX. Those are not included in the GEOS-Chem
   ! registry and only filled if GEOS-Chem is the RATS and/or analysis OX 


### PR DESCRIPTION
Fixes the usual "all strings in character constructor must be the same
size".

Also a minor fix to a Warning where GNU didn't like Unary operator near
math operator:
```
/discover/nobackup/mathomp4/SystemTests/builds/AGCM_GITHUBDEVGNU/CURRENT/GEOSgcm/src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/GEOSCHEMchem_GridComp/GEOSCHEMchem_GridCompMod.F90:4219:62:

                       IF ( Rnd(2) >= 0.5 ) Rnd(1) = Rnd(1) * -1.0
                                                              1
Warning: Extension: Unary operator following arithmetic operator (use parentheses) at (1)
```