### PR TITLE
Update Chem Grid Comp for Fortran Standards

### DIFF
--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -827,8 +827,8 @@ contains
      END IF
 
      ! make sure we don't have inconsistent MEGAN flags
-     IF ( doMEGANviaHEMCO == .TRUE.    .AND.  &
-          doMEGANemission == .FALSE. ) THEN
+     IF ( doMEGANviaHEMCO .eqv. .TRUE.    .AND.  &
+          doMEGANemission .eqv. .FALSE. ) THEN
         PRINT*,'Inconsistent GMI flags: doMEGANviaHEMCO==T, doMEGANemission==F'
         STATUS=99
         VERIFY_(STATUS)


### PR DESCRIPTION
Technically you cannot in Fortran do `variable == boolean`. Once must use `.eqv.` to test equivalence to boolean constants. Intel allows `==` but GNU will not.