### PR TITLE
Fixes for CMake using F2Py and LaTeX

### DIFF
--- a/Shared/Chem_Base/CMakeLists.txt
+++ b/Shared/Chem_Base/CMakeLists.txt
@@ -17,15 +17,17 @@ target_compile_definitions (${this} PRIVATE GEOS5)
 
 ecbuild_add_executable(TARGET gogo.x SOURCES gogo.F90 LIBS ${this})
 
-include (UseF2Py)
 include_directories (${esma_include}/${this})
-add_f2py_module(MieObs_ SOURCES MieObs_py.F90 
-   DESTINATION lib/Python
-   LIBRARIES Chem_Base MAPL_Base GMAO_mpeu ${NETCDF_LIBRARIES} ${ESMF_LIBRARY}
-   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
-   USE_MPI
-   )
-add_dependencies(MieObs_ ${this})
+
+if (F2PY_FOUND)
+   add_f2py_module(MieObs_ SOURCES MieObs_py.F90 
+      DESTINATION lib/Python
+      LIBRARIES Chem_Base MAPL_Base GMAO_mpeu ${NETCDF_LIBRARIES} ${ESMF_LIBRARY}
+      INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
+      USE_MPI
+      )
+   add_dependencies(MieObs_ ${this})
+endif (F2PY_FOUND)
 
 
 foreach (exe Chem_Aod.x Chem_Aod3d.x ctl_crst.x Chem_BundleToG5rs.x reff_calculator.xx ext_calculator.xx)


### PR DESCRIPTION
This update fixes some issues where systems do not have
either ImageMagick or F2Py. If F2Py is not found, then F2Py
targets are not built.

This should be taken in concert with:

GEOS-ESM/ESMA_cmake#62
GEOS-ESM/GEOSchem_GridComp#68
GEOS-ESM/GMAO_Shared#84
GEOS-ESM/UMD_Etc#11

That said, if the ESMA_cmake PR/change is not taken, the model will still build, but no f2py will run (as it's missing the `F2PY_FOUND` variable).