### PR TITLE
add predictor alarm into master

### DIFF
--- a/GAAS_GridComp/GAAS_GridCompMod.F90
+++ b/GAAS_GridComp/GAAS_GridCompMod.F90
@@ -399,9 +399,11 @@ CONTAINS
     type(ESMF_Config)             :: CF          ! Universal Config 
     type(ESMF_Time)               :: Time     ! Current time
     type(ESMF_Alarm)              :: Alarm
+    type(ESMF_Alarm)              :: Predictor_Alarm
 
     integer                       :: nymd, nhms, i550nm, izAOD, iyAOD
     logical                       :: analysis_time, fexists 
+    logical                       :: PREDICTOR_STEP
 
     character(len=ESMF_MAXSTR)    :: comp_name
 
@@ -440,6 +442,9 @@ CONTAINS
    analysis_time = ESMF_AlarmIsRinging(Alarm,__RC__)
 #endif
 
+   call ESMF_ClockGetAlarm(Clock,'PredictorActive',Predictor_Alarm,__RC__)
+   PREDICTOR_STEP = ESMF_AlarmIsRinging( Predictor_Alarm,__RC__)
+
 !  For some reason the alarm above is not working.
 !  For now, hardwire this...
 !  -----------------------------------------------
@@ -454,7 +459,7 @@ CONTAINS
 
 !  Stop here if it is NOT analysis time
 !  -------------------------------------
-   if ( .not. analysis_time ) then
+   if ( PREDICTOR_STEP .or. (.not. analysis_time) ) then
       RETURN_(ESMF_SUCCESS)
    end if
 

--- a/GOCART_GridComp/GOCART_GridCompMod.F90
+++ b/GOCART_GridComp/GOCART_GridCompMod.F90
@@ -2260,6 +2260,16 @@ CONTAINS
    call extract_ ( gc, clock, chemReg, gcChem, w_c, nymd, nhms, cdt, STATUS, state=myState )
    VERIFY_(STATUS)
 
+!  Until all the gas phase species handle GOCART_DT correctly, we must run at the heartbeat
+!  ----------------------------------------------------------------------------------------
+!  Assume that DT is always an integral number of seconds
+!  Add a fraction to both (and then truncate to int), to avoid cases like 900 /= 899.999999
+   if (abs(cdt-hdt) > 0.1) then
+     __raise__(234, 'Implementation of GOCART_DT is problematic; set GOCART_DT = HEARTBEAT_DT')
+   endif
+!  With the new MAPL2.0, use this line instead of the 3 above:
+!  _ASSERT(abs(cdt-hdt) < 0.1, 'Implementation of GOCART_DT is problematic; set GOCART_DT = HEARTBEAT_DT')
+
    allocate(r4ZTH(SIZE(LATS,1), SIZE(LATS,2)), __STAT__)
    allocate(  ZTH(SIZE(LATS,1), SIZE(LATS,2)), __STAT__)
    allocate(  SLR(SIZE(LATS,1), SIZE(LATS,2)), __STAT__)


### PR DESCRIPTION
This is a continuation of the pull request found here: https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/42#event-2948629293

In short, a PREDICTOR alarm was added within GAAS in order to get zero-diff when running REGULAR Replay within the new 4DIAU paradigm. We want this feature merged into our master branch to maintain zero-diff when the following pull-requests also get pulled into master branches (https://github.com/GEOS-ESM/GEOSgcm_App/pull/72 and https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/168).