### PR TITLE
Bug fix for hco_config_mod.F90

### DIFF
--- a/Shared/HEMCO/Core/hco_config_mod.F90
+++ b/Shared/HEMCO/Core/hco_config_mod.F90
@@ -548,6 +548,7 @@ CONTAINS
     ! Scalars
     INTEGER                   :: I, N
     INTEGER                   :: nScl
+    INTEGER                   :: nTmp
     INTEGER                   :: STAT
     INTEGER                   :: Int1
     INTEGER                   :: Int2
@@ -995,9 +996,9 @@ CONTAINS
                      
                    ! Extract grid box edges. Need to be four values.
                    CALL HCO_CharSplit ( Char1, Separator, Wildcard, & 
-                                        SplitInts, N, RC ) 
+                                        SplitInts, nTmp, RC ) 
                    IF ( RC /= HCO_SUCCESS ) RETURN
-                   IF ( N /= 4 ) THEN
+                   IF ( nTmp /= 4 ) THEN
                       MSG = 'Cannot properly read mask coverage: ' // &
                            TRIM(Lct%Dct%cName)
                       CALL HCO_ERROR ( HcoConfig%Err, MSG, RC, THISLOC=LOC )


### PR DESCRIPTION
GCC 9.3.0 found a bug in HEMCO. Namely:
https://github.com/GEOS-ESM/GEOSchem_GridComp/blob/99737f3210e62c8e6a37295e7646283b768efe24/Shared/HEMCO/Core/hco_config_mod.F90#L994-L1005
this code tries to call `HCO_CharSplit`  outputting `N` (it's `intent(out)`). The problem is that `N` is the loop variable in which this code is executing. gfortran 9.3.0 really doesn't like you over-writing a loop variable!

Unfortunately, I don't know if this is non-zero-diff or not. I'm making a PR, but @christophkeller might have to test it to see what happens.