### PR TITLE
Update CI to Baselibs 6.0.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gmao/geos-build-env-gcc-source:6.0.11
+      - image: gmao/geos-build-env-gcc-source:6.0.12
     working_directory: /root/project
     steps:
       - run:


### PR DESCRIPTION
This is in anticipation of MAPL 2.1.3 which requires Baselibs 6.0.12