### PR TITLE
Feature/mmanyin/gmi thru 19

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,21 @@
 AeroChem ChangeLog
+2019-10-09 <michael.manyin@nasa.gov> Tag: Icarus-3_2_p9_MEM_18
+    * In GMI, new values for ice and nat aerosols (surface area density)
+    * Also use CMIP6 files for surface area density
+    * GMI option to use HEMCO for MEGAN emissions
+    * In HEMCO, added a GMI instance
+    * In HEMCO GOCART instance added suffix to MEGAN emissions for symmetry
+    * In GOCART now disallow GOCART_DT /= HEARTBEAT_DT
+
+2019-10-09 <michael.manyin@nasa.gov> Tag: Icarus-3_2_p9_MEM_17
+    * Added RAS_NO_NEG option for guarding against negative tracer values
+
+2019-08-20 <michael.manyin@nasa.gov> Tag: Icarus-3_2_p9_MEM_16
+    * Added Jules' ship emissions option in GMI
+
+2019-07-16 <michael.manyin@nasa.gov> Tag: Icarus-3_2_p9_MEM_15
+    * Added Elliot's new aoa_bl tracer in TR
+
 2019-06-21 <michael.manyin@nasa.gov> Tag: Icarus-3_2_p9_MEM_15
     * In bundles, chem tracers now have grid comp prefix, to
       eliminate naming collisions

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -33,6 +33,7 @@ module GEOS_ChemGridCompMod
   use TR_GridCompMod,           only : TR_SetServices        => SetServices
   use DNA_GridCompMod,          only : DNA_SetServices       => SetServices
   use HEMCO_GridCompMod,        only : HEMCO_SetServices     => SetServices
+  use GmiESMFrcFileReading_mod, only : rcEsmfReadLogical
 
   implicit none
   private
@@ -126,7 +127,9 @@ contains
 !
 ! ErrLog Variables
 
-    __Iam__('SetServices')
+    __Iam__('SetServices')      ! NOTE: this macro declares STATUS
+                                ! ALSO: Never set Iam = TRIM(Iam) // suffix
+                                !       because Iam is a SAVED varaible
     character(len=ESMF_MAXSTR) :: COMP_NAME
 
 ! Locals
@@ -147,12 +150,26 @@ contains
     CHARACTER(LEN=ESMF_MAXSTR) :: shortName
     CHARACTER(LEN=ESMF_MAXSTR) :: str
 
+    !GMI MEGAN isoprene related 
+    CHARACTER(LEN=255) :: gmi_rcfilen = 'GMI_GridComp.rc'
+    TYPE(ESMF_Config)  :: gmi_config
+    LOGICAL  doMEGANemission,  doMEGANviaHEMCO
+
 !   Private state
 !   -------------
     type (GEOS_ChemGridComp), pointer :: myState   ! private, that is
     type (GEOS_ChemGridComp_Wrap)     :: wrap
     type(Chem_Registry)               :: chemReg
     character(len=ESMF_MAXSTR) :: chem_gridcomp_rc_file
+
+!   Related to HEMCO
+!   ----------------
+    type (ESMF_Config)          :: HemcoCF
+    character(len=ESMF_MAXSTR)  :: Label
+    character(len=ESMF_MAXSTR)  :: ConfigFile
+    integer                     :: nnInst
+    logical                     :: GOCART_instance_of_HEMCO   ! TRUE if HEMCO is running a GOCART instance
+    logical                     ::    GMI_instance_of_HEMCO   ! TRUE if HEMCO is running a GMI instance
 
 !=============================================================================
 
@@ -164,9 +181,8 @@ contains
     Iam = TRIM(COMP_NAME) // '::' //TRIM(Iam)
 
 !   Wrap internal state for storing in GC; rename legacyState
-!   -------------------------------------
-    allocate ( myState, stat=STATUS )
-    VERIFY_(STATUS)
+!   ---------------------------------------------------------
+    allocate ( myState, __STAT__ )
     wrap%ptr => myState
 
 !   Load the Chemistry Registry
@@ -188,26 +204,28 @@ contains
     call ESMF_ConfigGetAttribute(cf, chem_gridcomp_rc_file, label = "GEOS_ChemGridComp_RC_File:", &
          default = "GEOS_ChemGridComp.rc", __RC__)
   
-! Choose children to birth and which children not to conceive
-! -----------------------------------------------------------
+! Identify which children to run
+! ------------------------------
     myCF = ESMF_ConfigCreate(__RC__)
+
     call ESMF_ConfigLoadFile ( myCF, chem_gridcomp_rc_file, __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,      myState%enable_PCHEM, Default=.FALSE., Label="ENABLE_PCHEM:",       __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,      myState%enable_ACHEM, Default=.FALSE., Label="ENABLE_ACHEM:",       __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,     myState%enable_GOCART, Default=.FALSE., Label="ENABLE_GOCART:",      __RC__ )
+
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_PCHEM,      Default=.FALSE., Label="ENABLE_PCHEM:",       __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_ACHEM,      Default=.FALSE., Label="ENABLE_ACHEM:",       __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_GOCART,     Default=.FALSE., Label="ENABLE_GOCART:",      __RC__ )
     call ESMF_ConfigGetAttribute(myCF, myState%enable_GOCARTdata, Default=.FALSE., Label="ENABLE_GOCART_DATA:", __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,       myState%enable_GAAS, Default=.FALSE., Label="ENABLE_GAAS:",        __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,        myState%enable_H2O, Default=.FALSE., Label="ENABLE_H2O:",         __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,  myState%enable_STRATCHEM, Default=.FALSE., Label="ENABLE_STRATCHEM:",   __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,    myState%enable_GMICHEM, Default=.FALSE., Label="ENABLE_GMICHEM:",     __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,      myState%enable_CARMA, Default=.FALSE., Label="ENABLE_CARMA:",       __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,   myState%enable_GEOSCHEM, Default=.FALSE., Label="ENABLE_GEOSCHEM:",    __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,     myState%enable_MATRIX, Default=.FALSE., Label="ENABLE_MATRIX:",      __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,        myState%enable_MAM, Default=.FALSE., Label="ENABLE_MAM:",         __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,    myState%enable_MAMdata, Default=.FALSE., Label="ENABLE_MAM_DATA:",    __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,         myState%enable_TR, Default=.FALSE., Label="ENABLE_TR:",          __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,        myState%enable_DNA, Default=.FALSE., Label="ENABLE_DNA:",         __RC__ )
-    call ESMF_ConfigGetAttribute(myCF,      myState%enable_HEMCO, Default=.FALSE., Label="ENABLE_HEMCO:",       __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_GAAS,       Default=.FALSE., Label="ENABLE_GAAS:",        __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_H2O,        Default=.FALSE., Label="ENABLE_H2O:",         __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_STRATCHEM,  Default=.FALSE., Label="ENABLE_STRATCHEM:",   __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_GMICHEM,    Default=.FALSE., Label="ENABLE_GMICHEM:",     __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_CARMA,      Default=.FALSE., Label="ENABLE_CARMA:",       __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_GEOSCHEM,   Default=.FALSE., Label="ENABLE_GEOSCHEM:",    __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_MATRIX,     Default=.FALSE., Label="ENABLE_MATRIX:",      __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_MAM,        Default=.FALSE., Label="ENABLE_MAM:",         __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_MAMdata,    Default=.FALSE., Label="ENABLE_MAM_DATA:",    __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_TR,         Default=.FALSE., Label="ENABLE_TR:",          __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_DNA,        Default=.FALSE., Label="ENABLE_DNA:",         __RC__ )
+    call ESMF_ConfigGetAttribute(myCF, myState%enable_HEMCO,      Default=.FALSE., Label="ENABLE_HEMCO:",       __RC__ )
 
 !ALT: valgrind flagged a memory leak.    myState%CF => myCF ! save for later
     call ESMF_ConfigDestroy(myCF, __RC__)
@@ -695,12 +713,12 @@ contains
     SHORT_NAME  = (/ "TO3" /), &
     DST_ID=GEOSCHEM, SRC_ID=PCHEM, __RC__)
 
-
    ! added by ckeller, 10/31/2018
    CALL MAPL_AddConnectivity ( GC, &
     SRC_NAME  = (/"O3"/), &
     DST_NAME  = (/"PCHEM_O3"/), &
     DST_ID = GEOSCHEM, SRC_ID = PCHEM, __RC__  )
+
   END IF
 
   ! GOCART needs ozone for CFC12 photolysis.
@@ -716,15 +734,53 @@ contains
 
 ! HEMCO connections to CHEMENV
 ! -----------------------------
+  ! Default values:
+       GMI_instance_of_HEMCO = .FALSE.
+    GOCART_instance_of_HEMCO = .FALSE.
+
   IF( myState%enable_HEMCO ) THEN
-   CALL MAPL_AddConnectivity ( GC, &
-    SHORT_NAME  = (/ 'AIRDENS' /), &
-    DST_ID=HEMCO, SRC_ID=CHEMENV, __RC__)
+
+    CALL MAPL_AddConnectivity ( GC, SHORT_NAME  = (/ 'AIRDENS' /), DST_ID=HEMCO, SRC_ID=CHEMENV, __RC__)
+
+    !!!!!!!!!!!!!!!!!!
+    ! Determine if GOCART or GMI expect data from HEMCO:  
+    ! (adapted from HEMCO_GridCompMod.F90)
+    !!!!!!!!!!!!!!!!!!
+
+    ! Define ESMF config for HEMCO
+    HemcoCF = ESMF_ConfigCreate(__RC__)
+    CALL ESMF_ConfigLoadFile( HemcoCF, 'HEMCO_GridComp.rc', __RC__ )
+
+    ! Get number of instances
+    call ESMF_ConfigGetAttribute(HemcoCF, nnInst, Label="HEMCO_Instances:" , DEFAULT=1, __RC__)
+
+    ! Verbose
+    IF ( MAPL_Am_I_Root() ) WRITE(*,*) 'CHEMsetup - number of HEMCO instances: ', nnInst
+
+
+    ! Identify HEMCO instances
+    DO N = 1, nnInst
+
+       ! Get HEMCO configuration file names
+       WRITE(Label,'(a14,i3.3,a1)') 'HEMCO_CONFIG--',N,':'
+       call ESMF_ConfigGetAttribute( HemcoCF, ConfigFile, Label=TRIM(Label), &
+                                     DEFAULT="HEMCOsa_Config.rc", __RC__)
+
+       IF ( TRIM(ConfigFile) ==    'HEMCOgmi_Config.rc' )    GMI_instance_of_HEMCO = .TRUE.
+       IF ( TRIM(ConfigFile) == 'HEMCOgocart_Config.rc' ) GOCART_instance_of_HEMCO = .TRUE.
+
+       ! Verbose
+       IF ( MAPL_Am_I_Root() ) WRITE(*,'(a19,i3.3,a2,a)') '--> HEMCO instance ', N, ': ', TRIM(ConfigFile)
+
+    ENDDO
+
+    IF ( MAPL_Am_I_Root() ) WRITE(*,*) '-->    GMI_instance_of_HEMCO: ',    GMI_instance_of_HEMCO
+    IF ( MAPL_Am_I_Root() ) WRITE(*,*) '--> GOCART_instance_of_HEMCO: ', GOCART_instance_of_HEMCO
   END IF
 
 ! HEMCO -> GOCART
-! -----------------------------
-  IF( myState%enable_HEMCO .AND. myState%enable_GOCART ) THEN
+! ---------------
+  IF( myState%enable_HEMCO .AND. myState%enable_GOCART .and. GOCART_instance_of_HEMCO ) THEN
    CALL MAPL_AddConnectivity ( GC, &
     SHORT_NAME  = (/ 'SU_ANTHROL1' , 'SU_ANTHROL2',    &
                      'SU_SHIPSO2 ' , 'SU_SHIPSO4 ',    &
@@ -740,6 +796,52 @@ contains
     SRC_ID=HEMCO, DST_ID=GOCART, __RC__)
   END IF
 
+! HEMCO -> GMI 
+! ------------
+  IF( myState%enable_HEMCO .AND. myState%enable_GMICHEM ) THEN
+
+     ! MEM - NOTE: We have more flags than we need;
+     ! if we are running a GMI instance of HEMCO then it stands to reason that
+     ! doMEGANviaHEMCO and doMEGANemission are both TRUE.
+     ! Enforce consistency!
+     ! (We could just AddConnectivity for GMI_ISOPRENE without checking
+     ! whether it will be used, but if settings are inconsistent
+     ! the model may not be doing what the user expects.)
+
+     ! read GMI configuration
+     gmi_config = ESMF_ConfigCreate(__RC__ )
+     call ESMF_ConfigLoadFile(gmi_config, TRIM(gmi_rcfilen), __RC__ )
+
+     call rcEsmfReadLogical(gmi_config, doMEGANemission, &
+                                       "doMEGANemission:", default=.false., __RC__ )
+
+     call rcEsmfReadLogical(gmi_config, doMEGANviaHEMCO, &
+                                       "doMEGANviaHEMCO:", default=.false., __RC__ )
+       
+     ! make sure we don't have inconsistent HEMCO flags
+     IF ( GMI_instance_of_HEMCO /= doMEGANviaHEMCO ) THEN
+        PRINT*,'Inconsistency --- HEMCO GMI instance  = ', GMI_instance_of_HEMCO
+        PRINT*,'              --- GMI:doMEGANviaHEMCO = ', doMEGANviaHEMCO
+        STATUS=98
+        VERIFY_(STATUS)
+     END IF
+
+     ! make sure we don't have inconsistent MEGAN flags
+     IF ( doMEGANviaHEMCO == .TRUE.    .AND.  &
+          doMEGANemission == .FALSE. ) THEN
+        PRINT*,'Inconsistent GMI flags: doMEGANviaHEMCO==T, doMEGANemission==F'
+        STATUS=99
+        VERIFY_(STATUS)
+     END IF
+
+     ! connect HEMCO isoprene to GMI if doMEGANviaHEMCO is true
+     IF (doMEGANviaHEMCO) THEN
+        CALL MAPL_AddConnectivity ( GC,          &
+             SHORT_NAME  = (/'GMI_ISOPRENE'/),   &
+             SRC_ID=HEMCO, DST_ID=GMICHEM, __RC__)
+     ENDIF
+
+  END IF
 
 ! Finally, set the services
 ! -------------------------

--- a/GMIchem_GridComp/GMI_GridComp/GMI_ExtData.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_ExtData.rc
@@ -7,7 +7,7 @@ PrimaryExports%%
 #  Name      |     Units    |Clim |Mth|     Time Template    | Offset | Scale |     Variable    |      Template
 # -----------|--------------|-----|---|----------------------|--------|-------|-----------------|----------------------   
 ACET_FIXED       'mol mol-1' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  ACET		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
-SAD              'cm+2 cm-3' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  SAD		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/sad_dbc.x288_y181_z72_t12.2000.nc
+SAD              'cm+2 cm-3' 	N   N	%y4-%m2-%d2T12:00:00	 none	 none  lbssad            /discover/nobackup/mmanyin/CCM/emissions/CMIP6/SAD/sad_wt_CMIP6_x288_y181_z72_%y4.nc
 VEG_FRAC               'mil' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  VEG_FRAC 	 ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc
 LAI_FRAC                 '1' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  LAI_FRAC 	 ExtData/g5chem/sfc/LAI/lai_x720_y360_v72_t12_2008.nc
 SOILFERT      'ng N m-2 s-1' 	Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  soilFert 	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/fertilizer_GMI.x288_y181_t12.2006.nc

--- a/GMIchem_GridComp/GMI_GridComp/GMI_GridComp.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_GridComp.rc
@@ -6,7 +6,8 @@
         # Where is the GMI mechanism?
         #############################
 
-kineticsTextFile: setkin_chem_mech.txt___.rc
+# File not used, but kept for now as a reference:
+#kineticsTextFile: setkin_chem_mech.txt___.rc
 
         #############################
         # GMI Chemical Mechanism Name
@@ -167,6 +168,7 @@ emissionSpeciesLayers::
 # Ship Emissions requires SHIP_NO in ExtData:
 do_ShipEmission: T
 doMEGANemission: T
+doMEGANviaHEMCO: F
 
 isop_scale::
 1.0d0
@@ -283,9 +285,10 @@ sfalbedo_opt: 3
 # For FastJX & JPL10
 # cross section file: /discover/nobackup/ldoman/fvInput/xsec_jx_jpl10update2_JNOx1_0.dat
 # For FastJX 6.5 & JPL10
-cross_section_file: /discover/nobackup/ldoman/fvInput/fastjx/65/xsec_jx65_jpl10update2_JNOx1_0.dat
+cross_section_file: /discover/nobackup/mmanyin/fvInput/fastjx/65/xsec_jx65_jpl10update2_JNOx1_0.dat
 Prather_jNO_factor: 1.0
-#rate_file: ExtData/g5chem/x/ratec_119spc_jx_gmiv3.dat
+#rate_file not needed for FastJX6.5 and later; new approach only differs by roundoff
+#rate_file: ExtData/g5chem/x/ratec_124spc_jx_gmiv2.dat
 rate_file: /discover/nobackup/mmanyin/CCM/fvInput/fastjx/ratec_119spc_jx_gmiv3.dat
 T_O3_climatology_file: ExtData/g5chem/x/atms_jx_o3andtemp.dat
 do_ozone_inFastJX: F

--- a/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -188,7 +188,6 @@ CONTAINS
    CHARACTER(LEN=*), PARAMETER :: IAm    = 'GmiChem_GridCompClassInitialize'
    CHARACTER(LEN=255) :: rcfilen = 'GMI_GridComp.rc'
    CHARACTER(LEN=255) :: namelistFile
-   CHARACTER(LEN=255) :: kineticsTextFile
    CHARACTER(LEN=255) :: importRestartFile
    CHARACTER(LEN=255) :: string
    

--- a/GMIchem_GridComp/GMI_GridComp/GmiChemistry/sad/condense.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChemistry/sad/condense.F90
@@ -222,7 +222,7 @@
       real*8,  parameter :: DENSICE   =  1.0d0
       real*8,  parameter :: NICE      =  1.0d-2
       real*8,  parameter :: RICE      = 10.0d0
-      real*8,  parameter :: SATRATICE =  1.0d0
+      real*8,  parameter :: SATRATICE =  1.4d0
       real*8,  parameter :: SIGICE    =  1.6d0
 
 !     ------------------------------------
@@ -231,11 +231,11 @@
 
       logical, parameter :: CONSTANTNNAT = .true.
 
-      real*8,  parameter :: DENSNAT   = 1.6d0
-      real*8,  parameter :: NNAT      = 0.1d0
-      real*8,  parameter :: RNAT      = 0.4d0
-      real*8,  parameter :: SIGNAT    = 1.6d0
-      real*8,  parameter :: SATRATNAT = 1.0d0
+      real*8,  parameter :: DENSNAT   =  1.6d0
+      real*8,  parameter :: NNAT      =  0.1d0
+      real*8,  parameter :: RNAT      =  1.0d0
+      real*8,  parameter :: SIGNAT    =  1.6d0
+      real*8,  parameter :: SATRATNAT = 10.0d0
 
 !     ------------------------------------
 !     Parameters controlling sts aerosols:

--- a/GMIchem_GridComp/GMI_GridComp/GmiChemistry/stratTropMech/setkin_fastj.h
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChemistry/stratTropMech/setkin_fastj.h
@@ -1,0 +1,60 @@
+!=======================================================================
+!
+! $Id: setkin_fastj.h,v 1.1 2019/12/17 17:10:31 mmanyin Exp $
+!
+! FILE
+!   setkin_fastj.h - lookup matrix for GMI vs FastJX cross-sections
+!             (setkin_fastj.h)
+!   Oct 2018 - SDS
+!
+! DESCRIPTION
+!   Include file that provides ascii strings identifying
+!   GMI vs FastJX photo reaction names
+!
+!  Input mechanism file:    GMI_Combo_2015mechanism.txt
+!  Reaction dictionary:     GMI_reactions_JPL15.db
+!  Setkin files generated:  Tue Nov 20 18:21:26 2018
+!
+!=======================================================================
+!
+!.... 
+      integer idxph
+!
+!... Reference label for FastJX
+      character*6 :: fastj_lookup(NUM_J)
+      data (fastj_lookup(idxph), idxph=1,NUM_J) / &
+     & "O2    ", "O3    ", "O3(1D)", "NO    ", "N2O   ",  &
+     & "NO2   ", "H2O2  ", "CH3OOH", "H2COa ", "H2COb ",  &
+     & "HNO3  ", "HNO2  ", "HNO4  ", "NO3   ", "NO3   ",  &
+     & "N2O5  ", "HNO4  ", "Cl2   ", "OClO  ", "Cl2O2 ",  &
+     & "HOCl  ", "ClNO3a", "ClNO3b", "BrCl  ", "BrO   ",  &
+     & "HOBr  ", "BrNO3 ", "CH3Cl ", "CCl4  ", "MeCCl3",  &
+     & "CFCl3 ", "CF2Cl2", "F113  ", "F114  ", "F115  ",  &
+     & "F141b ", "F142b ", "CH3Br ", "H1301 ", "H1211 ",  &
+     & "H2402 ", "H1211 ", "ActAld", "PAN   ", "PrAld ",  &
+     & "Acet-a", "MEKeto", "GlyAld", "Glyxlb", "Glyxla",  &
+     & "Glyxlb", "MGlyxl", "MeVK  ", "MeVK  ", "MeAcr ",  &
+     & "Acet-a", "CH3OOH", "CH3OOH", "CH3OOH", "CH3OOH",  &
+     & "CH3OOH", "CH3OOH", "CH3OOH", "CH3OOH", "CH3OOH",  &
+     & "CH3OOH", "CH3OOH", "CH3OOH", "CH3OOH", "CH3OOH",  &
+     & "CH3NO3", "CH3OOH", "OCS   " /
+!... Quantum yield for photolysis
+      real*8 :: fastj_yield(NUM_J)
+      data (fastj_yield(idxph), idxph=1,NUM_J) / &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   3.330D-01,   8.860D-01,   1.140D-01,   &
+     &   1.000D+00,   6.670D-01,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   6.000D-01,   4.000D-01,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   1.000D+00,   &
+     &   1.000D+00,   1.000D+00,   1.000D+00  /
+!
+!... end setkin_fastj.h

--- a/GMIchem_GridComp/GMI_GridComp/GmiChemistry/stratTropMech/setkin_lchem.h
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChemistry/stratTropMech/setkin_lchem.h
@@ -18,7 +18,7 @@
 !=======================================================================
 
 
-      integer i
+      integer kmg_i
 
       character*16 lchemvar(NSP), ldynvar(NDYN)
       character*180 lqkchem(NUM_K),  lqjchem(NUM_J)
@@ -265,7 +265,7 @@
 !
 !.... Thermal reaction labels
 !
-      data (lqkchem(i), i=1,10) / &
+      data (lqkchem(kmg_i), kmg_i=1,10) / &
      & 'O + O2 = O3', &
      & 'O + O3 = 2 O2', &
      & 'N2 + O1D = N2 + O', &
@@ -277,7 +277,7 @@
      & 'N2O + O1D = N2 + O2', &
      & 'N2O + O1D = 2 NO' /
 
-      data (lqkchem(i), i=11,20) / &
+      data (lqkchem(kmg_i), kmg_i=11,20) / &
      & 'CH4 + O1D = MO2 + OH', &
      & 'CH4 + O1D = CH2O + H + HO2', &
      & 'CH4 + O1D = CH2O + H2', &
@@ -289,7 +289,7 @@
      & 'HCFC141b + O1D = 2 Cl', &
      & 'HCFC142b + O1D = Cl' /
 
-      data (lqkchem(i), i=21,30) / &
+      data (lqkchem(kmg_i), kmg_i=21,30) / &
      & 'H + O2 = HO2', &
      & 'H + O3 = O2 + OH', &
      & 'O + OH = H + O2', &
@@ -301,7 +301,7 @@
      & 'NO2 + O3 = NO3 + O2', &
      & 'OH + OH = H2O + O' /
 
-      data (lqkchem(i), i=31,40) / &
+      data (lqkchem(kmg_i), kmg_i=31,40) / &
      & 'OH + OH = H2O2', &
      & 'HO2 + OH = H2O + O2', &
      & 'H2O2 + OH = H2O + HO2', &
@@ -313,7 +313,7 @@
      & 'CH4 + OH = H2O + MO2', &
      & 'MO2 + NO = CH2O + HO2 + NO2' /
 
-      data (lqkchem(i), i=41,50) / &
+      data (lqkchem(kmg_i), kmg_i=41,50) / &
      & 'ClO + MO2 = CH2O + Cl + HO2 + O2', &
      & 'HO2 + MO2 = MP + O2', &
      & 'MO2 + MO2 = CH2O + MOH + O2', &
@@ -325,7 +325,7 @@
      & 'N + NO = N2 + O', &
      & 'NO2 + O = NO + O2' /
 
-      data (lqkchem(i), i=51,60) / &
+      data (lqkchem(kmg_i), kmg_i=51,60) / &
      & 'NO3 + O = NO2 + O2', &
      & 'NO2 + OH = HNO3', &
      & 'HNO3 + OH = H2O + NO3', &
@@ -337,7 +337,7 @@
      & 'HO2 + NO3 = NO2 + O2 + OH', &
      & 'NO + NO3 = 2 NO2' /
 
-      data (lqkchem(i), i=61,70) / &
+      data (lqkchem(kmg_i), kmg_i=61,70) / &
      & 'NO3 + OH = HO2 + NO2', &
      & 'NO2 + NO3 = N2O5', &
      & 'N2O5 = NO2 + NO3', &
@@ -349,7 +349,7 @@
      & 'Cl + H2 = H + HCl', &
      & 'Cl + H2O2 = HCl + HO2' /
 
-      data (lqkchem(i), i=71,80) / &
+      data (lqkchem(kmg_i), kmg_i=71,80) / &
      & 'Cl + HO2 = HCl + O2', &
      & 'Cl + HO2 = ClO + OH', &
      & 'ClO + O = Cl + O2', &
@@ -361,7 +361,7 @@
      & 'ClO + NO2 = ClONO2', &
      & 'ClO + ClO = 2 Cl + O2' /
 
-      data (lqkchem(i), i=81,90) / &
+      data (lqkchem(kmg_i), kmg_i=81,90) / &
      & 'ClO + ClO = Cl2 + O2', &
      & 'ClO + ClO = Cl + OClO', &
      & 'ClO + ClO = Cl2O2', &
@@ -373,7 +373,7 @@
      & 'Cl + ClONO2 = Cl2 + NO3', &
      & 'Br + O3 = BrO + O2' /
 
-      data (lqkchem(i), i=91,100) / &
+      data (lqkchem(kmg_i), kmg_i=91,100) / &
      & 'Br + HO2 = HBr + O2', &
      & 'Br + CH2O = CO + HBr + HO2', &
      & 'BrO + O = Br + O2', &
@@ -385,7 +385,7 @@
      & 'BrO + ClO = BrCl + O2', &
      & 'BrO + BrO = 2 Br + O2' /
 
-      data (lqkchem(i), i=101,110) / &
+      data (lqkchem(kmg_i), kmg_i=101,110) / &
      & 'HBr + OH = Br + H2O', &
      & 'CH2O + O = CO + HO2 + OH', &
      & 'CH4 + Cl = HCl + MO2', &
@@ -397,7 +397,7 @@
      & 'HCFC142b + OH = Cl + H2O', &
      & 'CH3Cl + Cl = CO + 2 HCl + HO2' /
 
-      data (lqkchem(i), i=111,120) / &
+      data (lqkchem(kmg_i), kmg_i=111,120) / &
      & 'CH3Br + OH = Br + H2O + HO2', &
      & 'A3O2 + HO2 = RA3P', &
      & 'A3O2 + MO2 =  0.75 CH2O + HO2 +  0.25 MOH +  0.75 RCHO +  0.25 ROH', &
@@ -409,7 +409,7 @@
      & 'ALK4 + NO3 = HNO3 + R4O2', &
      & 'ALK4 + OH = R4O2' /
 
-      data (lqkchem(i), i=121,130) / &
+      data (lqkchem(kmg_i), kmg_i=121,130) / &
      & 'ATO2 + HO2 = MCO3 + MO2', &
      & 'ATO2 + MCO3 = ACTA + MEK', &
      & 'ATO2 + MCO3 =  0.20 CH2O +  0.80 HO2 +  0.20 MCO3 +  0.80 MGLY + MO2', &
@@ -421,7 +421,7 @@
      & 'B3O2 + MO2 =  0.75 ACET +  0.75 CH2O + HO2 +  0.25 MOH +  0.25 ROH', &
      & 'B3O2 + NO = ACET + HO2 + NO2' /
 
-      data (lqkchem(i), i=131,140) / &
+      data (lqkchem(kmg_i), kmg_i=131,140) / &
      & 'C2H6 + NO3 = ETO2 + HNO3', &
      & 'C2H6 + OH = ETO2 + H2O', &
      & 'C2H6 + Cl = ETO2 + HCl', &
@@ -433,7 +433,7 @@
      & 'ETO2 + NO = ALD2 + HO2 + NO2', &
      & 'ETP + OH =  0.50 ALD2 +  0.50 ETO2 +  0.50 OH' /
 
-      data (lqkchem(i), i=141,150) / &
+      data (lqkchem(kmg_i), kmg_i=141,150) / &
      & 'GLYC + OH =  0.73 CH2O +  0.50 CO +  0.13 GLYX +  0.13 HCOOH +  0.77 HO2 +  0.23 OH', &
      & 'GLYC + OH = CO + HCOOH + OH', &
      & 'GLYX + NO3 = 2 CO + HNO3 + HO2', &
@@ -445,7 +445,7 @@
      & 'HO2 + MCO3 = MAP', &
      & 'IALD + O3 =  0.12 CH2O +  0.28 GLYC +  0.20 GLYX +  0.20 HAC +  0.20 HCOOH +  0.60 MGLY +  0.30 O3 +  0.10 OH' /
 
-      data (lqkchem(i), i=151,160) / &
+      data (lqkchem(kmg_i), kmg_i=151,160) / &
      & 'IALD + OH =  0.15 HO2 +  0.44 IAO2 +  0.41 MAO3', &
      & 'HO2 + IAO2 = IAP', &
      & 'IAO2 + MCO3 = ACTA + MEK', &
@@ -457,7 +457,7 @@
      & 'INO2 + MCO3 =  0.15 CH2O +  0.85 HNO3 +  0.80 HO2 +  0.10 MACR + MO2 +  0.05 MVK +  0.15 NO2', &
      & 'INO2 + MCO3 = ACTA + NO2 + RCHO' /
 
-      data (lqkchem(i), i=161,170) / &
+      data (lqkchem(kmg_i), kmg_i=161,170) / &
      & 'INO2 + MO2 =  0.83 CH2O +  0.43 HNO3 +  0.90 HO2 +  0.05 MACR +  0.25 MOH +  0.03 MVK +  0.57 NO2 +  0.25 RCHO +  0.25 ROH', &
      & 'INO2 + NO =  0.15 CH2O +  0.85 HNO3 +  0.80 HO2 +  0.10 MACR +  0.05 MVK +  1.15 NO2', &
      & 'INPN + OH = INO2', &
@@ -469,7 +469,7 @@
      & 'ISOP + NO3 = INO2', &
      & 'ISOP + O3 =  0.90 CH2O +  0.05 CO +  0.06 HO2 +  0.39 MACR +  0.16 MVK +  0.10 O3 +  0.27 OH +  0.07 PRPE' /
 
-      data (lqkchem(i), i=171,180) / &
+      data (lqkchem(kmg_i), kmg_i=171,180) / &
      & 'ISOP + OH = RIO2', &
      & 'HO2 + KO2 = MGLY + MO2', &
      & 'KO2 + MCO3 = ACTA + MEK', &
@@ -481,7 +481,7 @@
      & 'MACR + O3 =  0.70 CH2O +  0.20 CO +  0.28 HO2 +  0.80 MGLY +  0.20 O3 +  0.22 OH', &
      & 'MACR + OH =  0.53 MAO3 +  0.47 MRO2' /
 
-      data (lqkchem(i), i=181,190) / &
+      data (lqkchem(kmg_i), kmg_i=181,190) / &
      & 'HO2 + MAN2 = ISNP', &
      & 'MAN2 + MCO3 = CH2O + MGLY + MO2 + NO2', &
      & 'MAN2 + MCO3 = ACTA + NO2 + RCHO', &
@@ -493,7 +493,7 @@
      & 'MAO3 + MO2 = CH2O + RCOOH', &
      & 'MAO3 + NO2 = PMN' /
 
-      data (lqkchem(i), i=191,200) / &
+      data (lqkchem(kmg_i), kmg_i=191,200) / &
      & 'MAO3 + NO =  0.50 CH2O +  0.50 CO +  0.50 MCO3 +  0.50 MO2 + NO2', &
      & 'MAOP + OH = MAO3', &
      & 'A3O2 + MCO3 = ACTA + RCHO', &
@@ -505,7 +505,7 @@
      & 'MCO3 + MO2 = CH2O + HO2 + MO2', &
      & 'MCO3 + NO2 = PAN' /
 
-      data (lqkchem(i), i=201,210) / &
+      data (lqkchem(kmg_i), kmg_i=201,210) / &
      & 'MCO3 + NO = MO2 + NO2', &
      & 'MCO3 + PO2 = ACTA +  0.65 HAC +  0.35 RCHO', &
      & 'MCO3 + PO2 = ALD2 + CH2O + HO2 + MO2', &
@@ -517,7 +517,7 @@
      & 'HO2 + MRO2 = MRP', &
      & 'MCO3 + MRO2 = ACTA + MEK' /
 
-      data (lqkchem(i), i=211,220) / &
+      data (lqkchem(kmg_i), kmg_i=211,220) / &
      & 'MCO3 + MRO2 =  0.17 CH2O +  0.83 CO +  0.83 HAC + HO2 +  0.17 MGLY + MO2', &
      & 'MO2 + MRO2 = CH2O +  0.60 CO +  0.60 HAC + HO2 +  0.25 MGLY +  0.15 ROH', &
      & 'MRO2 + NO = HNO3', &
@@ -529,7 +529,7 @@
      & 'OH + RCHO = H2O + RCO3', &
      & 'PAN = MCO3 + NO2' /
 
-      data (lqkchem(i), i=221,230) / &
+      data (lqkchem(kmg_i), kmg_i=221,230) / &
      & 'PMN = MAO3 + NO2', &
      & 'O3 + PMN =  0.60 CH2O + HO2 + NO2', &
      & 'OH + PMN = CO + HAC + NO2', &
@@ -541,7 +541,7 @@
      & 'HO2 + PRN1 = PRPN', &
      & 'MCO3 + PRN1 = ALD2 + CH2O + MO2 + NO2' /
 
-      data (lqkchem(i), i=231,240) / &
+      data (lqkchem(kmg_i), kmg_i=231,240) / &
      & 'MCO3 + PRN1 = ACTA + NO2 + RCHO', &
      & 'MO2 + PRN1 =  0.50 ALD2 +  1.25 CH2O +  0.50 HO2 +  0.25 MOH + NO2 +  0.25 RCHO +  0.25 ROH', &
      & 'NO + PRN1 = ALD2 + CH2O + 2 NO2', &
@@ -553,7 +553,7 @@
      & 'MCO3 + R4N1 =  0.75 ALD2 +  0.39 CH2O + MO2 + NO2 +  0.30 R4O2 +  0.57 RCHO', &
      & 'MCO3 + R4N1 = ACTA + NO2 + RCHO' /
 
-      data (lqkchem(i), i=241,250) / &
+      data (lqkchem(kmg_i), kmg_i=241,250) / &
      & 'MO2 + R4N1 =  0.38 ALD2 +  0.95 CH2O +  0.50 HO2 +  0.25 MOH + NO2 +  0.15 R4O2 +  0.54 RCHO +  0.25 ROH', &
      & 'NO + R4N1 =  0.75 ALD2 +  0.39 CH2O + 2 NO2 +  0.30 R4O2 +  0.57 RCHO', &
      & 'OH + R4N2 = H2O + R4N1', &
@@ -565,7 +565,7 @@
      & 'NO + R4O2 = R4N2', &
      & 'OH + R4P =  0.50 OH +  0.50 R4O2 +  0.50 RCHO' /
 
-      data (lqkchem(i), i=251,260) / &
+      data (lqkchem(kmg_i), kmg_i=251,260) / &
      & 'OH + RA3P =  0.50 A3O2 +  0.50 OH +  0.50 RCHO', &
      & 'OH + RB3P =  0.79 ACET +  0.21 B3O2 +  0.79 OH', &
      & 'NO3 + RCHO = HNO3 + RCO3', &
@@ -577,7 +577,7 @@
      & 'NO2 + RCO3 = PPN', &
      & 'NO + RCO3 = ETO2 + NO2' /
 
-      data (lqkchem(i), i=261,270) / &
+      data (lqkchem(kmg_i), kmg_i=261,270) / &
      & 'HO2 + RIO1 = RIP', &
      & 'MCO3 + RIO1 = ACTA + MEK', &
      & 'MCO3 + RIO1 =  0.75 CH2O + HO2 + IALD + MO2', &
@@ -589,7 +589,7 @@
      & 'MCO3 + RIO2 =  0.69 CH2O +  0.86 HO2 +  0.13 IALD +  0.29 MACR + MO2 +  0.40 MVK +  0.14 RIO1', &
      & 'MO2 + RIO2 =  1.10 CH2O +  0.93 HO2 +  0.06 IALD +  0.14 MACR +  0.25 MEK +  0.25 MOH +  0.20 MVK +  0.07 RIO1 +  0.25 ROH' /
 
-      data (lqkchem(i), i=271,280) / &
+      data (lqkchem(kmg_i), kmg_i=271,280) / &
      & 'NO + RIO2 = HNO3', &
      & 'NO + RIO2 =  0.69 CH2O +  0.86 HO2 +  0.13 IALD +  0.29 MACR +  0.40 MVK + NO2 +  0.14 RIO1', &
      & 'OH + RIP =  0.50 IAO2 +  0.10 RIO1 +  0.40 RIO2', &
@@ -601,7 +601,7 @@
      & 'MO2 + VRO2 =  0.89 CH2O +  0.36 GLYC +  0.64 HO2 +  0.36 MCO3 +  0.25 MEK +  0.14 MGLY +  0.25 MOH +  0.25 ROH', &
      & 'NO + VRO2 = HNO3' /
 
-      data (lqkchem(i), i=281,290) / &
+      data (lqkchem(kmg_i), kmg_i=281,290) / &
      & 'NO + VRO2 =  0.28 CH2O +  0.72 GLYC +  0.28 HO2 +  0.72 MCO3 +  0.28 MGLY + NO2', &
      & 'OH + VRP =  0.50 OH +  0.50 RCHO +  0.50 VRO2', &
      & 'N2O5 = 2 HNO3', &
@@ -613,7 +613,7 @@
      & 'N2O5 = 2 HNO3', &
      & 'ClONO2 = HNO3 + HOCl' /
 
-      data (lqkchem(i), i=291,300) / &
+      data (lqkchem(kmg_i), kmg_i=291,300) / &
      & 'BrONO2 = HNO3 + HOBr', &
      & 'ClONO2 + HCl = Cl2 + HNO3', &
      & 'HCl + HOCl = Cl2 + H2O', &
@@ -625,7 +625,7 @@
      & 'BrONO2 + HCl = BrCl + HNO3', &
      & 'HCl + HOBr = BrCl + H2O' /
 
-      data (lqkchem(i), i=301,310) / &
+      data (lqkchem(kmg_i), kmg_i=301,310) / &
      & 'ClONO2 = HNO3 + HOCl', &
      & 'BrONO2 = HNO3 + HOBr', &
      & 'ClONO2 + HCl = Cl2 + HNO3', &
@@ -637,13 +637,13 @@
      & 'HO2 =  0.50 H2O', &
      & 'NO2 =  0.50 HNO2 +  0.50 HNO3' /
 
-      data (lqkchem(i), i=311,312) / &
+      data (lqkchem(kmg_i), kmg_i=311,312) / &
      & 'NO3 = HNO3', &
      & 'N2O5 = 2 HNO3' /
 !
 !.... Photolytic reaction labels
 !
-      data (lqjchem(i), i=1,10) / &
+      data (lqjchem(kmg_i), kmg_i=1,10) / &
      & 'O2 + hv = 2 O', &
      & 'O3 + hv = O + O2', &
      & 'O3 + hv = O1D + O2', &
@@ -655,7 +655,7 @@
      & 'CH2O + hv = CO + H + HO2', &
      & 'CH2O + hv = CO + H2' /
 
-      data (lqjchem(i), i=11,20) / &
+      data (lqjchem(kmg_i), kmg_i=11,20) / &
      & 'HNO3 + hv = NO2 + OH', &
      & 'HNO2 + hv = NO + OH', &
      & 'HNO4 + hv = NO3 + OH', &
@@ -667,7 +667,7 @@
      & 'OClO + hv = ClO + O', &
      & 'Cl2O2 + hv = 2 Cl + O2' /
 
-      data (lqjchem(i), i=21,30) / &
+      data (lqjchem(kmg_i), kmg_i=21,30) / &
      & 'HOCl + hv = Cl + OH', &
      & 'ClONO2 + hv = Cl + NO3', &
      & 'ClONO2 + hv = ClO + NO2', &
@@ -679,7 +679,7 @@
      & 'CCl4 + hv = 4 Cl', &
      & 'CH3CCl3 + hv = 3 Cl' /
 
-      data (lqjchem(i), i=31,40) / &
+      data (lqjchem(kmg_i), kmg_i=31,40) / &
      & 'CFCl3 + hv = 3 Cl', &
      & 'CF2Cl2 + hv = 2 Cl', &
      & 'CFC113 + hv = 3 Cl', &
@@ -691,7 +691,7 @@
      & 'CF3Br + hv = Br', &
      & 'CF2Br2 + hv = 2 Br' /
 
-      data (lqjchem(i), i=41,50) / &
+      data (lqjchem(kmg_i), kmg_i=41,50) / &
      & 'H2402 + hv = 2 Br', &
      & 'CF2ClBr + hv = Br + Cl', &
      & 'ALD2 + hv = CO + HO2 + MO2', &
@@ -703,7 +703,7 @@
      & 'GLYX + hv = 2 CO + H2', &
      & 'GLYX + hv = 2 CO + 2 HO2' /
 
-      data (lqjchem(i), i=51,60) / &
+      data (lqjchem(kmg_i), kmg_i=51,60) / &
      & 'GLYX + hv = CH2O + CO', &
      & 'MGLY + hv = CO + HO2 + MCO3', &
      & 'MVK + hv = CO + PRPE', &
@@ -715,7 +715,7 @@
      & 'ETP + hv = ALD2 + HO2 + OH', &
      & 'RA3P + hv = HO2 + OH + RCHO' /
 
-      data (lqjchem(i), i=61,70) / &
+      data (lqjchem(kmg_i), kmg_i=61,70) / &
      & 'RB3P + hv = HO2 + OH + RCHO', &
      & 'R4P + hv = HO2 + OH + RCHO', &
      & 'PP + hv = HO2 + OH + RCHO', &
@@ -727,7 +727,7 @@
      & 'MRP + hv =  0.17 CH2O +  0.83 CO +  0.83 HAC + HO2 +  0.17 MGLY + OH', &
      & 'MAOP + hv = HO2 + OH + RCHO' /
 
-      data (lqjchem(i), i=71,73) / &
+      data (lqjchem(kmg_i), kmg_i=71,73) / &
      & 'R4N2 + hv =  0.05 A3O2 +  0.32 ACET +  0.32 ALD2 +  0.18 B3O2 +  0.32 ETO2 +  0.27 HO2 +  0.19 MEK +  0.18 MO2 + NO2 +  0.13 RCHO', &
      & 'MAP + hv = MO2 + OH', &
      & 'OCSg + hv = CO' /

--- a/GMIchem_GridComp/GMI_GridComp/GmiDepos_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiDepos_GridCompClassMod.F90
@@ -185,7 +185,6 @@ CONTAINS
 
    CHARACTER(LEN=*), PARAMETER :: IAm = 'GmiDepos_GridCompInitialize'
    CHARACTER(LEN=255) :: rcfilen = 'GMI_GridComp.rc'
-   CHARACTER(LEN=255) :: kineticsTextFile
    CHARACTER(LEN=255) :: importRestartFile
    CHARACTER(LEN=255) :: string
    
@@ -247,11 +246,6 @@ CONTAINS
       VERIFY_(STATUS)
 
       call ESMF_ConfigLoadFile(gmiConfigFile, TRIM(rcfilen), rc=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_ConfigGetAttribute(gmiConfigFile, kineticsTextFile, &
-     &                label   = "kineticsTextFile:", &
-     &                default = ' ', rc=STATUS )
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, importRestartFile, &

--- a/GMIchem_GridComp/GMI_GridComp/GmiDeposition/GmiDepositionMethod_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiDeposition/GmiDepositionMethod_mod.F90
@@ -17,8 +17,7 @@
       use GmiGrid_mod                  , only : Get_julo, Get_jhi
       use GmiGrid_mod                  , only : Get_ilong, Get_ivert
       use GmiPrintError_mod            , only : GmiPrintError
-      use GmiEmissionMethod_mod        , only : t_Emission, Get_iuse, Get_xlai
-      use GmiEmissionMethod_mod        , only : Get_ireg, Get_iland
+      use GmiEmissionMethod_mod        , only : t_Emission
       use GmiESMFrcFileReading_mod     , only : rcEsmfReadTable
       use GmiESMFrcFileReading_mod     , only : rcEsmfReadLogical
       use GmiArrayBundlePointer_mod    , only : t_GmiArrayBundle
@@ -259,8 +258,7 @@
 ! Run method for the Dry Deposition component
 !
 ! !LOCAL VARIABLES:
-      integer, allocatable :: iland(:,:,:), iuse(:,:,:), ireg(:,:)
-      real*8 , allocatable :: dry_depos (:,:,:), xlai(:,:,:)
+      real*8 , allocatable :: dry_depos (:,:,:)
       real*8  :: tdt8
       integer :: i1, i2, ju1, j2, k1, k2, ilong
       integer :: ilo, ihi, julo, jhi
@@ -286,20 +284,11 @@
 
       call Get_concentration(SpeciesConcentration, concentration)
 
-      allocate(ireg (i1:i2, ju1:j2))
-      allocate(iland(i1:i2, ju1:j2, NTYPE))
-      allocate(iuse (i1:i2, ju1:j2, NTYPE))
-      allocate(xlai (i1:i2, ju1:j2, NTYPE))
-
-      call Get_ireg  (Emission, ireg )
-      call Get_iland (Emission, iland)
-      call Get_iuse  (Emission, iuse )
-      call Get_xlai  (Emission, xlai )
-
       call Update_Drydep (pr_dry_depos, lwi_flags, mcor, cosSolarZenithAngle,  &
      &           fracCloudCover, radswg, surf_air_temp, surf_rough, ustar,     &
      &           mass, concentration, self%dry_depos, diffaer, s_radius,       &
-     &           s_velocity, BoxHeightEdge, ireg, iland, iuse, xlai, pr_diag,  &
+     &           s_velocity, BoxHeightEdge, Emission%ireg, Emission%iland,     &
+     &           Emission%iuse, Emission%xlai, pr_diag,                        &
      &           loc_proc, chem_opt, tdt8, i1, i2, ju1, j2, k1, k2, ilong, ilo,&
      &           ihi, julo, jhi, mw, numSpecies)
 
@@ -310,11 +299,6 @@
       end if
 
       call Set_concentration(SpeciesConcentration, concentration)
-
-      deallocate(ireg)
-      deallocate(iland)
-      deallocate(iuse)
-      deallocate(xlai)
 
       return
 

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -245,7 +245,6 @@ CONTAINS
    CHARACTER(LEN=*), PARAMETER :: IAm = 'GmiEmiss_GridCompInitialize'
    CHARACTER(LEN=255) :: rcfilen = 'GMI_GridComp.rc'
    CHARACTER(LEN=255) :: namelistFile
-   CHARACTER(LEN=255) :: kineticsTextFile
    CHARACTER(LEN=255) :: importRestartFile
    CHARACTER(LEN=255) :: string, fieldName
    
@@ -322,11 +321,6 @@ CONTAINS
       VERIFY_(STATUS)
 
       call ESMF_ConfigLoadFile(gmiConfigFile, TRIM(rcfilen), rc=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_ConfigGetAttribute(gmiConfigFile, kineticsTextFile, &
-     &                label   = "kineticsTextFile:", &
-     &                default = ' ', rc=STATUS )
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, importRestartFile, &
@@ -770,11 +764,8 @@ CONTAINS
    USE GmiTimeControl_mod,            ONLY : Set_gmiSeconds, GetSecondsFromJanuary1
    USE GmiSpcConcentrationMethod_mod, ONLY : resetFixedConcentration
    USE GmiSolar_mod,                  ONLY : CalcCosSolarZenithAngle
-   USE GmiEmissionMethod_mod,         ONLY : RunEmission, Get_emiss_monot
-   USE GmiEmissionMethod_mod,         ONLY : Get_emiss_opt, Get_emiss_isop, Get_emiss_nox
-   USE GmiEmissionMethod_mod,         ONLY : Get_surf_emiss_out2, Set_surf_emiss_out2
-   USE GmiEmissionMethod_mod,         ONLY : Get_emiss_3d_out, Set_emiss_3d_out
-   USE GmiEmissionMethod_mod,         ONLY : Get_lightning_opt, Set_flashrate, Get_lightning_no
+   USE GmiEmissionMethod_mod,         ONLY : RunEmission
+   USE GmiEmissionMethod_mod,         ONLY : Get_lightning_opt
 
    IMPLICIT none
 
@@ -839,7 +830,7 @@ CONTAINS
 
 !  Local
 !  -----
-   INTEGER :: cymd, dymd, emiss_opt, hms
+   INTEGER :: cymd, dymd, hms
    INTEGER :: i, i1, i2, ic, idehyd_num, im, iXj
    INTEGER :: j, j1, j2, jm
    INTEGER :: k, km, kReverse
@@ -901,8 +892,6 @@ CONTAINS
    REAL(KIND=DBL), ALLOCATABLE :: flashRate(:,:)
 
    REAL(KIND=DBL), ALLOCATABLE :: var2dDBL(:,:)
-   REAL(KIND=DBL), ALLOCATABLE :: var3dDBL(:,:,:)
-   REAL(KIND=DBL), ALLOCATABLE :: var4dDBL(:,:,:,:)
 
    REAL(KIND=DBL), ALLOCATABLE :: mass(:,:,:)
    REAL(KIND=DBL), ALLOCATABLE :: press3c(:,:,:)
@@ -1101,23 +1090,9 @@ CONTAINS
 ! ------------------------------------------------------------------------
    IF(self%do_emission .AND. self%gotImportRst) THEN
 
-    IF(self%pr_emiss_3d) THEN
-     ALLOCATE(var4dDBL(i1:i2,j1:j2,1:km,1:NSP),STAT=STATUS)
-     VERIFY_(STATUS)
-     var4dDBL(i1:i2,j1:j2,1:km,1:NSP) = 0.00D+00
-     Call Set_emiss_3d_out(self%Emission, var4dDBL)
-     DEALLOCATE(var4dDBL, STAT=STATUS)
-     VERIFY_(STATUS)
-    END IF
+    IF(self%pr_emiss_3d)   self%Emission%emiss_3d_out    = 0.00D+00
 
-    IF(self%pr_surf_emiss) THEN
-     ALLOCATE(var3dDBL(i1:i2,j1:j2,1:NSP),STAT=STATUS)
-     VERIFY_(STATUS)
-     var3dDBL(i1:i2,j1:j2,1:NSP) = 0.00D+00
-     Call Set_surf_emiss_out2(self%Emission, var3dDBL)
-     DEALLOCATE(var3dDBL, STAT=STATUS)
-     VERIFY_(STATUS)
-    END IF
+    IF(self%pr_surf_emiss) self%Emission%surf_emiss_out2 = 0.00D+00
 
 ! Grab lightning option, and pass flash rates to Emission
 !  0: Prescribed emission, NO_lgt
@@ -1125,7 +1100,7 @@ CONTAINS
 !  2: None
 ! --------------------------------------------------------
     CALL Get_lightning_opt(self%Emission, lightning_opt)
-    IF(lightning_opt == 1) CALL Set_flashrate(self%Emission, flashRate)
+    IF(lightning_opt == 1) self%Emission%flashrate(:,:) = flashRate(:,:)
 
     IF (self%Emission%do_ShipEmission) THEN
 
@@ -1262,6 +1237,8 @@ CONTAINS
   REAL, POINTER, DIMENSION(:,:,:) :: PTR3D
 
   REAL, PARAMETER :: VEG_MIN_VALID = 1.0
+
+  REAL :: qmin, qmax
   
   rc = 0
   IAm = "Acquire_Clims"
@@ -1354,6 +1331,15 @@ CONTAINS
 ! Read emission factors and convert from [micrograms C m^{-2} hr^{-1}] to [kg C box^{-1} dt^{-1}]
 ! -----------------------------------------------------------------------------------------------
    tokgCPerBox = tdt*1.00E-09/3600.00
+
+   IF(self%Emission%doMEGANviaHEMCO) THEN 
+   ! get MEGAN emissions pointers from HEMCO  (already kgC/m2/s)
+      CALL MAPL_GetPointer(impChem,   PTR2D, 'GMI_ISOPRENE', RC=STATUS)
+      VERIFY_(STATUS)
+      CALL pmaxmin('emiss_isop ptr in gmiEmiss:', PTR2D, qmin, qmax, iXj, 1, 1. )
+      self%Emission%emiss_isop(:,:) = PTR2D(:,:)
+      NULLIFY(PTR2D)
+   END IF
 
    importName = 'MEGAN_ISOP'
    CALL MAPL_GetPointer(impChem, PTR2D, TRIM(importName), RC=STATUS)
@@ -1605,6 +1591,8 @@ CONTAINS
 !---------------------------------------------------------------------------
   type(ESMF_FieldBundle)      :: sadBundle
   real(rPrec), pointer        :: ptr3D(:,:,:)
+  REAL                        :: qmin, qmax           ! for pmaxmin
+  real*4                      :: tmpisop(i1:i2,j1:j2) ! for pmaxmin
 
   CHARACTER(LEN=255) :: IAm
   rc = 0
@@ -1617,45 +1605,29 @@ CONTAINS
 ! Surface emissions.  GmiEmission says that
 ! these are kg s^{-1}. Convert to kg m^{-2} s^{-1}.
 ! -------------------------------------------------
-   CALL Get_emiss_opt(self%Emission, emiss_opt)
-   IF(self%do_emission .AND. emiss_opt == 2) THEN
-    ALLOCATE(var2dDBL(i1:i2,j1:j2), STAT=STATUS)
-    VERIFY_(STATUS)
+   IF(self%do_emission .AND. self%Emission%emiss_opt == 2) THEN
+     IF(ASSOCIATED(emNOx))         emNOx(:,:) = self%Emission%emiss_nox(  :,:)/self%cellArea(:,:)
+     IF(ASSOCIATED(emMonot))     emMonot(:,:) = self%Emission%emiss_monot(:,:)/self%cellArea(:,:)
+     IF(ASSOCIATED(emIsopSfc)) emIsopSfc(:,:) = self%Emission%emiss_isop( :,:)/self%cellArea(:,:)
 
-    IF(ASSOCIATED(emIsopSfc)) THEN
-     CALL Get_emiss_isop(self%Emission, var2dDBL)
-     emIsopSfc(i1:i2,j1:j2) = var2dDBL(i1:i2,j1:j2)/self%cellArea(i1:i2,j1:j2)
-    END IF
-    IF(ASSOCIATED(emNOx)) THEN
-     CALL Get_emiss_nox(self%Emission, var2dDBL)
-     emNOx(i1:i2,j1:j2) = var2dDBL(i1:i2,j1:j2)/self%cellArea(i1:i2,j1:j2)
-    END IF
-    IF(ASSOCIATED(emMonot)) THEN
-     CALL Get_emiss_monot(self%Emission, var2dDBL)
-     emMonot(i1:i2,j1:j2) = var2dDBL(i1:i2,j1:j2)/self%cellArea(i1:i2,j1:j2)
-    END IF
-
-    DEALLOCATE(var2dDBL, STAT=STATUS)
-    VERIFY_(STATUS)
+     IF(ASSOCIATED(emIsopSfc)) THEN
+       tmpisop = emIsopSfc(i1:i2,j1:j2) 
+       CALL pmaxmin('emIsopSfc in gmiEmiss:',tmpisop(:,:),qmin, qmax, iXj, 1, 1. ) 
+     END IF
    END IF
 
 ! Biogenic CO, soil NOx, and surface ship emissions.  GmiEmission says 
 ! that these are kg m^{-2} per time step.  Convert to kg m^{-2} s^{-1}.
 ! ---------------------------------------------------------------------
    IF(self%do_emission .AND. self%pr_surf_emiss) THEN
-    ALLOCATE(var3dDBL(i1:i2,j1:j2,6), STAT=STATUS)
-    VERIFY_(STATUS)
-    CALL Get_surf_emiss_out2(self%Emission, var3dDBL)
-    IF(ASSOCIATED( emBioCOMeth))   emBioCOMeth(i1:i2,j1:j2) = var3dDBL(i1:i2,j1:j2,1)*OneOverDt
-    IF(ASSOCIATED(emBioCOMonot))  emBioCOMonot(i1:i2,j1:j2) = var3dDBL(i1:i2,j1:j2,2)*OneOverDt
-    IF(ASSOCIATED(emBioPropene))  emBioPropene(i1:i2,j1:j2) = var3dDBL(i1:i2,j1:j2,3)*OneOverDt
-    IF(ASSOCIATED(   emSoilNOx))     emSoilNOx(i1:i2,j1:j2) = var3dDBL(i1:i2,j1:j2,4)*OneOverDt
+    IF(ASSOCIATED( emBioCOMeth))   emBioCOMeth(:,:) = self%Emission%surf_emiss_out2(:,:,1)*OneOverDt
+    IF(ASSOCIATED(emBioCOMonot))  emBioCOMonot(:,:) = self%Emission%surf_emiss_out2(:,:,2)*OneOverDt
+    IF(ASSOCIATED(emBioPropene))  emBioPropene(:,:) = self%Emission%surf_emiss_out2(:,:,3)*OneOverDt
+    IF(ASSOCIATED(   emSoilNOx))     emSoilNOx(:,:) = self%Emission%surf_emiss_out2(:,:,4)*OneOverDt
     IF(self%Emission%do_ShipEmission) THEN
-     IF(ASSOCIATED(  emShipHNO3))   emShipHNO3(i1:i2,j1:j2) = var3dDBL(i1:i2,j1:j2,5)*OneOverDt
-     IF(ASSOCIATED(    emShipO3))     emShipO3(i1:i2,j1:j2) = var3dDBL(i1:i2,j1:j2,6)*OneOverDt
+     IF(ASSOCIATED(  emShipHNO3))   emShipHNO3(:,:) = self%Emission%surf_emiss_out2(:,:,5)*OneOverDt
+     IF(ASSOCIATED(    emShipO3))     emShipO3(:,:) = self%Emission%surf_emiss_out2(:,:,6)*OneOverDt
     END IF
-    DEALLOCATE(var3dDBL, STAT=STATUS)
-    VERIFY_(STATUS)
    END IF
 
 ! EM_ emissions. Reverse in vertical and convert units if necessary.
@@ -1665,9 +1637,6 @@ CONTAINS
 
     ALLOCATE(var2dDBL(i1:i2,j1:j2), STAT=STATUS)
     VERIFY_(STATUS)
-    ALLOCATE(var4dDBL(i1:i2,j1:j2,km,NSP), STAT=STATUS)
-    VERIFY_(STATUS)
-    CALL Get_emiss_3d_out(self%Emission, var4dDBL)
 
 ! For each EM_ export ...
 ! -----------------------
@@ -1688,11 +1657,6 @@ CONTAINS
       IF(TRIM(fieldName) == "EM_LGTNO") THEN
 
        CALL Get_lightning_opt(self%Emission,lightning_opt)
-       IF(lightning_opt == 1) THEN
-        ALLOCATE(var3dDBL(i1:i2,j1:j2,1:km), STAT=STATUS)
-        VERIFY_(STATUS)
-        CALL Get_lightning_no(self%Emission, var3dDBL)
-       END IF
 
        DO k = 1,km 
         kReverse = km-k+1
@@ -1704,7 +1668,7 @@ CONTAINS
 	 EM_pointer(i1:i2,j1:j2,kReverse) = self%Emission%emissionArray(self%ic_NO_lgt)%pArray3D(i1:i2,j1:j2,k)/ &
 	                                    (gridBoxThickness(:,:,k)*self%cellArea(:,:))
 	CASE (1)
-         EM_pointer(i1:i2,j1:j2,kReverse) = var3dDBL(i1:i2,j1:j2,k)
+         EM_pointer(i1:i2,j1:j2,kReverse) = self%Emission%lightning_NO(i1:i2,j1:j2,k)
         CASE DEFAULT
 	 EM_pointer(i1:i2,j1:j2,k) = 0.00
         END SELECT
@@ -1727,11 +1691,6 @@ CONTAINS
 
        END DO
       
-       IF(lightning_opt == 1) THEN
-        DEALLOCATE(var3dDBL, STAT=STATUS)
-        VERIFY_(STATUS)
-       END IF
-
 !      Record the Overpass values   (note: AddExport done in GMIchem_GridCompMod.F90)
 !      ------------------------------------------------------------------------------
 
@@ -1760,12 +1719,12 @@ CONTAINS
 ! -----------------------------------------------------------
         SELECT CASE (unitsName)
         CASE ("kg m-2 s-1")
-         EM_pointer(i1:i2,j1:j2,kReverse) = var4dDBL(i1:i2,j1:j2,k,ic)*OneOverDt
+         EM_pointer(:,:,kReverse) = self%Emission%emiss_3d_out(:,:,k,ic)*OneOverDt
         CASE ("kg m-3 s-1")
-         EM_pointer(i1:i2,j1:j2,kReverse) = var4dDBL(i1:i2,j1:j2,k,ic)*OneOverDt/gridBoxThickness(:,:,k)
+         EM_pointer(:,:,kReverse) = self%Emission%emiss_3d_out(:,:,k,ic)*OneOverDt/gridBoxThickness(:,:,k)
         CASE ("mol mol-1 s-1")
-         var2dDBL(i1:i2,j1:j2) = OneOverDt*MAPL_AIRMW/(AIRDENS(:,:,kReverse)*mw*gridBoxThickness(:,:,k))
-         EM_pointer(i1:i2,j1:j2,kReverse) = var4dDBL(i1:i2,j1:j2,k,ic)*var2dDBL(i1:i2,j1:j2)
+         var2dDBL(:,:) = OneOverDt*MAPL_AIRMW/(AIRDENS(:,:,kReverse)*mw*gridBoxThickness(:,:,k))
+         EM_pointer(:,:,kReverse) = self%Emission%emiss_3d_out(:,:,k,ic)*var2dDBL(:,:)
         CASE DEFAULT
          PRINT *,TRIM(Iam)//": Modifications needed to export  "//TRIM(unitsName)//" for "//TRIM(fieldName)
          STATUS = -1 
@@ -1823,8 +1782,6 @@ CONTAINS
 
 ! Clean up
 ! --------
-    DEALLOCATE(var4dDBL, STAT=STATUS)
-    VERIFY_(STATUS)
     DEALLOCATE(var2dDBL, STAT=STATUS)
     VERIFY_(STATUS)
 

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmission/GmiEmissionMethod_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmission/GmiEmissionMethod_mod.F90
@@ -35,44 +35,13 @@
       public  :: RunEmission
       public  :: FinalizeEmission
     
-      public  :: Set_emissionArray
-      public  :: Set_emiss_isop  , Set_emiss_monot, Set_emiss_nox
-      public  :: Set_emiss_o3    , Set_emiss_hno3
-      public  :: Set_lightning_NO, Set_flashrate
-      public  :: Set_emissDust   , Set_emissAero
-      public  :: Set_emissDust_t , Set_emissAero_t
-      public  :: Set_isop_scale  , Set_aerosolSurfEmiss, Set_aerosolEmiss3D
-      public  :: Set_emiss_3d_out, Set_surf_emiss_out  , Set_surf_emiss_out2
-
-      public  :: Get_emissionArray
-      public  :: Get_emiss_isop          , Get_emiss_monot , Get_emiss_nox
-      public  :: Get_emiss_o3            , Get_emiss_hno3
-      public  :: Get_emiss_opt           , Get_emiss_in_opt
-      public  :: Get_emiss_map           , Get_emiss_timpyr
-      public  :: Get_lightning_NO        , Get_flashrate
-      public  :: Get_emissDust           , Get_emissAero
-      public  :: Get_emissDust_t         , Get_emissAero_t
-      public  :: Get_fertscal_infile_name
-      public  :: Get_lai_infile_name     , Get_precip_infile_name
-      public  :: Get_soil_infile_name    , Get_veg_infile_name
-      public  :: Get_isopconv_infile_name, Get_monotconv_infile_name
+!     public  :: Get_emissionArray
       public  :: Get_lightning_opt       , Get_emiss_aero_opt
       public  :: Get_emiss_dust_opt      , Get_num_emiss
       public  :: Get_ndust               , Get_naero
-      public  :: Get_nst_dust            , Get_nt_dust 
-      public  :: Get_emiss_map_dust      , Get_emiss_map_aero
-      public  :: Get_isop_scale          , Get_do_gcr
-      public  :: Get_do_semiss_inchem    , Get_do_ShipEmission, Get_doMEGANemission
-      public  :: Get_doReadDailyEmiss
-      public  :: Get_lightNOampFactor    , Get_numberNOPerFlash, Get_minDeepCloudTop
-      public  :: Get_begDailyEmissRec    , Get_endDailyEmissRec
-      public  :: Get_aerosolSurfEmiss    , Get_aerosolSurfEmissMap, Get_aerosolEmiss3D
-      public  :: Get_emiss_3d_out        , Get_surf_emiss_out     , Get_surf_emiss_out2
-      public  :: Get_ireg        , Get_iuse
-      public  :: Get_iland       , Get_ncon_soil
-      public  :: Get_xlai        , Get_xlai2
-      public  :: Get_base_isop   , Get_base_monot
-      public  :: Get_coeff_isop  , Get_convert_isop, Get_convert_monot
+      public  :: Get_do_gcr
+      public  :: Get_do_semiss_inchem
+      public  :: Get_lightNOampFactor    , Get_numberNOPerFlash
 !
 ! !PUBLIC MEMBER DATA:
       public  :: t_Emission
@@ -123,16 +92,9 @@
     logical             :: do_gcr 
                            ! ! Galactic Cosmic Ray  input file name
     character (len=MAX_LENGTH_FILE_NAME) :: gcr_infile_name 
-    character (len=MAX_LENGTH_FILE_NAME) :: fertscal_infile_name          ! fertilizer scale     input file name
-    character (len=MAX_LENGTH_FILE_NAME) :: lai_infile_name               ! leaf area index      input file name
-    character (len=MAX_LENGTH_FILE_NAME) :: precip_infile_name            ! precipitation        input file name
     character (len=MAX_LENGTH_FILE_NAME) :: soil_infile_name              ! soil type            input file name
-    character (len=MAX_LENGTH_FILE_NAME) :: veg_infile_name               ! vegetation type      input file name
     character (len=MAX_LENGTH_FILE_NAME) :: isopconv_infile_name          ! isoprene convert     input file name
     character (len=MAX_LENGTH_FILE_NAME) :: monotconv_infile_name         ! monoterpene convert  input file name
-    character (len=MAX_LENGTH_FILE_NAME) :: GOCARTerod_infile_name
-    character (len=MAX_LENGTH_FILE_NAME) :: GOCARTocean_infile_name
-    character (len=MAX_LENGTH_FILE_NAME) :: GOCARTerod_mod_infile_name
     real*8              :: isop_scale (12)               ! array of monthly isoprene scaling coefficients
 
     CHARACTER(LEN=64):: emissionSpeciesNames(MAX_NUM_CONST)  ! Names of emssions on netCDF/hdf file #
@@ -160,16 +122,13 @@
     integer          :: nt_dust                   ! ending   index for dust
     logical          :: do_ShipEmission           ! do ship emissions?
     logical          :: doMEGANemission           ! do MEGAN emissions?
-    character (len=MAX_LENGTH_FILE_NAME) :: laiMEGAN_InfileName    ! Inpuf file name for AVHRR
-                                                  ! leaf-area-indices
-    character (len=MAX_LENGTH_FILE_NAME) :: aefMboMEGAN_InfileName ! Annual emission factor for
-                                                  ! methyl butenol input file name
-    character (len=MAX_LENGTH_FILE_NAME) :: aefIsopMEGAN_InfileName ! Annual emission factor for
-                                                   ! isoprene input file name
-    character (len=MAX_LENGTH_FILE_NAME) :: aefMonotMEGAN_InfileName ! Annual emission factor for
-                                                    ! monoterpenes input file name
-    character (len=MAX_LENGTH_FILE_NAME) :: aefOvocMEGAN_InfileName ! Annual emission factor for other
-                                                   ! biogenic VOCs input file name
+    logical          :: doMEGANviaHEMCO           ! use HEMCO for MEGAN? 
+
+    character (len=MAX_LENGTH_FILE_NAME) ::      laiMEGAN_InfileName ! Inpuf file name for AVHRR leaf-area-indices
+    character (len=MAX_LENGTH_FILE_NAME) ::   aefMboMEGAN_InfileName ! Annual emission factor for methyl butenol input file name
+    character (len=MAX_LENGTH_FILE_NAME) ::  aefIsopMEGAN_InfileName ! Annual emission factor for isoprene input file name
+    character (len=MAX_LENGTH_FILE_NAME) :: aefMonotMEGAN_InfileName ! Annual emission factor for monoterpenes input file name
+    character (len=MAX_LENGTH_FILE_NAME) ::  aefOvocMEGAN_InfileName ! Annual emission factor for other biogenic VOCs input file name
     integer          :: days_btw_m     ! days between midmonths in the LAI data
     real*8 , pointer :: isoLai    (:,:) => null()  ! AVHRR LAI data for the current day
     real*8 , pointer :: isoLaiPrev(:,:) => null()  ! AVHRR LAI data for the previous month
@@ -219,9 +178,6 @@
     real*8 , pointer :: xlai        (:,:,:) => null()  ! leaf area index of land type for month #1
     real*8 , pointer :: xlai2       (:,:,:) => null()  ! leaf area index of land type for month #2
     type(t_GmiArrayBundle), pointer :: emissionArray(:)
-
-    logical       :: doReadDailyEmiss
-    integer       :: begDailyEmissRec, endDailyEmissRec
 
     real*8 , pointer    :: surf_emiss_out     (:,:,:)     => null()
     real*8 , pointer    :: surf_emiss_out2    (:,:,:)     => null()
@@ -388,24 +344,6 @@
       call rcEsmfReadTable(config, self%emissionSpeciesLayers, &
      &                     "emissionSpeciesLayers::", rc=STATUS)
 
-    !---------------------------------------
-    ! Reading of daily emission file options
-    !---------------------------------------
-
-      call rcEsmfReadLogical(config, self%doReadDailyEmiss, &
-     &           "doReadDailyEmiss:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
-
-      call ESMF_ConfigGetAttribute(config, self%begDailyEmissRec, &
-     &                label   = "begDailyEmissRec:", &
-     &                default = 1, rc=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_ConfigGetAttribute(config, self%endDailyEmissRec, &
-     &                label   = "endDailyEmissRec:", &
-     &                default = 366, rc=STATUS )
-      VERIFY_(STATUS)
-      
     ! --------------------------------------
     ! Aerosols and Sulfur from Penner et al.
     ! --------------------------------------
@@ -514,25 +452,6 @@
       call rcEsmfReadTable(config, self%isop_scale, &
      &                     "isop_scale::", rc=STATUS)
      
-    !     --------------------------------------
-    !     Aerosols and Sulfur from GOCART
-    !     --------------------------------------
-      
-      call ESMF_ConfigGetAttribute(config, self%GOCARTerod_infile_name, &
-     &                label   = "GOCARTerod_infile_name:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
-     
-      call ESMF_ConfigGetAttribute(config, self%GOCARTocean_infile_name, &
-     &                label   = "GOCARTocean_infile_name:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
-      
-      call ESMF_ConfigGetAttribute(config, self%GOCARTerod_mod_infile_name, &
-     &                label   = "GOCARTerod_mod_infile_name:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
-    
     !... do Galactic Cosmic Rays source of NOx?
     
       ! turn on Galactic Cosmic ray emmission of N and NO
@@ -554,6 +473,10 @@
 
       call rcEsmfReadLogical(config, self%doMEGANemission, &
      &           "doMEGANemission:", default=.false., rc=STATUS)
+      VERIFY_(STATUS)
+
+      call rcEsmfReadLogical(config, self%doMEGANviaHEMCO, &  
+     &           "doMEGANviaHEMCO:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(config, self%MEGAN_infile_name, &
@@ -586,29 +509,9 @@
      &                default = ' ', rc=STATUS )
       VERIFY_(STATUS)
      
-      call ESMF_ConfigGetAttribute(config, self%fertscal_infile_name, &
-     &                label   = "fertscal_infile_name:", &
-     &                default = 'fertscale_4x5_dao.asc', rc=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_ConfigGetAttribute(config, self%lai_infile_name, &
-     &                label   = "lai_infile_name:", &
-     &                default = 'lai_4x5_dao.asc', rc=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_ConfigGetAttribute(config, self%precip_infile_name, &
-     &                label   = "precip_infile_name:", &
-     &                default = 'precip_4x5_dao.asc', rc=STATUS )
-      VERIFY_(STATUS)
-
       call ESMF_ConfigGetAttribute(config, self%soil_infile_name, &
      &                label   = "soil_infile_name:", &
      &                default = 'soiltype.asc', rc=STATUS )
-      VERIFY_(STATUS)
-
-      call ESMF_ConfigGetAttribute(config, self%veg_infile_name, &
-     &                label   = "veg_infile_name:", &
-     &                default = 'vegtype_4x5_dao.asc', rc=STATUS )
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(config, self%isopconv_infile_name, &
@@ -811,7 +714,6 @@
                      pr_diag)
 !
 ! !USES:
-      use ReadOtherEmissionData_mod, only : readFertilizerData, readPrecipitationData
 
 ! !INPUT PARAMETERS:
       logical,           intent(in) :: pr_diag
@@ -962,10 +864,10 @@
      CALL Allocate_isoLaiPrev  (self, i1, i2, ju1, j2)
      CALL Allocate_isoLaiNext  (self, i1, i2, ju1, j2)
      CALL Allocate_isoLaiYear  (self, i1, i2, ju1, j2)
-     CALL Allocate_aefMbo  (self, i1, i2, ju1, j2)
-     CALL Allocate_aefIsop (self, i1, i2, ju1, j2)
-     CALL Allocate_aefOvoc (self, i1, i2, ju1, j2)
-     CALL Allocate_aefMonot(self, i1, i2, ju1, j2)
+     CALL Allocate_aefMbo      (self, i1, i2, ju1, j2)
+     CALL Allocate_aefIsop     (self, i1, i2, ju1, j2)
+     CALL Allocate_aefOvoc     (self, i1, i2, ju1, j2)
+     CALL Allocate_aefMonot    (self, i1, i2, ju1, j2)
     ELSE
      CALL Allocate_base_isop  (self, i1, i2, ju1, j2)
      CALL Allocate_base_monot (self, i1, i2, ju1, j2)
@@ -1140,8 +1042,7 @@
 
       character (len=128) err_msg
       integer       :: ydummy, thisDay, thisMonth, thisDate, ddummy, ic, curRecord
-      logical       :: doReadDailyEmiss, rootProc
-      integer       :: begDailyEmissRec, endDailyEmissRec
+      logical       :: rootProc
       integer       :: nymd, num_time_steps, ndt
       real*8        :: tdt8
       integer       :: i1, i2, ju1, j2, k, k1, k2, ilo, ihi, julo, jhi
@@ -1186,8 +1087,10 @@
 
      if (self%emiss_opt == 2) then
         self%emiss_monot = 0.0d0
-        self%emiss_isop  = 0.0d0
         self%emiss_nox   = 0.0d0
+        IF ( .not. self%doMEGANviaHEMCO ) THEN 
+           self%emiss_isop  = 0.0d0 
+        END IF
      end if
 
 ! For GOCART emission
@@ -1228,8 +1131,8 @@
      &           mw, tdt8, ndt, self%emiss_timpyr, self%num_emiss,             &
      &           self%isop_scale, i1, i2, ju1, j2, k1, k2, ilo, ihi, julo, jhi,&
      &           i1_gl, i2_gl, ju1_gl, j2_gl, ilong, numSpecies,               &
-     &           self%doMEGANemission, self%aefIsop, self%aefMbo,              &
-     &           self%aefMonot, self%isoLaiPrev, self%isoLaiCurr,              &
+     &           self%doMEGANemission, self%doMEGANviaHEMCO, self%aefIsop,     &
+     &           self%aefMbo, self%aefMonot, self%isoLaiPrev, self%isoLaiCurr, &
      &           self%isoLaiNext, pardif, pardir, T_15_AVG,                    &
      &           self%emissionSpeciesLayers, self%exp_fac, mixPBL)
 
@@ -1486,21 +1389,14 @@
     return
   end subroutine Allocate_emissionArray
 !-------------------------------------------------------------------------
-  subroutine Get_emissionArray (self, emissionArray)
-!    type (t_GmiArrayBundle), pointer, intent(out) :: emissionArray (:)
-    type (t_GmiArrayBundle), pointer :: emissionArray (:)
-    type (t_Emission), intent(in)   :: self
-!    emissionArray(:) = self%emissionArray(:)
-    emissionArray => self%emissionArray
-    return
-  end subroutine Get_emissionArray
-!-------------------------------------------------------------------------
-  subroutine Set_emissionArray (self, emissionArray)
-    type (t_GmiArrayBundle), pointer :: emissionArray (:)
-    type (t_Emission), intent(inOut) :: self
-    self%emissionArray => emissionArray
-    return
-  end subroutine Set_emissionArray
+!!   subroutine Get_emissionArray (self, emissionArray)
+!! !    type (t_GmiArrayBundle), pointer, intent(out) :: emissionArray (:)
+!!     type (t_GmiArrayBundle), pointer :: emissionArray (:)
+!!     type (t_Emission), intent(in)   :: self
+!! !    emissionArray(:) = self%emissionArray(:)
+!!     emissionArray => self%emissionArray
+!!     return
+!!   end subroutine Get_emissionArray
 !-------------------------------------------------------------------------
   subroutine Allocate_base_isop (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1510,20 +1406,6 @@
     return
   end subroutine Allocate_base_isop
 !-------------------------------------------------------------------------
-  subroutine Get_base_isop (self, base_isop)
-    real*8          , intent(out)  :: base_isop (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    base_isop(:,:,:) = self%base_isop(:,:,:)
-    return
-  end subroutine Get_base_isop
-!-------------------------------------------------------------------------
-  subroutine Set_base_isop (self, base_isop)
-    real*8          , intent(in)  :: base_isop (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%base_isop(:,:,:) = base_isop(:,:,:)
-    return
-  end subroutine Set_base_isop
-!-------------------------------------------------------------------------
   subroutine Allocate_base_monot (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
     type (t_Emission), intent(inOut) :: self
@@ -1531,20 +1413,6 @@
     self%base_monot = 0.0d0
     return
   end subroutine Allocate_base_monot
-!-------------------------------------------------------------------------
-  subroutine Get_base_monot (self, base_monot)
-    real*8          , intent(out)  :: base_monot (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    base_monot(:,:,:) = self%base_monot(:,:,:)
-    return
-  end subroutine Get_base_monot
-!-------------------------------------------------------------------------
-  subroutine Set_base_monot (self, base_monot)
-    real*8          , intent(in)  :: base_monot (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%base_monot(:,:,:) = base_monot(:,:,:)
-    return
-  end subroutine Set_base_monot
 !-------------------------------------------------------------------------
   subroutine Allocate_xlai (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1554,20 +1422,6 @@
     return
   end subroutine Allocate_xlai
 !-------------------------------------------------------------------------
-  subroutine Get_xlai (self, xlai)
-    real*8          , intent(out)  :: xlai (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    xlai(:,:,:) = self%xlai(:,:,:)
-    return
-  end subroutine Get_xlai
-!-------------------------------------------------------------------------
-  subroutine Set_xlai (self, xlai)
-    real*8          , intent(in)  :: xlai (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%xlai(:,:,:) = xlai(:,:,:)
-    return
-  end subroutine Set_xlai
-!-------------------------------------------------------------------------
   subroutine Allocate_xlai2 (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
     type (t_Emission), intent(inOut) :: self
@@ -1575,62 +1429,6 @@
     self%xlai2 = 0.0d0
     return
   end subroutine Allocate_xlai2
-!-------------------------------------------------------------------------
-  subroutine Get_xlai2 (self, xlai2)
-    real*8          , intent(out)  :: xlai2 (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    xlai2(:,:,:) = self%xlai2(:,:,:)
-    return
-  end subroutine Get_xlai2
-!-------------------------------------------------------------------------
-  subroutine Set_xlai2 (self, xlai2)
-    real*8          , intent(in)  :: xlai2 (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%xlai2(:,:,:) = xlai2(:,:,:)
-    return
-  end subroutine Set_xlai2
-!-------------------------------------------------------------------------
-  subroutine Get_coeff_isop (self, coeff_isop)
-    real*8          , intent(out)  :: coeff_isop (:)
-    type (t_Emission), intent(in)   :: self
-    coeff_isop(:) = self%coeff_isop(:)
-    return
-  end subroutine Get_coeff_isop
-!-------------------------------------------------------------------------
-  subroutine Set_coeff_isop (self, coeff_isop)
-    real*8          , intent(in)  :: coeff_isop (:)
-    type (t_Emission), intent(inOut) :: self
-    self%coeff_isop(:) = coeff_isop(:)
-    return
-  end subroutine Set_coeff_isop
-!-------------------------------------------------------------------------
-  subroutine Get_convert_isop (self, convert_isop)
-    real*8          , intent(out)  :: convert_isop (:)
-    type (t_Emission), intent(in)   :: self
-    convert_isop(:) = self%convert_isop(:)
-    return
-  end subroutine Get_convert_isop
-!-------------------------------------------------------------------------
-  subroutine Set_convert_isop (self, convert_isop)
-    real*8           , intent(in)  :: convert_isop (:)
-    type (t_Emission), intent(inOut) :: self
-    self%convert_isop(:) = convert_isop(:)
-    return
-  end subroutine Set_convert_isop
-!-------------------------------------------------------------------------
-  subroutine Get_convert_monot (self, convert_monot)
-    real*8           , intent(out)  :: convert_monot (:)
-    type (t_Emission), intent(in)   :: self
-    convert_monot(:) = self%convert_monot(:)
-    return
-  end subroutine Get_convert_monot
-!-------------------------------------------------------------------------
-  subroutine Set_convert_monot (self, convert_monot)
-    real*8           , intent(in)  :: convert_monot (:)
-    type (t_Emission), intent(inOut) :: self
-    self%convert_monot(:) = convert_monot(:)
-    return
-  end subroutine Set_convert_monot
 !-------------------------------------------------------------------------
   subroutine Allocate_iland (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1640,20 +1438,6 @@
     return
   end subroutine Allocate_iland
 !-------------------------------------------------------------------------
-  subroutine Get_iland (self, iland)
-    integer          , intent(out)  :: iland (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    iland(:,:,:) = self%iland(:,:,:)
-    return
-  end subroutine Get_iland
-!-------------------------------------------------------------------------
-  subroutine Set_iland (self, iland)
-    integer          , intent(in)  :: iland (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%iland(:,:,:) = iland(:,:,:)
-    return
-  end subroutine Set_iland
-!-------------------------------------------------------------------------
   subroutine Allocate_iuse (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
     type (t_Emission), intent(inOut) :: self
@@ -1661,20 +1445,6 @@
     self%iuse = 0
     return
   end subroutine Allocate_iuse
-!-------------------------------------------------------------------------
-  subroutine Get_iuse (self, iuse)
-    integer          , intent(out)  :: iuse (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    iuse(:,:,:) = self%iuse(:,:,:)
-    return
-  end subroutine Get_iuse
-!-------------------------------------------------------------------------
-  subroutine Set_iuse (self, iuse)
-    integer          , intent(in)  :: iuse (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%iuse(:,:,:) = iuse(:,:,:)
-    return
-  end subroutine Set_iuse
 !-------------------------------------------------------------------------
   subroutine Allocate_ireg (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1684,34 +1454,6 @@
     return
   end subroutine Allocate_ireg
 !-------------------------------------------------------------------------
-  subroutine Get_ireg (self, ireg)
-    integer          , intent(out)  :: ireg (:,:)
-    type (t_Emission), intent(in)   :: self
-    ireg(:,:) = self%ireg(:,:)
-    return
-  end subroutine Get_ireg
-!-------------------------------------------------------------------------
-  subroutine Set_ireg (self, ireg)
-    integer          , intent(in)  :: ireg (:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%ireg(:,:) = ireg(:,:)
-    return
-  end subroutine Set_ireg
-!-------------------------------------------------------------------------
-  subroutine Get_ncon_soil (self, ncon_soil)
-    integer          , intent(out)  :: ncon_soil (:)
-    type (t_Emission), intent(in)   :: self
-    ncon_soil(:) = self%ncon_soil(:)
-    return
-  end subroutine Get_ncon_soil
-!-------------------------------------------------------------------------
-  subroutine Set_ncon_soil (self, ncon_soil)
-    integer          , intent(in)  :: ncon_soil (:)
-    type (t_Emission), intent(inOut) :: self
-    self%ncon_soil(:) = ncon_soil(:)
-    return
-  end subroutine Set_ncon_soil
-!-------------------------------------------------------------------------
   subroutine Allocate_emissAero (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
     type (t_Emission)       , intent(inOut) :: self
@@ -1719,20 +1461,6 @@
     self%emissAero = 0.0d0
     return
   end subroutine Allocate_emissAero
-!-------------------------------------------------------------------------
-  subroutine Get_emissAero (self, emiss_aero)
-    real*8          , intent(out)  :: emiss_aero (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_aero(:,:,:) = self%emissAero(:,:,:)
-    return
-  end subroutine Get_emissAero
-!-------------------------------------------------------------------------
-  subroutine Set_emissAero (self, emiss_aero)
-    real*8          , intent(in)  :: emiss_aero (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emissAero(:,:,:) = emiss_aero(:,:,:) 
-    return
-  end subroutine Set_emissAero
 !-------------------------------------------------------------------------
   subroutine Allocate_emissDust (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1742,20 +1470,6 @@
     return
   end subroutine Allocate_emissDust
 !-------------------------------------------------------------------------
-  subroutine Get_emissDust (self, emiss_dust)
-    real*8           , intent(out)  :: emiss_dust (:,:,:)
-    type (t_Emission), intent(in )  :: self
-    emiss_dust(:,:,:) = self%emissDust(:,:,:)
-    return
-  end subroutine Get_emissDust
-!-------------------------------------------------------------------------
-  subroutine Set_emissDust (self, emiss_dust)
-    real*8           , intent(in   ) :: emiss_dust (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emissDust(:,:,:) = emiss_dust(:,:,:) 
-    return
-  end subroutine Set_emissDust
-!-------------------------------------------------------------------------
   subroutine Allocate_lightning_NO (self, i1, i2, ju1, j2, k1, k2)
     integer          , intent(in   ) :: i1, i2, ju1, j2, k1, k2
     type (t_Emission)      , intent(inOut) :: self
@@ -1763,20 +1477,6 @@
     self%lightning_NO = 0.0d0
     return
   end subroutine Allocate_lightning_NO
-!-------------------------------------------------------------------------
-  subroutine Get_lightning_NO (self, lightning_NO)
-    real*8          , intent(out)  :: lightning_NO (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    lightning_NO(:,:,:) = self%lightning_NO(:,:,:)
-    return
-  end subroutine Get_lightning_NO
-!-------------------------------------------------------------------------
-  subroutine Set_lightning_NO (self, lightning_NO)
-    real*8          , intent(in)  :: lightning_NO (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%lightning_NO(:,:,:) = lightning_NO(:,:,:) 
-    return
-  end subroutine Set_lightning_NO
 !-------------------------------------------------------------------------
   subroutine Allocate_emiss_isop (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1786,20 +1486,6 @@
     return
   end subroutine Allocate_emiss_isop
 !-------------------------------------------------------------------------
-  subroutine Get_emiss_isop (self, emiss_isop)
-    real*8          , intent(out)  :: emiss_isop (:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_isop(:,:) = self%emiss_isop(:,:)
-    return
-  end subroutine Get_emiss_isop
-!-------------------------------------------------------------------------
-  subroutine Set_emiss_isop (self, emiss_isop)
-    real*8          , intent(in)  :: emiss_isop (:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emiss_isop(:,:) = emiss_isop(:,:)
-    return
-  end subroutine Set_emiss_isop
-!-------------------------------------------------------------------------
   subroutine Allocate_emiss_monot (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
     type (t_Emission)      , intent(inOut) :: self
@@ -1807,20 +1493,6 @@
     self%emiss_monot = 0.0d0
     return
   end subroutine Allocate_emiss_monot
-!-------------------------------------------------------------------------
-  subroutine Get_emiss_monot (self, emiss_monot)
-    real*8          , intent(out)  :: emiss_monot (:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_monot(:,:) = self%emiss_monot(:,:)
-    return
-  end subroutine Get_emiss_monot
-!-------------------------------------------------------------------------
-  subroutine Set_emiss_monot (self, emiss_monot)
-    real*8          , intent(in)  :: emiss_monot (:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emiss_monot(:,:) = emiss_monot(:,:)
-    return
-  end subroutine Set_emiss_monot
 !-------------------------------------------------------------------------
   subroutine Allocate_emiss_nox (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1830,20 +1502,6 @@
     return
   end subroutine Allocate_emiss_nox
 !-------------------------------------------------------------------------
-  subroutine Get_emiss_nox (self, emiss_nox)
-    real*8          , intent(out)  :: emiss_nox (:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_nox(:,:) = self%emiss_nox(:,:)
-    return
-  end subroutine Get_emiss_nox
-!-------------------------------------------------------------------------
-  subroutine Set_emiss_nox (self, emiss_nox)
-    real*8          , intent(in)  :: emiss_nox (:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emiss_nox(:,:) = emiss_nox(:,:)
-    return
-  end subroutine Set_emiss_nox
-!-------------------------------------------------------------------------
   subroutine Allocate_emiss_hno3 (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
     type (t_Emission)      , intent(inOut) :: self
@@ -1851,20 +1509,6 @@
     self%emiss_hno3 = 0.0d0
     return
   end subroutine Allocate_emiss_hno3
-!-------------------------------------------------------------------------
-  subroutine Get_emiss_hno3 (self, emiss_hno3)
-    real*8          , intent(out)  :: emiss_hno3 (:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_hno3(:,:) = self%emiss_hno3(:,:)
-    return
-  end subroutine Get_emiss_hno3
-!-------------------------------------------------------------------------
-  subroutine Set_emiss_hno3 (self, emiss_hno3)
-    real*8          , intent(in)  :: emiss_hno3 (:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emiss_hno3(:,:) = emiss_hno3(:,:)
-    return
-  end subroutine Set_emiss_hno3
 !-------------------------------------------------------------------------
   subroutine Allocate_emiss_o3 (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1874,20 +1518,6 @@
     return
   end subroutine Allocate_emiss_o3
 !-------------------------------------------------------------------------
-  subroutine Get_emiss_o3 (self, emiss_o3)
-    real*8          , intent(out)  :: emiss_o3 (:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_o3(:,:) = self%emiss_o3(:,:)
-    return
-  end subroutine Get_emiss_o3
-!-------------------------------------------------------------------------
-  subroutine Set_emiss_o3 (self, emiss_o3)
-    real*8          , intent(in)  :: emiss_o3 (:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emiss_o3(:,:) = emiss_o3(:,:)
-    return
-  end subroutine Set_emiss_o3
-!-------------------------------------------------------------------------
   subroutine Allocate_surf_emiss_out (self, i1, i2, ju1, j2, numSpecies)
     integer          , intent(in   ) :: i1, i2, ju1, j2, numSpecies
     type (t_Emission)      , intent(inOut) :: self
@@ -1895,20 +1525,6 @@
     self%surf_emiss_out = 0.0d0
     return
   end subroutine Allocate_surf_emiss_out
-!-------------------------------------------------------------------------
-  subroutine Get_surf_emiss_out (self, surf_emiss_out)
-    real*8          , intent(out)  :: surf_emiss_out (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    surf_emiss_out(:,:,:) = self%surf_emiss_out(:,:,:)
-    return
-  end subroutine Get_surf_emiss_out
-!-------------------------------------------------------------------------
-  subroutine Set_surf_emiss_out (self, surf_emiss_out)
-    real*8          , intent(in)  :: surf_emiss_out (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%surf_emiss_out(:,:,:) = surf_emiss_out(:,:,:)
-    return
-  end subroutine Set_surf_emiss_out
 !-------------------------------------------------------------------------
   subroutine Allocate_surf_emiss_out2 (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1918,20 +1534,6 @@
     return
   end subroutine Allocate_surf_emiss_out2
 !-------------------------------------------------------------------------
-  subroutine Get_surf_emiss_out2 (self, surf_emiss_out2)
-    real*8          , intent(out)  :: surf_emiss_out2 (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    surf_emiss_out2(:,:,:) = self%surf_emiss_out2(:,:,:)
-    return
-  end subroutine Get_surf_emiss_out2
-!-------------------------------------------------------------------------
-  subroutine Set_surf_emiss_out2 (self, surf_emiss_out2)
-    real*8          , intent(in)  :: surf_emiss_out2 (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%surf_emiss_out2(:,:,:) = surf_emiss_out2(:,:,:)
-    return
-  end subroutine Set_surf_emiss_out2
-!-------------------------------------------------------------------------
   subroutine Allocate_emiss_3d_out (self, i1, i2, ju1, j2, k1, k2, numSpecies)
     integer          , intent(in   ) :: i1, i2, ju1, j2, k1, k2, numSpecies
     type (t_Emission), intent(inOut) :: self
@@ -1940,20 +1542,6 @@
     return
   end subroutine Allocate_emiss_3d_out
 !-------------------------------------------------------------------------
-  subroutine Get_emiss_3d_out (self, emiss_3d_out)
-    real*8          , intent(out)  :: emiss_3d_out (:,:,:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_3d_out(:,:,:,:) = self%emiss_3d_out(:,:,:,:)
-    return
-  end subroutine Get_emiss_3d_out
-!-------------------------------------------------------------------------
-  subroutine Set_emiss_3d_out (self, emiss_3d_out)
-    real*8          , intent(in)  :: emiss_3d_out (:,:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emiss_3d_out(:,:,:,:) = emiss_3d_out(:,:,:,:)
-    return
-  end subroutine Set_emiss_3d_out
-!-------------------------------------------------------------------------
   subroutine Allocate_aerosolEmiss3D (self, i1, i2, ju1, j2, k1, k2)
     integer          , intent(in   ) :: i1, i2, ju1, j2, k1, k2
     type (t_Emission)      , intent(inOut) :: self
@@ -1961,20 +1549,6 @@
     self%aerosolEmiss3D = 0.0d0
     return
   end subroutine Allocate_aerosolEmiss3D
-!-------------------------------------------------------------------------
-  subroutine Get_aerosolEmiss3D (self, aerosolEmiss3D)
-    real*8          , intent(out)  :: aerosolEmiss3D (:,:,:,:)
-    type (t_Emission), intent(in)   :: self
-    aerosolEmiss3D(:,:,:,:) = self%aerosolEmiss3D(:,:,:,:)
-    return
-  end subroutine Get_aerosolEmiss3D
-!-------------------------------------------------------------------------
-  subroutine Set_aerosolEmiss3D (self, aerosolEmiss3D)
-    real*8          , intent(in)  :: aerosolEmiss3D (:,:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%aerosolEmiss3D(:,:,:,:) = aerosolEmiss3D(:,:,:,:)
-    return
-  end subroutine Set_aerosolEmiss3D
 !-------------------------------------------------------------------------
   subroutine Allocate_aerosolSurfEmiss (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -1985,33 +1559,12 @@
     return
   end subroutine Allocate_aerosolSurfEmiss
 !-------------------------------------------------------------------------
-  subroutine Get_aerosolSurfEmiss (self, aerosolSurfEmiss)
-    real*8          , intent(out)  :: aerosolSurfEmiss (:,:,:)
-    type (t_Emission), intent(in)   :: self
-    aerosolSurfEmiss(:,:,:) = self%aerosolSurfEmiss(:,:,:)
-    return
-  end subroutine Get_aerosolSurfEmiss
-!-------------------------------------------------------------------------
-  subroutine Set_aerosolSurfEmiss (self, aerosolSurfEmiss)
-    real*8          , intent(in)  :: aerosolSurfEmiss (:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%aerosolSurfEmiss(:,:,:) = aerosolSurfEmiss(:,:,:)
-    return
-  end subroutine Set_aerosolSurfEmiss
-!-------------------------------------------------------------------------
   subroutine Allocate_aerosolSurfEmissMap (self)
     type (t_Emission)      , intent(inOut) :: self
     Allocate(self%aerosolSurfEmissMap &
         (self%ndust + self%naero + 5))
     return
   end subroutine Allocate_aerosolSurfEmissMap
-!-------------------------------------------------------------------------
-  subroutine Get_aerosolSurfEmissMap (self, aerosolSurfEmissMap)
-    integer          , intent(out)  :: aerosolSurfEmissMap (:)
-    type (t_Emission), intent(in)   :: self
-    aerosolSurfEmissMap(:) = self%aerosolSurfEmissMap(:)
-    return
-  end subroutine Get_aerosolSurfEmissMap
 !-------------------------------------------------------------------------
   subroutine Allocate_flashrate (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -2020,20 +1573,6 @@
     self%flashrate = 0.0d0
     return
   end subroutine Allocate_flashrate
-!-------------------------------------------------------------------------
-  subroutine Get_flashrate (self, flashrate)
-    real*8          , intent(out)  :: flashrate (:,:)
-    type (t_Emission), intent(in)   :: self
-    flashrate(:,:) = self%flashrate(:,:)
-    return
-  end subroutine Get_flashrate
-!-------------------------------------------------------------------------
-  subroutine Set_flashrate (self, flashrate)
-    real*8          , intent(in)  :: flashrate (:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%flashrate(:,:) = flashrate(:,:) 
-    return
-  end subroutine Set_flashrate
 !-------------------------------------------------------------------------
   subroutine Allocate_emissDust_t (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
@@ -2047,20 +1586,6 @@
     return
   end subroutine Allocate_emissDust_t
 !-------------------------------------------------------------------------
-  subroutine Get_emissDust_t (self, emiss_dust_t)
-    real*8          , intent(out)  :: emiss_dust_t (:,:,:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_dust_t(:,:,:,:) = self%emissDust_t(:,:,:,:)
-    return
-  end subroutine Get_emissDust_t
-!-------------------------------------------------------------------------
-  subroutine Set_emissDust_t (self, emiss_dust_t)
-    real*8          , intent(in)  :: emiss_dust_t (:,:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emissDust_t(:,:,:,:) = emiss_dust_t(:,:,:,:)
-    return
-  end subroutine Set_emissDust_t
-!-------------------------------------------------------------------------
   subroutine Allocate_emissAero_t (self, i1, i2, ju1, j2)
     integer          , intent(in   ) :: i1, i2, ju1, j2
     type (t_Emission), intent(inOut) :: self
@@ -2071,42 +1596,6 @@
     self%emissAero_t = 0.0d0
     return
   end subroutine Allocate_emissAero_t
-!-------------------------------------------------------------------------
-  subroutine Get_emissAero_t (self, emiss_aero_t)
-    real*8          , intent(out)  :: emiss_aero_t (:,:,:,:)
-    type (t_Emission), intent(in)   :: self
-    emiss_aero_t(:,:,:,:) = self%emissAero_t(:,:,:,:)
-    return
-  end subroutine Get_emissAero_t
-!-------------------------------------------------------------------------
-  subroutine Set_emissAero_t (self, emiss_aero_t)
-    real*8          , intent(in)  :: emiss_aero_t (:,:,:,:)
-    type (t_Emission), intent(inOut) :: self
-    self%emissAero_t(:,:,:,:) = emiss_aero_t(:,:,:,:)
-    return
-  end subroutine Set_emissAero_t
-!-------------------------------------------------------------------------
-  subroutine Get_emiss_map (self, emiss_map, numSpecies)
-    integer        , intent(in )  :: numSpecies
-    integer        , intent(out)  :: emiss_map (:)
-    type (t_Emission), intent(in)   :: self
-    emiss_map(1:numSpecies) = self%emiss_map(1:numSpecies)
-    return
-  end subroutine Get_emiss_map
-!-------------------------------------------------------------------------
-  subroutine Get_emiss_timpyr (self, emiss_timpyr)
-    integer        , intent(out)  :: emiss_timpyr 
-    type (t_Emission), intent(in)   :: self
-    emiss_timpyr = self%emiss_timpyr
-    return
-  end subroutine Get_emiss_timpyr
-!-------------------------------------------------------------------------
-  subroutine Set_emiss_timpyr (self, emiss_timpyr)
-    integer        , intent(in)  :: emiss_timpyr 
-    type (t_Emission), intent(inOut) :: self
-    self%emiss_timpyr = emiss_timpyr
-    return
-  end subroutine Set_emiss_timpyr
 !-------------------------------------------------------------------------
   subroutine Get_do_gcr (self, do_gcr)
     logical        , intent(out)  :: do_gcr
@@ -2121,20 +1610,6 @@
     do_semiss_inchem = self%do_semiss_inchem
     return
   end subroutine Get_do_semiss_inchem
-!-------------------------------------------------------------------------
-  subroutine Get_do_ShipEmission (self, do_ShipEmission)
-    logical        , intent(out)  :: do_ShipEmission
-    type (t_Emission), intent(in)   :: self
-    do_ShipEmission = self%do_ShipEmission
-    return
-  end subroutine Get_do_ShipEmission
-!-------------------------------------------------------------------------
-  subroutine Get_doMEGANemission (self, doMEGANemission)
-    logical        , intent(out)  :: doMEGANemission
-    type (t_Emission), intent(in)   :: self
-    doMEGANemission = self%doMEGANemission
-    return
-  end subroutine Get_doMEGANemission
 !-------------------------------------------------------------------------
   subroutine Allocate_isoLaiNext(self, i1, i2, ju1, j2)
     integer, intent(in) :: i1, i2, ju1, j2
@@ -2176,13 +1651,6 @@
     return
   end subroutine Allocate_aefMbo
 !-------------------------------------------------------------------------
-  subroutine Get_aefMbo(self, aefMbo)
-    real*8 , intent(out) :: aefMbo(:,:)
-    type (t_Emission), intent(in)   :: self
-    aefMbo(:,:) = self%aefMbo(:,:)
-    return
-  end subroutine Get_aefMbo
-!-------------------------------------------------------------------------
   subroutine Allocate_aefIsop(self, i1, i2, ju1, j2)
     integer, intent(in) :: i1, i2, ju1, j2
     type (t_Emission), intent(inOut)   :: self
@@ -2190,13 +1658,6 @@
     self%aefIsop = 0.0d0
     return
   end subroutine Allocate_aefIsop
-!-------------------------------------------------------------------------
-  subroutine Get_aefIsop(self, aefIsop)
-    real*8 , intent(out) :: aefIsop(:,:)
-    type (t_Emission), intent(in)   :: self
-    aefIsop(:,:) = self%aefIsop(:,:)
-    return
-  end subroutine Get_aefIsop
 !-------------------------------------------------------------------------
   subroutine Allocate_aefOvoc(self, i1, i2, ju1, j2)
     integer, intent(in) :: i1, i2, ju1, j2
@@ -2206,13 +1667,6 @@
     return
   end subroutine Allocate_aefOvoc
 !-------------------------------------------------------------------------
-  subroutine Get_aefOvoc(self, aefOvoc)
-    real*8 , intent(out) :: aefOvoc(:,:)
-    type (t_Emission), intent(in)   :: self
-    aefOvoc(:,:) = self%aefOvoc(:,:)
-    return
-  end subroutine Get_aefOvoc
-!-------------------------------------------------------------------------
   subroutine Allocate_aefMonot(self, i1, i2, ju1, j2)
     integer, intent(in) :: i1, i2, ju1, j2
     type (t_Emission), intent(inOut)   :: self
@@ -2220,27 +1674,6 @@
     self%aefMonot = 0.0d0
     return
   end subroutine Allocate_aefMonot
-!-------------------------------------------------------------------------
-  subroutine Get_aefMonot(self, aefMonot)
-    real*8 , intent(out) :: aefMonot(:,:)
-    type (t_Emission), intent(in)   :: self
-    aefMonot(:,:) = self%aefMonot(:,:)
-    return
-  end subroutine Get_aefMonot
-!-------------------------------------------------------------------------
-  subroutine Get_emiss_in_opt (self, emiss_in_opt)
-    integer        , intent(out)  :: emiss_in_opt 
-    type (t_Emission), intent(in)   :: self
-    emiss_in_opt = self%emiss_in_opt
-    return
-  end subroutine Get_emiss_in_opt
-!-------------------------------------------------------------------------
-  subroutine Get_emiss_opt (self, emiss_opt)
-    integer        , intent(out)  :: emiss_opt 
-    type (t_Emission), intent(in)   :: self
-    emiss_opt = self%emiss_opt
-    return
-  end subroutine Get_emiss_opt
 !-------------------------------------------------------------------------
   subroutine Get_lightning_opt (self, lightning_opt)
     integer        , intent(out)  :: lightning_opt
@@ -2284,106 +1717,6 @@
     return
   end subroutine Get_naero
 !-------------------------------------------------------------------------
-  subroutine Get_nst_dust (self, nst_dust)
-    integer        , intent(out)  :: nst_dust
-    type (t_Emission), intent(in)   :: self
-    nst_dust = self%nst_dust
-    return
-  end subroutine Get_nst_dust
-!-------------------------------------------------------------------------
-  subroutine Get_nt_dust (self, nt_dust)
-    integer        , intent(out)  :: nt_dust
-    type (t_Emission), intent(in)   :: self
-    nt_dust = self%nt_dust
-    return
-  end subroutine Get_nt_dust
-!-------------------------------------------------------------------------
-  subroutine Get_emiss_map_dust (self, emiss_map_dust, ndust)
-    integer        , intent(in )  :: ndust
-    integer        , intent(out)  :: emiss_map_dust(:)
-    type (t_Emission), intent(in)   :: self
-    emiss_map_dust(1:ndust) = self%emiss_map_dust(1:ndust)
-    return
-  end subroutine Get_emiss_map_dust
-!-------------------------------------------------------------------------
-  subroutine Get_emiss_map_aero (self, emiss_map_aero, naero)
-    integer        , intent(in )  :: naero
-    integer        , intent(out)  :: emiss_map_aero(:)
-    type (t_Emission), intent(in)   :: self
-    emiss_map_aero(1:naero) = self%emiss_map_aero(1:naero)
-    return
-  end subroutine Get_emiss_map_aero
-!-------------------------------------------------------------------------
-  subroutine Get_fertscal_infile_name (self, fertscal_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: fertscal_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    fertscal_infile_name = self%fertscal_infile_name
-    return
-  end subroutine Get_fertscal_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_lai_infile_name (self, lai_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: lai_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    lai_infile_name = self%lai_infile_name
-    return
-  end subroutine Get_lai_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_precip_infile_name (self, precip_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: precip_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    precip_infile_name = self%precip_infile_name
-    return
-  end subroutine Get_precip_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_soil_infile_name (self, soil_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: soil_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    soil_infile_name = self%soil_infile_name
-    return
-  end subroutine Get_soil_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_veg_infile_name (self, veg_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: veg_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    veg_infile_name = self%veg_infile_name
-    return
-  end subroutine Get_veg_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_isopconv_infile_name (self, isopconv_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: isopconv_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    isopconv_infile_name = self%isopconv_infile_name
-    return
-  end subroutine Get_isopconv_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_monotconv_infile_name (self, monotconv_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: monotconv_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    monotconv_infile_name = self%monotconv_infile_name
-    return
-  end subroutine Get_monotconv_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_GOCARTerod_infile_name (self, GOCARTerod_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: GOCARTerod_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    GOCARTerod_infile_name = self%GOCARTerod_infile_name
-    return
-  end subroutine Get_GOCARTerod_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_GOCARTocean_infile_name (self, GOCARTocean_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: GOCARTocean_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    GOCARTocean_infile_name = self%GOCARTocean_infile_name
-    return
-  end subroutine Get_GOCARTocean_infile_name
-!-------------------------------------------------------------------------
-  subroutine Get_GOCARTerod_mod_infile_name (self, GOCARTerod_mod_infile_name)
-    character (len=MAX_LENGTH_FILE_NAME), intent(out)  :: GOCARTerod_mod_infile_name
-    type (t_Emission)    , intent(in)   :: self
-    GOCARTerod_mod_infile_name = self%GOCARTerod_mod_infile_name
-    return
-  end subroutine Get_GOCARTerod_mod_infile_name
-!-------------------------------------------------------------------------
   subroutine Get_lightNOampFactor (self, lightNOampFactor)
     implicit none
     real           , intent(out)  :: lightNOampFactor
@@ -2399,48 +1732,5 @@
     numberNOperFlash = self%numberNOperFlash
     return
   end subroutine Get_numberNOperFlash
-!-------------------------------------------------------------------------
-  subroutine Get_minDeepCloudTop (self, minDeepCloudTop)
-    implicit none
-    real           , intent(out)  :: minDeepCloudTop
-    type (t_Emission), intent(in)   :: self
-    minDeepCloudTop = self%minDeepCloudTop
-    return
-  end subroutine Get_minDeepCloudTop
-!-------------------------------------------------------------------------
-  subroutine Get_isop_scale (self, isop_scale)
-    real*8         , intent(out)  :: isop_scale(:)
-    type (t_Emission), intent(in)   :: self
-    isop_scale(:) = self%isop_scale(:)
-    return
-  end subroutine Get_isop_scale
-!-------------------------------------------------------------------------
-  subroutine Set_isop_scale (self, isop_scale)
-    real*8         , intent(in   )  :: isop_scale(:)
-    type (t_Emission), intent(inOut)  :: self
-    self%isop_scale(:) = isop_scale(:)
-    return
-  end subroutine Set_isop_scale
-!-------------------------------------------------------------------------
-  subroutine Get_begDailyEmissRec (self, begDailyEmissRec)
-    integer          , intent(out)  :: begDailyEmissRec 
-    type (t_Emission), intent(in)   :: self
-    begDailyEmissRec = self%begDailyEmissRec
-    return
-  end subroutine Get_begDailyEmissRec
-!-------------------------------------------------------------------------
-  subroutine Get_endDailyEmissRec (self, endDailyEmissRec)
-    integer          , intent(out)  :: endDailyEmissRec 
-    type (t_Emission), intent(in)   :: self
-    endDailyEmissRec = self%endDailyEmissRec
-    return
-  end subroutine Get_endDailyEmissRec
-!-------------------------------------------------------------------------
-  subroutine Get_doReadDailyEmiss (self, doReadDailyEmiss)
-    logical          , intent(out)  :: doReadDailyEmiss 
-    type (t_Emission), intent(in)   :: self
-    doReadDailyEmiss = self%doReadDailyEmiss
-    return
-  end subroutine Get_doReadDailyEmiss
 !-------------------------------------------------------------------------
   end module GmiEmissionMethod_mod

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmission/emiss_update.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmission/emiss_update.F90
@@ -78,9 +78,9 @@
      &   emiss_map_dust, emiss_map_aero, ndust, nst_dust, nt_dust, naero, nymd, &
      &   num_time_steps, mw, tdt, ndt, emiss_timpyr, num_emiss, isop_scale, &
      &   i1, i2, ju1, j2, k1, k2, ilo, ihi, julo, jhi, i1_gl, i2_gl, ju1_gl, j2_gl, &
-     &   ilong, num_species, doMEGANemission, aefIsop, aefMbo, aefMonot, isoLaiPrev, &
-     &   isoLaiCurr, isoLaiNext, pardif, pardir, T_15_AVG, emissionSpeciesLayers, &
-         exp_fac, mixPBL)
+     &   ilong, num_species, doMEGANemission, doMEGANviaHEMCO, aefIsop, aefMbo, &
+     &   aefMonot, isoLaiPrev, isoLaiCurr, isoLaiNext, pardif, pardir, T_15_AVG, &
+     &   emissionSpeciesLayers, exp_fac, mixPBL)
 
       use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle
       use GmiTimeControl_mod       , only : GmiSplitDateTime
@@ -118,7 +118,7 @@
       real*8 , intent(in   ) :: cosSolarZenithAngle(i1:i2, ju1:j2)
       real*8 , intent(in   ) :: latdeg   (i1:i2, ju1:j2)
       real*8 , intent(in   ) :: mcor     (i1:i2, ju1:j2)
-      real*8 , intent(  out) :: emiss_isop   (i1:i2, ju1:j2)
+      real*8 , intent(inout) :: emiss_isop   (i1:i2, ju1:j2)
       real*8 , intent(  out) :: emiss_monot  (i1:i2, ju1:j2)
       real*8 , intent(  out) :: emiss_nox    (i1:i2, ju1:j2)
       real*8 , intent(in   ) :: emiss_o3     (i1:i2, ju1:j2)
@@ -146,6 +146,7 @@
       real*8 , intent(in   ) :: fracCloudCover (i1:i2, ju1:j2) ! cloud fraction
 
       logical, intent(in   ) :: doMEGANemission
+      logical, intent(in   ) :: doMEGANviaHEMCO
       real*8 , intent(in) :: aefIsop   (i1:i2, ju1:j2)
       real*8 , intent(in) :: aefMbo    (i1:i2, ju1:j2)
       real*8 , intent(in) :: aefMonot  (i1:i2, ju1:j2)
@@ -245,7 +246,9 @@
 
         if (btest(emiss_opt,1)) then
 
-          emiss_isop (:,:) = 0.0d0
+          IF ( .not. doMEGANviaHEMCO ) THEN 
+             emiss_isop (:,:) = 0.0d0 
+          END IF
           emiss_monot(:,:) = 0.0d0
           emiss_nox  (:,:) = 0.0d0
 
@@ -262,7 +265,7 @@
      &       soil_pulse, ireg, iland, iuse, convert_isop, convert_monot, coeff_isop,  &
      &       base_isop, base_monot, xlai, pr_diag, loc_proc, rootProc, i1, i2, ju1, j2, &
      &       k1, k2, i1_gl, i2_gl, ju1_gl, j2_gl, ilong, num_species, doMEGANemission, &
-     &       aefIsop, aefMbo, aefMonot, isoLaiPrev, isoLaiCurr, isoLaiNext, &
+     &       doMEGANviaHEMCO, aefIsop, aefMbo, aefMonot, isoLaiPrev, isoLaiCurr, isoLaiNext, &
              pardif, pardir,T_15_AVG, exp_fac)
 
 !         ------------------------------------------------

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmission/harvard/GmiEmissionMEGAN_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmission/harvard/GmiEmissionMEGAN_mod.F90
@@ -83,7 +83,7 @@
      &      (emiss_isop, emiss_monot, DAYS_BTW_M, &
      &       aefIsop, aefMbo, aefMonot, isoLai, isoLaiCurr, isoLaiPrev, &
      &       surfTemp, T_15_AVG, pardif, pardir, cosSolarZenithAngle, &
-     &       pr_diag, procID, i1, i2, ju1, j2, PT_15isOK)
+     &       pr_diag, procID, i1, i2, ju1, j2, PT_15isOK, compute_isop)
 !
       implicit none
 
@@ -117,13 +117,12 @@
       real*8 , intent(in) :: pardir              (i1:i2, ju1:j2)
                              ! Cosines of the solar zenith angle
       real*8 , intent(in) :: cosSolarZenithAngle (i1:i2, ju1:j2)
-      LOGICAL, INTENT(IN) :: PT_15isOK ! If .TRUE. use Eq. 5b, 5c for E_OPT and T_OPT
+      LOGICAL, INTENT(IN) :: PT_15isOK    ! If .TRUE. use Eq. 5b, 5c for E_OPT and T_OPT
+      LOGICAL, INTENT(IN) :: compute_isop ! Only set emiss_isop if .TRUE.
 !
 ! !OUTPUT PARAMETERS:
-                              ! isoprene    emissions    (kg/s)
-      real*8 , intent(out) :: emiss_isop (i1:i2, ju1:j2)
-                              ! monoterpene emissions    (kg/s)
-      real*8 , intent(out) :: emiss_monot(i1:i2, ju1:j2)
+      real*8 , intent(out) :: emiss_isop (i1:i2, ju1:j2)  ! isoprene    emissions    (kg/s)
+      real*8 , intent(out) :: emiss_monot(i1:i2, ju1:j2)  ! monoterpene emissions    (kg/s)
 !
 ! !DESCRIPTION:
 ! Updates the MEGAN biogenic emissions (isoprene, monoterpene).
@@ -163,16 +162,17 @@
             isoLaiPrev_ij = isoLaiPrev         (ix, iy)
 
             ! Isoprene
-            emiss_isop (ix,iy) =  GET_EMISOP_MEGAN &
-     &                               (T_15_AVG_ij, SUNCOS, aefIsop_ij, &
-     &                                isoLai_ij, isoLaiCurr_ij, isoLaiPrev_ij, &
-     &                                DAYS_BTW_M, TS_ij, XNUMOL_C, Q_DIR, Q_DIFF, PT_15isOK)
+            if (compute_isop)                                                                   &
+     &        emiss_isop (ix,iy) =  GET_EMISOP_MEGAN                                            &
+     &                                 (T_15_AVG_ij, SUNCOS, aefIsop_ij,                        &
+     &                                  isoLai_ij, isoLaiCurr_ij, isoLaiPrev_ij,                &
+     &                                  DAYS_BTW_M, TS_ij, XNUMOL_C, Q_DIR, Q_DIFF, PT_15isOK)
 
             ! Monoterpenes
-            emiss_monot(ix,iy) = GET_EMMONOT_MEGAN &
-     &                              (T_15_AVG_ij, TS_ij, XNUMOL_C, aefMonot_ij, &
-     &                               isoLai_ij, isoLaiCurr_ij, isoLaiPrev_ij, &
-     &                               DAYS_BTW_M, PT_15isOK)
+              emiss_monot(ix,iy) = GET_EMMONOT_MEGAN                                            &
+     &                                (T_15_AVG_ij, TS_ij, XNUMOL_C, aefMonot_ij,               &
+     &                                 isoLai_ij, isoLaiCurr_ij, isoLaiPrev_ij,                 &
+     &                                 DAYS_BTW_M, PT_15isOK)
 
 !            ! Methyl butenol
 !            emiss_meth (ix,iy) = GET_EMMBO_MEGAN &

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmission/ioEmission/ReadOtherEmissionData_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmission/ioEmission/ReadOtherEmissionData_mod.F90
@@ -20,9 +20,9 @@
 !
 !
     private
-    public  :: readLightData, readSoilData, readFertilizerData
+    public  :: readLightData, readSoilData     !   readFertilizerData
     public  :: readIsopreneConvertData, readMonoterpeneConvertData
-    public  :: readPrecipitationData
+!   public  :: readPrecipitationData
 !
 #     include "gmi_emiss_constants.h"
 #     include "gmi_time_constants.h"
@@ -259,36 +259,36 @@
 
 !-----------------------------------------------------------------------------
 
-!   fertscal_infile_name : fertilizer scale input file name
-!   index_soil : i,j of the grid
-!   soil_fert  : fertilizers    (ng N/m^2/s)
-
-      subroutine readFertilizerData &
-     &  (fertscal_infile_name, index_soil, soil_fert, pr_diag, rootProc)
-
-      logical, intent(in) :: pr_diag, rootProc
-      character (len=*) :: fertscal_infile_name
-      integer :: index_soil(2, NLANDHAR)
-      real*8  :: soil_fert (NLANDHAR)
-
-      integer :: lun, mm, ii
-
-      call AsciiOpenRead (lun, fertscal_infile_name)
-
-      do mm = 1, NLANDHAR
-          Read (lun, *) (index_soil(ii,mm), ii=1,2), soil_fert(mm)
-      end do
-
-      Close (lun)
-
-      IF(rootProc) THEN
-        WRITE(6,*) 'Fertilizer scaling read from'
-	WRITE(6,*) '  '//TRIM(fertscal_infile_name)
-      END IF
-
-      return
-
-      end subroutine readFertilizerData
+!!   fertscal_infile_name : fertilizer scale input file name
+!!   index_soil : i,j of the grid
+!!   soil_fert  : fertilizers    (ng N/m^2/s)
+!
+!      subroutine readFertilizerData &
+!     &  (fertscal_infile_name, index_soil, soil_fert, pr_diag, rootProc)
+!
+!      logical, intent(in) :: pr_diag, rootProc
+!      character (len=*) :: fertscal_infile_name
+!      integer :: index_soil(2, NLANDHAR)
+!      real*8  :: soil_fert (NLANDHAR)
+!
+!      integer :: lun, mm, ii
+!
+!      call AsciiOpenRead (lun, fertscal_infile_name)
+!
+!      do mm = 1, NLANDHAR
+!          Read (lun, *) (index_soil(ii,mm), ii=1,2), soil_fert(mm)
+!      end do
+!
+!      Close (lun)
+!
+!      IF(rootProc) THEN
+!        WRITE(6,*) 'Fertilizer scaling read from'
+!	WRITE(6,*) '  '//TRIM(fertscal_infile_name)
+!      END IF
+!
+!      return
+!
+!      end subroutine readFertilizerData
 
 !-----------------------------------------------------------------------------
 !
@@ -309,102 +309,102 @@
 !
 !-----------------------------------------------------------------------------
 
-      subroutine readPrecipitationData  &
-     &  (precip_infile_name, index_soil, soil_prep, nymd, soil_month, pr_diag, rootProc)
-
-      implicit none
-
-!     ----------------------
-!     Argument declarations.
-!     ----------------------
-
-      logical, intent(in) :: pr_diag, rootProc
-      character (len=*) :: precip_infile_name
-      integer, intent(in) :: nymd
-      integer, intent(in) :: index_soil(2, NLANDHAR)
-      real*8              :: soil_prep (2, NLANDHAR)
-      integer, intent(inOut) :: soil_month ! to determine if a new month
-
-!     ----------------------
-!     Variable declarations.
-!     ----------------------
-
-      character (len=75) :: err_msg
-
-      integer :: ddummy, ydummy
-      integer :: ii, jj, kk, mm
-      integer :: imonth
-      integer :: lun
-      integer :: prev_soil_month
-
-
-      real*8  :: sp_tmp(MONTHS_PER_YEAR)
-
-!     ----------------
-!     Begin execution.
-!     ----------------
-
-!     ---------------------------
-!     Read in precipitation data.
-!     ---------------------------
-
-!     ====================
-      call GmiSplitDateTime  &
-!     ====================
-     &  (nymd, ydummy, imonth, ddummy)
-
-      if (soil_month /= imonth) then
-
-        soil_month = imonth
-
-        if (soil_month == 1) then
-          prev_soil_month = MONTHS_PER_YEAR
-        else
-          prev_soil_month = soil_month - 1
-        end if
-
-!       ================
-        call AsciiOpenRead  &
-!       ================
-     &    (lun, precip_infile_name)
-
-        do mm = 1, NLANDHAR
-
-          Read (lun,FMT="(2I3,12F6.2)") ii, jj, (sp_tmp(kk), kk=1,MONTHS_PER_YEAR)
-
-          if ((index_soil(1,mm) /= ii) .or.  &
-     &        (index_soil(2,mm) /= jj)) then
-
-            err_msg = 'Problem in Read_Soil_Data.'
-            call GmiPrintError  &
-     &        (err_msg, .true., 2, ii, jj, 0, 0.0d0, 0.0d0)
-
-          else
-
-            soil_prep(1,mm) = sp_tmp(prev_soil_month)
-            soil_prep(2,mm) = sp_tmp(soil_month)
-
-          end if
-
-        end do
-
-        Close (lun)
-
-        IF(rootProc) THEN
-          WRITE(6,*) 'Climatological precipitation for computing'
-          WRITE(6,*) '   soil NOx emission read from'
-	  WRITE(6,*) '  '//TRIM(precip_infile_name)
-	  WRITE(6,*) '              nymd=',nymd
-	  WRITE(6,*) '   prev_soil_month=',prev_soil_month
-	  WRITE(6,*) '        soil_month=',soil_month
-        END IF
-
-      end if
-
-
-      return
-
-      end subroutine readPrecipitationData
+!      subroutine readPrecipitationData  &
+!     &  (precip_infile_name, index_soil, soil_prep, nymd, soil_month, pr_diag, rootProc)
+!
+!      implicit none
+!
+!!     ----------------------
+!!     Argument declarations.
+!!     ----------------------
+!
+!      logical, intent(in) :: pr_diag, rootProc
+!      character (len=*) :: precip_infile_name
+!      integer, intent(in) :: nymd
+!      integer, intent(in) :: index_soil(2, NLANDHAR)
+!      real*8              :: soil_prep (2, NLANDHAR)
+!      integer, intent(inOut) :: soil_month ! to determine if a new month
+!
+!!     ----------------------
+!!     Variable declarations.
+!!     ----------------------
+!
+!      character (len=75) :: err_msg
+!
+!      integer :: ddummy, ydummy
+!      integer :: ii, jj, kk, mm
+!      integer :: imonth
+!      integer :: lun
+!      integer :: prev_soil_month
+!
+!
+!      real*8  :: sp_tmp(MONTHS_PER_YEAR)
+!
+!!     ----------------
+!!     Begin execution.
+!!     ----------------
+!
+!!     ---------------------------
+!!     Read in precipitation data.
+!!     ---------------------------
+!
+!!     ====================
+!      call GmiSplitDateTime  &
+!!     ====================
+!     &  (nymd, ydummy, imonth, ddummy)
+!
+!      if (soil_month /= imonth) then
+!
+!        soil_month = imonth
+!
+!        if (soil_month == 1) then
+!          prev_soil_month = MONTHS_PER_YEAR
+!        else
+!          prev_soil_month = soil_month - 1
+!        end if
+!
+!!       ================
+!        call AsciiOpenRead  &
+!!       ================
+!     &    (lun, precip_infile_name)
+!
+!        do mm = 1, NLANDHAR
+!
+!          Read (lun,FMT="(2I3,12F6.2)") ii, jj, (sp_tmp(kk), kk=1,MONTHS_PER_YEAR)
+!
+!          if ((index_soil(1,mm) /= ii) .or.  &
+!     &        (index_soil(2,mm) /= jj)) then
+!
+!            err_msg = 'Problem in Read_Soil_Data.'
+!            call GmiPrintError  &
+!     &        (err_msg, .true., 2, ii, jj, 0, 0.0d0, 0.0d0)
+!
+!          else
+!
+!            soil_prep(1,mm) = sp_tmp(prev_soil_month)
+!            soil_prep(2,mm) = sp_tmp(soil_month)
+!
+!          end if
+!
+!        end do
+!
+!        Close (lun)
+!
+!        IF(rootProc) THEN
+!          WRITE(6,*) 'Climatological precipitation for computing'
+!          WRITE(6,*) '   soil NOx emission read from'
+!	  WRITE(6,*) '  '//TRIM(precip_infile_name)
+!	  WRITE(6,*) '              nymd=',nymd
+!	  WRITE(6,*) '   prev_soil_month=',prev_soil_month
+!	  WRITE(6,*) '        soil_month=',soil_month
+!        END IF
+!
+!      end if
+!
+!
+!      return
+!
+!      end subroutine readPrecipitationData
 
 !-------------------------------------------------------------------------
     end module ReadOtherEmissionData_mod

--- a/GMIchem_GridComp/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
@@ -188,7 +188,6 @@ CONTAINS
    CHARACTER(LEN=*), PARAMETER :: IAm = 'GmiForcingBC_GridCompInitialize'
    CHARACTER(LEN=255) :: rcfilen = 'GMI_GridComp.rc'
    CHARACTER(LEN=255) :: namelistFile
-   CHARACTER(LEN=255) :: kineticsTextFile
    CHARACTER(LEN=255) :: importRestartFile
    CHARACTER(LEN=255) :: string
       character (len=MAX_LENGTH_SPECIES_NAME), pointer :: tempListNames(:)

--- a/GMIchem_GridComp/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridComp/GMIchem_GridCompMod.F90
@@ -20,6 +20,7 @@
    USE Chem_UtilMod, ONLY : Chem_UtilNegFiller  ! Eliminates negative vmr
    USE Chem_GroupMod                            ! For Family Transport
    USE OVP,     ONLY:  OVP_init, OVP_end_of_timestep_hms, OVP_mask, OVP_apply_mask
+   USE GmiESMFrcFileReading_mod, only : rcEsmfReadLogical
 
    IMPLICIT NONE
    PRIVATE
@@ -137,6 +138,11 @@ CONTAINS
 
     LOGICAL :: do_ShipEmission
     TYPE(ESMF_Config)  :: gmiConfig
+
+    ! HEMCO isoprene related -sas
+    CHARACTER(LEN=255) :: gmi_rcfilen = 'GMI_GridComp.rc'
+    TYPE (ESMF_Config) :: gmi_config
+    LOGICAL :: doMEGANviaHEMCO
 
 !   Get my name and set-up traceback handle
 !   ---------------------------------------
@@ -316,6 +322,24 @@ CONTAINS
         UNITS      = 'mol mol-1',                          &
         DIMS       = MAPL_DimsHorzVert,                    &
         VLOCATION  = MAPL_VLocationCenter,   __RC__) 
+
+     ! add MEGAN emission imports -sas 
+     ! note: might change this later to use GMICHEM_ImportSpec___.h
+     gmi_config = ESMF_ConfigCreate(__RC__ )
+     call ESMF_ConfigLoadFile(gmi_config, TRIM(gmi_rcfilen), __RC__ )
+     call rcEsmfReadLogical(gmi_config, doMEGANviaHEMCO, "doMEGANviaHEMCO:", default=.false., __RC__ )
+
+     IF ( doMEGANviaHEMCO ) THEN
+        call MAPL_AddImportSpec(GC, &
+             SHORT_NAME = 'GMI_ISOPRENE', &
+             LONG_NAME  = 'isoprene emissions'  , &
+             UNITS      = 'kgC/m2/s',                &
+             DIMS       = MAPL_DimsHorzOnly,  &
+             VLOCATION  = MAPL_VLocationNone, &
+             RESTART    = MAPL_RestartSkip,   &
+             RC         = STATUS)
+        VERIFY_(STATUS)
+     END IF
 
 #include "GMICHEM_ImportSpec___.h"
 
@@ -1610,6 +1634,8 @@ CONTAINS
    TYPE(ESMF_Alarm)                  :: PredictorIsActive
    LOGICAL                           :: doingPredictorNow
 
+   LOGICAL                           :: RAS_NO_NEG  ! Whether RAS will guard against negatives
+
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
    CALL ESMF_GridCompGet(GC, NAME=COMP_NAME, CONFIG=CF, GRID=grid, __RC__)
@@ -1653,9 +1679,20 @@ CONTAINS
 
 !  Assure non-negative volumetric mixing ratios [mole fractions]
 !  -------------------------------------------------------------
-   DO n = ChemReg%i_GMI, ChemReg%j_GMI
-    CALL Chem_UtilNegFiller(w_c%qa(n)%data3d, DELP, i2, j2, QMIN=TINY(1.0))
-   END DO
+   CALL ESMF_ConfigGetAttribute( CF, RAS_NO_NEG, Label='RAS_NO_NEG:', default=.FALSE. , __RC__)
+   IF ( .NOT. RAS_NO_NEG ) THEN
+     DO n = ChemReg%i_GMI, ChemReg%j_GMI
+! original approach - make all values no less than a tiny positive number:
+       CALL Chem_UtilNegFiller(w_c%qa(n)%data3d, DELP, i2, j2, QMIN=TINY(1.0))
+! debug print:
+!      IF(  ANY(w_c%qa(n)%data3d < 1.0e-30) ) THEN
+!        m = COUNT( w_c%qa(n)%data3d < 1.0e-30 )
+!        PRINT*,'GMI SPECIES TOO SMALL (species,count):', n-ChemReg%i_GMI+1, m
+!      ENDIF
+! first take:
+!     WHERE(w_c%qa(n)%data3d < 1.0e-30) w_c%qa(n)%data3d=1.0e-30
+     END DO
+   END IF
 
 !  Occasionally, MAPL_UNDEFs appear in the imported tropopause pressures,
 !  TROPP. To avoid encountering them, save the most recent valid tropopause 

--- a/HEMCO_GridComp/HEMCO_GridComp.rc
+++ b/HEMCO_GridComp/HEMCO_GridComp.rc
@@ -14,3 +14,4 @@ HEMCO_Instances: 1
         ###############################
 
 HEMCO_CONFIG--001: HEMCOgocart_Config.rc
+HEMCO_CONFIG--002: HEMCOgmi_Config.rc

--- a/HEMCO_GridComp/HEMCOgmi_Config.rc
+++ b/HEMCO_GridComp/HEMCOgmi_Config.rc
@@ -1,0 +1,104 @@
+### HEMCO INPUT FILE ###
+# ==================================================================================================
+
+####################################################################################
+BEGIN SECTION SETTINGS
+####################################################################################
+#
+ROOT               : /discover/nobackup/cakelle2/data
+Logfile            : HEMCOgmi.log
+DiagnPrefix        : HEMCOgmi_diagnostics
+DiagnFreq          : 00000000 010000
+Negative values    : 2
+Unit tolerance     : 1
+Verbose            : 3
+Warnings           : 1
+DiagnTimeStamp     : Start
+DiagnNoLevDim      : true 
+SpecFile           : HEMCOgmi_Spec.rc
+DiagnFile          : HEMCOgmi_Diagn.rc
+DefaultDiagnOn     : false
+DefaultDiagnSname  : HEMCOgmi_
+DefaultDiagnLname  : HEMCOgmi_emissions_species
+DefaultDiagnDim    : 2
+#
+END SECTION SETTINGS 
+
+####################################################################################
+BEGIN SECTION EXTENSION SWITCHES
+####################################################################################
+# Make sure that the ExtNr provided here matches with the ExtNr provided in the base 
+# emissions sections. Otherwise, the listed files won't be read!
+#
+# ExtNr ExtName           on/off  Species
+0       Base              : on    *
+    --> TIMEZONES         :       false
+    --> GMICHEM           :       true
+    --> MEGAN_FIELDS      :       true
+108     MEGAN             : on    ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
+    --> Isoprene scaling  :       1.0
+    --> CO2 inhibition    :       true
+    --> CO2 conc (ppmv)   :       390.0
+    --> Isoprene to SOAP  :       0.015
+    --> Isoprene to SOAS  :       0.015
+    --> Normalize LAI     :       true
+    --> MEGAN_SUFFIX      :       _GMI
+#3% mass yield from isoprene to SOA
+109     MEGAN_Mono        : on    CO/MTPA/MTPO/LIMO/SESQ
+    --> Monoterp to SOAP  :       0.050
+    --> Monoterp to SOAS  :       0.050
+#10% mass yield from monoterpenes to SOA
+    --> Othrterp to SOAP  :       0.050
+    --> Othrterp to SOAS  :       0.050
+#
+END SECTION EXTENSION SWITCHES 
+
+####################################################################################
+BEGIN SECTION BASE EMISSIONS 
+####################################################################################
+
+
+#=======================================================================================================================================
+# --- MEGAN biogenic emissions (Extension 108)
+#=======================================================================================================================================
+# NOTE: These are the base emissions, which will be converted to kgC/m2/s by HEMCO. The specified species (OCPI/ISOP/ACET) are required
+#       for proper unit conversion. Since netCDF files are already in mass carbon (ug(C)), the only important thing is to specify a VOC
+#       with a specified MW of 12g/mol. This is the case for OCPI, ISOP and ACET.
+(((MEGAN_FIELDS
+108  MEGAN_AEF_ISOP_GMI           ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_ISOPRENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_MBOX_GMI           ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_MBO                 1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_BPIN_GMI           ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_BETA_PINENE         1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_CARE_GMI           ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_CARENE              1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_LIMO_GMI           ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_LIMONENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_OCIM_GMI           ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_OCIMENE             1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_SABI_GMI           ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_SABINENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  CLM4_PFT_BARE_GMI            ~/data/CLM4_PFT.geos.1x1.nc    PFT_BARE                2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_NDLF_EVGN_TMPT_TREE_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_EVGN_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_NDLF_EVGN_BORL_TREE_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_EVGN_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_NDLF_DECD_BORL_TREE_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_DECD_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_EVGN_TROP_TREE_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_TROP_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_EVGN_TMPT_TREE_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_TROP_TREE_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TROP_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_TMPT_TREE_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_BORL_TREE_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_EVGN_SHRB_GMI      ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_SHRB      2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_TMPT_SHRB_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TMPT_SHRB 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_BORL_SHRB_GMI ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_BORL_SHRB 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_C3_ARCT_GRSS_GMI        ~/data/CLM4_PFT.geos.1x1.nc    PFT_C3_ARCT_GRSS        2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_C3_NARC_GRSS_GMI        ~/data/CLM4_PFT.geos.1x1.nc    PFT_C3_NARC_GRSS        2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_C4_GRSS_GMI         ~/data/CLM4_PFT.geos.1x1.nc    PFT_C4_GRSS             2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_CROP_GMI            ~/data/CLM4_PFT.geos.1x1.nc    PFT_CROP                2000/1/1/0    C xy 1        * - 1 1
+109  MEGAN_ORVC_GMI               ~/data/NVOC.geos.1x1.nc        OCPI                    1990/1-12/1/0 C xy kgC/m2/s * - 1 1
+)))MEGAN_FIELDS
+
+#==============================================================================
+# --- time zones (offset to UTC) ---
+#==============================================================================
+(((TIMEZONES
+* TIMEZONES $ROOT/timezones_esmf.2x25.nc UTC_OFFSET 2000/1/1/0 C xy count * - 1 1
+)))TIMEZONES
+
+END SECTION BASE EMISSIONS 
+
+
+### END OF HEMCO INPUT FILE ###

--- a/HEMCO_GridComp/HEMCOgmi_Diagn.rc
+++ b/HEMCO_GridComp/HEMCOgmi_Diagn.rc
@@ -1,0 +1,11 @@
+# This file defines the diagnostics to be written
+# out by the HEMCO standalone model
+#
+# Name           Spec   ExtNr Cat Hier Dim Unit
+GMI_ISOPRENE     ISOP   108   -1  -1   2   kgC/m2/s
+GMI_TERPENE      MTPA   109   -1  -1   2   kgC/m2/s
+GMI_MTPO       	 MTPO   109   -1  -1   2   kgC/m2/s
+GMI_LIMO       	 LIMO   109   -1  -1   2   kgC/m2/s
+GMI_SESQ       	 SESQ   109   -1  -1   2   kgC/m2/s
+EMIS_PRPE_BG   	 PRPE   108   -1  -1   2   kgC/m2/s
+EMIS_CO_BG     	 CO     109   -1  -1   2   kg/m2/s

--- a/HEMCO_GridComp/HEMCOgmi_ExtData.rc
+++ b/HEMCO_GridComp/HEMCOgmi_ExtData.rc
@@ -1,0 +1,55 @@
+#
+Include%%
+##
+%%
+
+#
+PrimaryExports%%
+# -------------|-------|-------|--------|----------------------|--------|--------|-------------|----------|
+#  Import      |       |       | Regrid |        Refresh       | OffSet | Scale  | Variable On |   File   |
+#  Name        | Units | Clim  | Method |     Time Template    | Factor | Factor |     File    | Template |
+# -------------|-------|-------|--------|----------------------|--------|--------|-------------|----------|
+#
+# ----------------
+# EMISSION FIELDS
+# ----------------
+#
+
+# --- MEGAN ---
+MEGAN_AEF_ISOP_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_ISOPRENE      /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_MBOX_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_MBO           /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_BPIN_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_BETA_PINENE   /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_CARE_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_CARENE        /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_LIMO_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_LIMONENE      /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_OCIM_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_OCIMENE       /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_SABI_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_SABINENE      /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
+CLM4_PFT_BARE_GMI      '1'          N    N -                    none     none    PFT_BARE          /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_NDLF_EVGN_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_EVGN_TMPT_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_NDLF_EVGN_BORL_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_EVGN_BORL_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_NDLF_DECD_BORL_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_DECD_BORL_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_EVGN_TROP_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_EVGN_TROP_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_EVGN_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_EVGN_TMPT_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_TROP_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TROP_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TMPT_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_BORL_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_BORL_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_EVGN_SHRB_GMI      '1' N    N -                    none     none    PFT_BDLF_EVGN_SHRB      /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_TMPT_SHRB_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TMPT_SHRB /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_BORL_SHRB_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_BORL_SHRB /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_C3_ARCT_GRSS_GMI        '1' N    N -                    none     none    PFT_C3_ARCT_GRSS        /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_C3_NARC_GRSS_GMI        '1' N    N -                    none     none    PFT_C3_NARC_GRSS        /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_C4_GRSS_GMI             '1' N    N -                    none     none    PFT_C4_GRSS             /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_CROP_GMI                '1' N    N -                    none     none    PFT_CROP                /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+MEGAN_ORVC_GMI       'kgC/m2/s'      Y    Y 1999-%m2-01T00:00:00 none     none    OCPI                    /discover/nobackup/cakelle2/data/NVOC.geos.1x1.esmf.nc
+
+# --- Mask ---
+#TIMEZONES NA  N V - none none  UTC_OFFSET /discover/nobackup/cakelle2/data/timezones_esmf.2x25.nc
+
+%%
+
+DerivedExports%%
+# ---------|---------|--------------------------------------------|
+#  Export  | Primary |_________________ Mask _____________________|
+#  Name    |  Name   |    Name    |           Expression          |    
+# ---------|---------|------------|-------------------------------|
+# ---------|---------|------------|-------------------------------|
+%%

--- a/HEMCO_GridComp/HEMCOgmi_Spec.rc
+++ b/HEMCO_GridComp/HEMCOgmi_Spec.rc
@@ -1,0 +1,24 @@
+# List species below. For each species, the following entries must be given:
+# ID        : species ID
+# NAME      : species name
+# MW       : molecular weight (g/mol) 
+# MWEMIS    : molecular weight of emitted species (g/mol)
+# MOLECRATIO: molecules of emitted species per molecule of species
+# K0        : Henry constant at 298 K (M/atm, liquid over gas)
+# CR        : Henry temperature dependency (-d ln(KH)/d(1/T)
+# pKA       : acid dissociation constant
+#
+# Note: all hydrocarbons are listed as MW=12.0 to reflect the fact
+# that the input data is already in kgC or the conversion factors are
+# explicitly listed as scale factors in HEMCO_Config.rc. This avoid
+# any unwanted conversions between mass species as mass C 
+# (ckeller, 1/18/16).
+
+# ID NAME   MW    MWEMIS MOLECRATIO K0     CR     PKA
+1    ISOP  68.12  12.0	 5.0        0.0    0.0    0.0
+2    MTPA  136.23 136.23 1.0        0.0    0.0    0.0
+3    MTPO  136.23 136.23 1.0        0.0    0.0    0.0
+4    SESQ  136.23 136.23 1.0        0.0    0.0    0.0
+5    LIMO  136.23 136.23 1.0        0.0    0.0    0.0
+6    PRPE  42.08  42.08	 1.0        0.0    0.0    0.0
+7    CO    28.0   28.0   1.0        0.0    0.0    0.0

--- a/HEMCO_GridComp/HEMCOgocart_Config.rc
+++ b/HEMCO_GridComp/HEMCOgocart_Config.rc
@@ -34,6 +34,7 @@ BEGIN SECTION EXTENSION SWITCHES
 0       Base              : on    *
     --> TIMEZONES         :       false
     --> GOCART            :       true
+    --> MEGAN_FIELDS      :       true
     --> HTAP              :       false
     --> KORUS             :       false
 108     MEGAN             : on    ISOP/ACET/PRPE/C2H4/ALD2/EOH/SOAP/SOAS
@@ -43,6 +44,7 @@ BEGIN SECTION EXTENSION SWITCHES
     --> Isoprene to SOAP  :       0.015
     --> Isoprene to SOAS  :       0.015
     --> Normalize LAI     :       true
+    --> MEGAN_SUFFIX      :       _GOCART
 #3% mass yield from isoprene to SOA
 109     MEGAN_Mono        : on    CO/MTPA/MTPO/LIMO/SESQ
     --> Monoterp to SOAP  :       0.050
@@ -176,30 +178,32 @@ BEGIN SECTION BASE EMISSIONS
 # NOTE: These are the base emissions, which will be converted to kgC/m2/s by HEMCO. The specified species (OCPI/ISOP/ACET) are required
 #       for proper unit conversion. Since netCDF files are already in mass carbon (ug(C)), the only important thing is to specify a VOC
 #       with a specified MW of 12g/mol. This is the case for OCPI, ISOP and ACET.
-108  MEGAN_AEF_ISOP               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_ISOPRENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
-109  MEGAN_AEF_MBOX               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_MBO                 1985/1/1/0    C xy kgC/m2/s * - 1 1
-109  MEGAN_AEF_BPIN               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_BETA_PINENE         1985/1/1/0    C xy kgC/m2/s * - 1 1
-109  MEGAN_AEF_CARE               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_CARENE              1985/1/1/0    C xy kgC/m2/s * - 1 1
-109  MEGAN_AEF_LIMO               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_LIMONENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
-109  MEGAN_AEF_OCIM               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_OCIMENE             1985/1/1/0    C xy kgC/m2/s * - 1 1
-109  MEGAN_AEF_SABI               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_SABINENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
-109  CLM4_PFT_BARE                ~/data/CLM4_PFT.geos.1x1.nc    PFT_BARE                2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_NDLF_EVGN_TMPT_TREE ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_EVGN_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_NDLF_EVGN_BORL_TREE ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_EVGN_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_NDLF_DECD_BORL_TREE ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_DECD_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_BDLF_EVGN_TROP_TREE ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_TROP_TREE 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_BDLF_EVGN_TMPT_TREE ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_BDLF_DECD_TROP_TREE ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TROP_TREE 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_BDLF_DECD_TMPT_TREE ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_BDLF_DECD_BORL_TREE ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_BDLF_EVGN_SHRB      ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_SHRB      2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_BDLF_DECD_TMPT_SHRB ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TMPT_SHRB 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_BDLF_DECD_BORL_SHRB ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_BORL_SHRB 2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_C3_ARCT_GRSS        ~/data/CLM4_PFT.geos.1x1.nc    PFT_C3_ARCT_GRSS        2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_C3_NARC_GRSS        ~/data/CLM4_PFT.geos.1x1.nc    PFT_C3_NARC_GRSS        2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_C4_GRSS             ~/data/CLM4_PFT.geos.1x1.nc    PFT_C4_GRSS             2000/1/1/0    C xy 1        * - 1 1
-109  CLM4_PFT_CROP                ~/data/CLM4_PFT.geos.1x1.nc    PFT_CROP                2000/1/1/0    C xy 1        * - 1 1
-109  MEGAN_ORVC                   ~/data/NVOC.geos.1x1.nc        OCPI                    1990/1-12/1/0 C xy kgC/m2/s * - 1 1
+(((MEGAN_FIELDS
+108  MEGAN_AEF_ISOP_GOCART               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_ISOPRENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_MBOX_GOCART               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_MBO                 1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_BPIN_GOCART               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_BETA_PINENE         1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_CARE_GOCART               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_CARENE              1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_LIMO_GOCART               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_LIMONENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_OCIM_GOCART               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_OCIMENE             1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  MEGAN_AEF_SABI_GOCART               ~/data/MEGAN2.1_EF.geos.1x1.nc AEF_SABINENE            1985/1/1/0    C xy kgC/m2/s * - 1 1
+109  CLM4_PFT_BARE_GOCART                ~/data/CLM4_PFT.geos.1x1.nc    PFT_BARE                2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_NDLF_EVGN_TMPT_TREE_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_EVGN_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_NDLF_EVGN_BORL_TREE_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_EVGN_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_NDLF_DECD_BORL_TREE_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_NDLF_DECD_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_EVGN_TROP_TREE_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_TROP_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_EVGN_TMPT_TREE_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_TROP_TREE_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TROP_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_TMPT_TREE_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TMPT_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_BORL_TREE_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_BORL_TREE 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_EVGN_SHRB_GOCART      ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_EVGN_SHRB      2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_TMPT_SHRB_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_TMPT_SHRB 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_BDLF_DECD_BORL_SHRB_GOCART ~/data/CLM4_PFT.geos.1x1.nc    PFT_BDLF_DECD_BORL_SHRB 2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_C3_ARCT_GRSS_GOCART        ~/data/CLM4_PFT.geos.1x1.nc    PFT_C3_ARCT_GRSS        2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_C3_NARC_GRSS_GOCART        ~/data/CLM4_PFT.geos.1x1.nc    PFT_C3_NARC_GRSS        2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_C4_GRSS_GOCART             ~/data/CLM4_PFT.geos.1x1.nc    PFT_C4_GRSS             2000/1/1/0    C xy 1        * - 1 1
+109  CLM4_PFT_CROP_GOCART                ~/data/CLM4_PFT.geos.1x1.nc    PFT_CROP                2000/1/1/0    C xy 1        * - 1 1
+109  MEGAN_ORVC_GOCART                   ~/data/NVOC.geos.1x1.nc        OCPI                    1990/1-12/1/0 C xy kgC/m2/s * - 1 1
+)))MEGAN_FIELDS
 
 #==============================================================================
 # --- time zones (offset to UTC) ---

--- a/Shared/Chem_Shared/Chem_GroupMod.F90
+++ b/Shared/Chem_Shared/Chem_GroupMod.F90
@@ -624,7 +624,11 @@ CONTAINS
      &                               sgrp_fac(im,ig)
         end do
 
-        group_factor(:,:,:)        = qq1(:,:,:) / qq2(:,:,:)
+        where ( qq2(:,:,:) > VERY_SMALL )
+          group_factor(:,:,:)      = qq1(:,:,:) / qq2(:,:,:)
+        elsewhere
+          group_factor(:,:,:)      = -999.0
+        end where
 
         do im                      = 1, MAXGRP_ELEM
           imsgrp                   = sgrp_elem_map(im,ig)
@@ -632,6 +636,18 @@ CONTAINS
      &      x(imsgrp)%p(:,:,:)     = x(imsgrp)%p(:,:,:) *  &
      &                               group_factor(:,:,:)
         end do
+
+!.... In the very rare cases where the species sum is tiny, divide up Cly
+          where( group_factor(:,:,:) == -999.0 )
+            x(iCL    )%p(:,:,:) = (qq1(:,:,:) / 10.0)
+            x(iCL2   )%p(:,:,:) = (qq1(:,:,:) / 10.0) * 2.0
+            x(iCLO   )%p(:,:,:) = (qq1(:,:,:) / 10.0)
+            x(iCL2O2 )%p(:,:,:) = (qq1(:,:,:) / 10.0) * 2.0
+            x(iCLONO2)%p(:,:,:) = (qq1(:,:,:) / 10.0)
+            x(iHCL   )%p(:,:,:) = (qq1(:,:,:) / 10.0)
+            x(iHOCL  )%p(:,:,:) = (qq1(:,:,:) / 10.0)
+            x(iOCLO  )%p(:,:,:) = (qq1(:,:,:) / 10.0)
+          end where
 
       end select
 

--- a/StratChem_GridComp/SC_GridComp/StratChem_ExtData.rc
+++ b/StratChem_GridComp/SC_GridComp/StratChem_ExtData.rc
@@ -3,14 +3,14 @@ PrimaryExports%%
 #  Export    |              |    |Con|_______ Refresh ______|____ Factors ___|___________ External File __________
 #  Name      |     Units    |Clim|Rgr|     Time Template    | Offset | Scale |     Variable    |      Template
 # -----------|--------------|----|---|----------------------|--------|-------|-----------------|----------------------   
-F11FLUX       'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CFC11_EMISSION    ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
-F12FLUX       'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CFC12_EMISSION    ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
-F113FLUX      'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CFC113_EMISSION   ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
-MCFFLUX       'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CH3CCL3_EMISSION  ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
-CCL4FLUX      'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CCL4_EMISSION     ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
-HCFC22FLUX    'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  HCFC22_EMISSION   ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
-CHBR3FLUX     'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CHBR3_EMISSION    ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
-CH2BR2FLUX    'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CH2BR2_EMISSION   ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
+F11FLUX       'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CFC11_emission    ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
+F12FLUX       'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CFC12_emission    ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
+F113FLUX      'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CFC113_emission   ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
+MCFFLUX       'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CH3CCL3_emission  ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
+CCL4FLUX      'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CCL4_emission     ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
+HCFC22FLUX    'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  HCFC22_emission   ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
+CHBR3FLUX     'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CHBR3_emission    ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
+CH2BR2FLUX    'kg m-2 s-1'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  CH2BR2_emission   ExtData/g5chem/sfc/SC.ODS.Emission.x360_y181.2005.20161025.nc
 OH3DClim      'molec cm-3'     Y   N   %y4-%m2-%d2T00:00:00      0.0     1.0  OH3DClim          ExtData/g5chem/L72/SC.OH3DClimatology.x360_y181_z72_t12.2000.nc
 # -----------|--------------|----|---|----------------------|--------|-------|-----------------|----------------------   
 SO4SAREA       'm2 m-3'        Y   Y   %y4-%m2-%d2t12:00:00     none    none  none              /dev/null


### PR DESCRIPTION
This incorporates changes to GMI, primarily the option to use HEMCO for isoprene emissions, the change of using surface area density from CMIP6, and the option to skip scanning for bad mixing ratios when RAS is set to disallow negative value results.  HEMCO files for GMI have been added, and HEMCO GOCART functionality has been preserved.  This PR is zero-diff for PCHEM/GOCART simulations.