### PR TITLE
Enforce GOCART_DT == HEARTBEAT_DT to avoid problems in gas phase GOCA…

### DIFF
--- a/GOCART_GridComp/GOCART_GridCompMod.F90
+++ b/GOCART_GridComp/GOCART_GridCompMod.F90
@@ -2264,12 +2264,11 @@ CONTAINS
 !  ----------------------------------------------------------------------------------------
 !  Assume that DT is always an integral number of seconds
 !  Add a fraction to both (and then truncate to int), to avoid cases like 900 /= 899.999999
-   if (int(cdt+0.2) /= int(hdt+0.2)) then
-      PRINT*,'   Implementation of GOCART_DT is problematic; set GOCART_DT = HEARTBEAT_DT.'
-      VERIFY_(234)
+   if (abs(cdt-hdt) > 0.1) then
+     __raise__(234, 'Implementation of GOCART_DT is problematic; set GOCART_DT = HEARTBEAT_DT')
    endif
-!  With the new MAPL:
-!  _ASSERT(int(cdt+0.2) /= int(hdt+0.2), 'needs informative message')
+!  With the new MAPL2.0, use this line instead of the 3 above:
+!  _ASSERT(abs(cdt-hdt) < 0.1, 'Implementation of GOCART_DT is problematic; set GOCART_DT = HEARTBEAT_DT')
 
    allocate(r4ZTH(SIZE(LATS,1), SIZE(LATS,2)), __STAT__)
    allocate(  ZTH(SIZE(LATS,1), SIZE(LATS,2)), __STAT__)

--- a/GOCART_GridComp/GOCART_GridCompMod.F90
+++ b/GOCART_GridComp/GOCART_GridCompMod.F90
@@ -2265,7 +2265,7 @@ CONTAINS
 !  Assume that DT is always an integral number of seconds
 !  Add a fraction to both (and then truncate to int), to avoid cases like 900 /= 899.999999
    if (int(cdt+0.2) /= int(hdt+0.2)) then
-      PRINT*,'   Implementation of GOCART_DT is problematic; set GOCART_DT equal to the HEARTBEAT_DT.'
+      PRINT*,'   Implementation of GOCART_DT is problematic; set GOCART_DT = HEARTBEAT_DT.'
       VERIFY_(234)
    endif
 !  With the new MAPL:

--- a/GOCART_GridComp/GOCART_GridCompMod.F90
+++ b/GOCART_GridComp/GOCART_GridCompMod.F90
@@ -2260,6 +2260,17 @@ CONTAINS
    call extract_ ( gc, clock, chemReg, gcChem, w_c, nymd, nhms, cdt, STATUS, state=myState )
    VERIFY_(STATUS)
 
+!  Until all the gas phase species handle GOCART_DT correctly, we must run at the heartbeat
+!  ----------------------------------------------------------------------------------------
+!  Assume that DT is always an integral number of seconds
+!  Add a fraction to both (and then truncate to int), to avoid cases like 900 /= 899.999999
+   if (int(cdt+0.2) /= int(hdt+0.2)) then
+      PRINT*,'   Implementation of GOCART_DT is problematic; set GOCART_DT equal to the HEARTBEAT_DT.'
+      VERIFY_(234)
+   endif
+!  With the new MAPL:
+!  _ASSERT(int(cdt+0.2) /= int(hdt+0.2), 'needs informative message')
+
    allocate(r4ZTH(SIZE(LATS,1), SIZE(LATS,2)), __STAT__)
    allocate(  ZTH(SIZE(LATS,1), SIZE(LATS,2)), __STAT__)
    allocate(  SLR(SIZE(LATS,1), SIZE(LATS,2)), __STAT__)


### PR DESCRIPTION
…RT species
Certain GOCART species do not properly handle the case where GOCART_DT /= HEARTBEAT_DT, so we abort the model if the two timesteps are not the same.  Eventually this should be remedied by updating the code for the problem species.