### PR TITLE
Update CODEOWNERS for chemistry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,27 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# This makes all files here owned by the Chem Gatekeepers
+# This makes all files here owned by the Chem Gatekeepers by default
 * @GEOS-ESM/chemistry-gatekeepers
+
+# Anton is CODEOWNER of some directories so he is informed
+DNA_GridComp/ @adarmenov
+GAAS_GridComp/ @adarmenov
+GEOSachem_GridComp/ @adarmenov
+GOCART_GridComp/ @adarmenov
+MAMchem_GridComp/ @adarmenov
+MATRIXchem_GridComp/ @adarmenov
+
+# Some files are important to both the gatekeepers and adarmenov
+Shared/Chem_Base/ @GEOS-ESM/chemistry-gatekeepers @adarmenov
+Shared/Chem_Shared/ @GEOS-ESM/chemistry-gatekeepers @adarmenov
+GEOS_ChemEnvGridComp.F90 @GEOS-ESM/chemistry-gatekeepers @adarmenov
+GEOS_ChemGridComp.F90 @GEOS-ESM/chemistry-gatekeepers @adarmenov
+
+# Christoph should be CODEOWNER of GCC and HEMCO
+GEOSCHEMchem_GridComp/ @christophkeller
+HEMCO_GridComp/ @christophkeller
+Shared/HEMCO/ @christophkeller
 
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team


### PR DESCRIPTION
Per @tclune, Arlindo was concerned that @adarmenov might not see some changes to GOCART. So a proposed set of changes to the `CODEOWNERS` file. 

1. I asked @adarmenov which ones he'd like knowledge over (though this should become an "aerosol-team" or something). 
2. A few areas are ones both @adarmenov and @GEOS-ESM/chemistry-gatekeepers both edit.  
3. And I also made @christophkeller a CODEOWNER 

Anything other than these or `CMake` fall back to the @GEOS-ESM/chemistry-gatekeepers 