### PR TITLE
J36p2_updates

### DIFF
--- a/GAAS_GridComp/GAAS_GridCompMod.F90
+++ b/GAAS_GridComp/GAAS_GridCompMod.F90
@@ -399,10 +399,12 @@ CONTAINS
     type(ESMF_Time)               :: Time     ! Current time
     type(ESMF_Alarm)              :: Alarm
     type(ESMF_Alarm)              :: Predictor_Alarm
+    type(ESMF_Alarm)              :: ReplayShutOff_Alarm
 
     integer                       :: nymd, nhms, i550nm, izAOD, iyAOD
     logical                       :: analysis_time, fexists 
     logical                       :: PREDICTOR_STEP
+    logical                       :: ReplayShutOff
 
     character(len=ESMF_MAXSTR)    :: comp_name
 
@@ -444,6 +446,9 @@ CONTAINS
    call ESMF_ClockGetAlarm(Clock,'PredictorActive',Predictor_Alarm,__RC__)
    PREDICTOR_STEP = ESMF_AlarmIsRinging( Predictor_Alarm,__RC__)
 
+   call ESMF_ClockGetAlarm(Clock,'ReplayShutOff',ReplayShutOff_Alarm,__RC__)
+   ReplayShutOff  = ESMF_AlarmIsRinging( ReplayShutOff_Alarm,__RC__)
+
 !  For some reason the alarm above is not working.
 !  For now, hardwire this...
 !  -----------------------------------------------
@@ -458,7 +463,7 @@ CONTAINS
 
 !  Stop here if it is NOT analysis time
 !  -------------------------------------
-   if ( PREDICTOR_STEP .or. (.not. analysis_time) ) then
+   if ( PREDICTOR_STEP .or. ReplayShutOff .or. (.not. analysis_time) ) then
       RETURN_(ESMF_SUCCESS)
    end if
 


### PR DESCRIPTION
Changed REPLAY_Shutoff alarm from NON-STICKY to STICKY, and used it in GAAS to stop updates in forecasts during REPLAY mode. These were changes done by @lltakacs to fix a bug on how replays handled gaas. I tested this under the default settings and it was confirmed to be 0-diff. This PR must be taken with [GEOSgcm_GridComp#241](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/241)