### PR TITLE
Feature/mmanyin/allow gmi stubbing

### DIFF
--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -18,22 +18,21 @@ module GEOS_ChemGridCompMod
   use Chem_UtilMod
   use Bundle_IncrementMod
 
-  use GEOS_ChemEnvGridCompMod,  only : ChemEnv_SetServices   => SetServices
-  use GOCART_GridCompMod,       only : GOCART_SetServices    => SetServices
-  use StratChem_GridCompMod,    only : StratChem_SetServices => SetServices
-  use GMIchem_GridCompMod,      only : GMI_SetServices       => SetServices
-  use CARMAchem_GridCompMod,    only : CARMA_SetServices     => SetServices
-  use GEOSCHEMchem_GridCompMod, only : GCChem_SetServices    => SetServices
-  use MATRIXchem_GridCompMod,   only : MATRIX_SetServices    => SetServices
-  use MAMchem_GridCompMod,      only : MAM_SetServices       => SetServices
-  use GEOS_PChemGridCompMod,    only : PChem_SetServices     => SetServices
-  use GEOS_AChemGridCompMod,    only : AChem_SetServices     => SetServices
-  use GAAS_GridCompMod,         only : GAAS_SetServices      => SetServices
-  use H2O_GridCompMod,          only : H2O_SetServices       => SetServices
-  use TR_GridCompMod,           only : TR_SetServices        => SetServices
-  use DNA_GridCompMod,          only : DNA_SetServices       => SetServices
-  use HEMCO_GridCompMod,        only : HEMCO_SetServices     => SetServices
-  use GmiESMFrcFileReading_mod, only : rcEsmfReadLogical
+  use  GEOS_ChemEnvGridCompMod,  only :   ChemEnv_SetServices => SetServices
+  use       GOCART_GridCompMod,  only :    GOCART_SetServices => SetServices
+  use    StratChem_GridCompMod,  only : StratChem_SetServices => SetServices
+  use      GMIchem_GridCompMod,  only :       GMI_SetServices => SetServices
+  use    CARMAchem_GridCompMod,  only :     CARMA_SetServices => SetServices
+  use GEOSCHEMchem_GridCompMod,  only :    GCChem_SetServices => SetServices
+  use   MATRIXchem_GridCompMod,  only :    MATRIX_SetServices => SetServices
+  use      MAMchem_GridCompMod,  only :       MAM_SetServices => SetServices
+  use    GEOS_PChemGridCompMod,  only :     PChem_SetServices => SetServices
+  use    GEOS_AChemGridCompMod,  only :     AChem_SetServices => SetServices
+  use         GAAS_GridCompMod,  only :      GAAS_SetServices => SetServices
+  use          H2O_GridCompMod,  only :       H2O_SetServices => SetServices
+  use           TR_GridCompMod,  only :        TR_SetServices => SetServices
+  use          DNA_GridCompMod,  only :       DNA_SetServices => SetServices
+  use        HEMCO_GridCompMod,  only :     HEMCO_SetServices => SetServices
 
   implicit none
   private
@@ -812,11 +811,11 @@ contains
      gmi_config = ESMF_ConfigCreate(__RC__ )
      call ESMF_ConfigLoadFile(gmi_config, TRIM(gmi_rcfilen), __RC__ )
 
-     call rcEsmfReadLogical(gmi_config, doMEGANemission, &
-                                       "doMEGANemission:", default=.false., __RC__ )
+     call ESMF_ConfigGetAttribute(gmi_config, value=doMEGANemission, &
+                                             label="doMEGANemission:", default=.FALSE., __RC__ )
 
-     call rcEsmfReadLogical(gmi_config, doMEGANviaHEMCO, &
-                                       "doMEGANviaHEMCO:", default=.false., __RC__ )
+     call ESMF_ConfigGetAttribute(gmi_config, value=doMEGANviaHEMCO, &
+                                             label="doMEGANviaHEMCO:", default=.FALSE., __RC__ )
        
      ! make sure we don't have inconsistent HEMCO flags
      IF ( GMI_instance_of_HEMCO .neqv. doMEGANviaHEMCO ) THEN

--- a/GMIchem_GridComp/ChangeLog
+++ b/GMIchem_GridComp/ChangeLog
@@ -1,4 +1,9 @@
 GMIchem ChangeLog
+2020-05-25 <michael.manyin@nasa.gov> Branch: feature/mmanyin/allow_GMI_stubbing
+        * Replace routine rcEsmfReadLogical with ESMF_ConfigGetAttribute
+        * Eliminate spurious FAIL message from photolysis
+        * New boundary condition file
+
 2019-08-15 <michael.manyin@nasa.gov> Tag: Icarus-3_2_p9_MEM_16
         * Added Jules' ship emissions, with some refinements
 

--- a/GMIchem_GridComp/GMI_GridComp/GMI_GridComp.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_GridComp.rc
@@ -237,7 +237,7 @@ forc_bc_kmax: 2
 # CO2 is not included in this file; it is specified in getco2.F90 which has different RCP versions too.
 # Be sure to use the same RCP versions of forc_bc_infile and getco2.F90 .
 #
-forc_bc_infile_name: /discover/nobackup/ldoman/fvInput/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
+forc_bc_infile_name: /discover/nobackup/ldoman/fvInput/RCP6.0_5BrWMO2018_ch4latvar_1950_2100.asc
 
 forcedBcSpeciesNames:: 
 CFCl3

--- a/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -26,7 +26,6 @@
    USE GmiSpcConcentrationMethod_mod, ONLY : t_SpeciesConcentration
    USE GmiGrid_mod,                   ONLY : t_gmiGrid
    USE GmiTimeControl_mod,            ONLY : t_GmiClock
-   USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadLogical
    USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadTable
    use GmiArrayBundlePointer_mod,     ONLY : t_GmiArrayBundle, CleanArrayPointer
    use GmiFieldBundleESMF_mod,        ONLY : obtainTracerFromBundle
@@ -269,48 +268,48 @@ CONTAINS
       ! Advection related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_grav_set, &
-     &           "do_grav_set:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_grav_set, &
+     &           label="do_grav_set:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       !------------------------------
       ! Emission related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_synoz, &
-     &           "do_synoz:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_synoz, &
+     &           label="do_synoz:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_semiss_inchem, &
-     &           "do_semiss_inchem:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_semiss_inchem, &
+     &           label="do_semiss_inchem:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       !------------------------------
       ! Diagnostics related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_diag, &
-     &           "pr_diag:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_diag, &
+     &           label="pr_diag:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%verbose, &
-     &           "verbose:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%verbose, &
+     &           label="verbose:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_surf_emiss, &
-     &           "pr_surf_emiss:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_surf_emiss, &
+     &           label="pr_surf_emiss:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_emiss_3d, &
-     &           "pr_emiss_3d:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_emiss_3d, &
+     &           label="pr_emiss_3d:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_qqjk, &
-     &           "pr_qqjk:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qqjk, &
+     &           label="pr_qqjk:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_qqjk_reset, &
-     &           "do_qqjk_reset:", default=.true., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_qqjk_reset, &
+     &           label="do_qqjk_reset:", default=.true., rc=STATUS)
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, self%pr_nc_period, &
@@ -318,28 +317,28 @@ CONTAINS
      &                default = -1.0d0, rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_ftiming, &
-     &               "do_ftiming:", default=.false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_ftiming, &
+     &               label="do_ftiming:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%rd_restart, &
-     &               "rd_restart:", default=.false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%rd_restart, &
+     &               label="rd_restart:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_qj_o3_o1d, &
-     &               "pr_qj_o3_o1d:", default=.false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qj_o3_o1d, &
+     &               label="pr_qj_o3_o1d:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_qj_opt_depth, &
-     &               "pr_qj_opt_depth:", default=.false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qj_opt_depth, &
+     &               label="pr_qj_opt_depth:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_smv2, &
-     &               "pr_smv2:", default=.false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_smv2, &
+     &               label="pr_smv2:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_const, &
-     &               "pr_const:", default=.false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_const, &
+     &               label="pr_const:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_org, &
@@ -356,8 +355,8 @@ CONTAINS
       ! Chemistry Related Variables
       !----------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_qqjk_inchem, &
-     &           "do_qqjk_inchem:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_qqjk_inchem, &
+     &           label="do_qqjk_inchem:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
 ! Does the GMICHEM import restart file exist?  If not,

--- a/GMIchem_GridComp/GMI_GridComp/GmiChemistry/GmiChemistryMethod_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChemistry/GmiChemistryMethod_mod.F90
@@ -21,7 +21,7 @@
       use GmiTimeControl_mod,       only : t_GmiClock, Get_curGmiDate, GmiSplitDateTime
       use GmiSpeciesRegistry_mod,   only : getSpeciesIndex, UNKNOWN_SPECIES
       use GmiPrintError_mod,        only : GmiPrintError
-      use GmiESMFrcFileReading_mod, only : rcEsmfReadTable, rcEsmfReadLogical
+      use GmiESMFrcFileReading_mod, only : rcEsmfReadTable
       use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle
       use GmiSavedVariables_mod,     only : t_ChemistrySaved
 
@@ -266,14 +266,14 @@
      &                default = 263.0d0, rc=STATUS )
       VERIFY_(STATUS) 
 
-      call rcEsmfReadLogical(config, self%do_chem_grp, "do_chem_grp:", &
-     &                       default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%do_chem_grp,  label="do_chem_grp:",  &
+     &                       default=.false., __RC__ )
      
-      call rcEsmfReadLogical(config, self%do_smv_reord, "do_smv_reord:", &
-     &                       default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%do_smv_reord, label="do_smv_reord:", &
+     &                       default=.false., __RC__ )
 
-      call rcEsmfReadLogical(config, self%do_wetchem, "do_wetchem:", &
-     &                       default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%do_wetchem,   label="do_wetchem:",   &
+     &                       default=.false., __RC__ )
 
 !     ---------------------------
 !     Surface Area Density (SAD):

--- a/GMIchem_GridComp/GMI_GridComp/GmiDepos_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiDepos_GridCompClassMod.F90
@@ -24,7 +24,6 @@
    USE GmiSpcConcentrationMethod_mod, ONLY : t_SpeciesConcentration
    USE GmiGrid_mod,                   ONLY : t_gmiGrid
    USE GmiTimeControl_mod,            ONLY : t_GmiClock
-   USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadLogical
    USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadTable
    USE GmiSwapSpeciesBundlesMod,      ONLY : SwapSpeciesBundles, speciesReg_for_CCM
    USE VegLaiMod,                     ONLY : Decode_Land_Types, Decode_XLAI
@@ -253,8 +252,8 @@ CONTAINS
      &                default = ' ', rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_synoz, &
-     &           "do_synoz:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_synoz, &
+     &           label="do_synoz:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, self%chem_opt, &
@@ -266,39 +265,39 @@ CONTAINS
       ! Deposition related variables
       !------------------------------
       
-      call rcEsmfReadLogical(gmiConfigFile, self%do_drydep, &
-     &           "do_drydep:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_drydep, &
+     &           label="do_drydep:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_wetdep, &
-     &           "do_wetdep:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_wetdep, &
+     &           label="do_wetdep:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       !------------------------------
       ! Diagnostics related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_grav_set, &
-     &           "do_grav_set:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_grav_set, &
+     &           label="do_grav_set:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_diag, &
-     &           "pr_diag:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_diag, &
+     &           label="pr_diag:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%verbose, &
-     &           "verbose:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%verbose, &
+     &           label="verbose:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_scav, &
-     &           "pr_scav:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_scav, &
+     &           label="pr_scav:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_dry_depos, &
-     &           "pr_dry_depos:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_dry_depos, &
+     &           label="pr_dry_depos:", default=.false., rc=STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_wet_depos, &
-     &           "pr_wet_depos:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_wet_depos, &
+     &           label="pr_wet_depos:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_org, &

--- a/GMIchem_GridComp/GMI_GridComp/GmiDeposition/GmiDepositionMethod_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiDeposition/GmiDepositionMethod_mod.F90
@@ -19,7 +19,6 @@
       use GmiPrintError_mod            , only : GmiPrintError
       use GmiEmissionMethod_mod        , only : t_Emission
       use GmiESMFrcFileReading_mod     , only : rcEsmfReadTable
-      use GmiESMFrcFileReading_mod     , only : rcEsmfReadLogical
       use GmiArrayBundlePointer_mod    , only : t_GmiArrayBundle
       use GmiSpcConcentrationMethod_mod, only : t_SpeciesConcentration
       use GmiSpcConcentrationMethod_mod, only : Get_concentration
@@ -114,17 +113,14 @@
      &                default = 1, rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(config, self%do_drydep, &
-     &               "do_drydep:", default=.false., rc=STATUS )
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%do_drydep,    &
+     &               label="do_drydep:",    default=.false., __RC__ )
 
-      call rcEsmfReadLogical(config, self%do_wetdep, &
-     &               "do_wetdep:", default=.false., rc=STATUS )
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%do_wetdep,    &
+     &               label="do_wetdep:",    default=.false., __RC__ )
 
-      call rcEsmfReadLogical(config, self%do_simpledep, &
-     &               "do_simpledep:", default=.false., rc=STATUS )
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%do_simpledep, &
+     &               label="do_simpledep:", default=.false., __RC__ )
 
      ! ----------------------------------------------------------------
      ! wetdep_eff : wet deposition (scavenging) efficiencies; should be

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -27,7 +27,6 @@
    USE GmiSpcConcentrationMethod_mod, ONLY : t_SpeciesConcentration
    USE GmiGrid_mod,                   ONLY : t_gmiGrid
    USE GmiTimeControl_mod,            ONLY : t_GmiClock
-   USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadLogical
    USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadTable
    USE GmiArrayBundlePointer_mod,     ONLY : t_GmiArrayBundle, CleanArrayPointer
    USE GmiFieldBundleESMF_mod,        ONLY : updateTracerToBundle
@@ -337,24 +336,24 @@ CONTAINS
       ! Deposition related variables
       !------------------------------
       
-      call rcEsmfReadLogical(gmiConfigFile, self%do_drydep, &
-     &           "do_drydep:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_drydep, &
+     &           label="do_drydep:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_wetdep, &
-     &           "do_wetdep:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_wetdep, &
+     &           label="do_wetdep:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       !------------------------------
       ! Emission related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_emission, &
-     &           "do_emission:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_emission, &
+     &           label="do_emission:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_synoz, &
-     &           "do_synoz:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_synoz, &
+     &           label="do_synoz:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       CALL ESMF_ConfigGetAttribute(gmiConfigFile, self%num_diurnal_emiss, &
@@ -365,28 +364,28 @@ CONTAINS
       ! Diagnostics related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_diag, &
-     &           "pr_diag:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_diag, &
+     &           label="pr_diag:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%verbose, &
-     &           "verbose:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%verbose, &
+     &           label="verbose:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_surf_emiss, &
-     &           "pr_surf_emiss:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_surf_emiss, &
+     &           label="pr_surf_emiss:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_emiss_3d, &
-     &           "pr_emiss_3d:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_emiss_3d, &
+     &           label="pr_emiss_3d:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_const, &
-     &               "pr_const:", default=.false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_const, &
+     &               label="pr_const:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_aerocom, &
-     &               "do_aerocom:", default=.false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_aerocom, &
+     &               label="do_aerocom:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_org, &
@@ -421,8 +420,8 @@ CONTAINS
       ! Useful for mission support and replays.
       !--------------------------------------------
       
-      call rcEsmfReadLogical(gmiConfigFile, self%BCRealTime, &
-     &           "BCRealTime:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%BCRealTime, &
+     &           label="BCRealTime:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
       
 ! Does the GMICHEM import restart file exist?  If not,

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmission/GmiEmissionMethod_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmission/GmiEmissionMethod_mod.F90
@@ -19,7 +19,7 @@
       use GmiGrid_mod, only : Get_ilong, Get_ilat, Get_ivert
       use GmiPrintError_mod, only : GmiPrintError
       use GmiCheckRange_mod, only : CheckRange3d
-      use GmiESMFrcFileReading_mod, only : rcEsmfReadTable, rcEsmfReadLogical
+      use GmiESMFrcFileReading_mod, only : rcEsmfReadTable
       use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle, CleanArrayPointer
       use GmiSpcConcentrationMethod_mod, only : t_SpeciesConcentration
       use GmiSpcConcentrationMethod_mod, only : Get_concentration, Set_concentration
@@ -332,8 +332,8 @@
      &                default = 1.0d0, rc=STATUS )
       VERIFY_(STATUS)
 
-      CALL rcEsmfReadLogical(config, self%clim_emiss_by_area, &
-     &           "clim_emiss_by_area:", DEFAULT=.TRUE., RC=STATUS)
+      CALL ESMF_ConfigGetAttribute(config, value=self%clim_emiss_by_area, &
+     &           label="clim_emiss_by_area:", DEFAULT=.TRUE., RC=STATUS)
       VERIFY_(STATUS)
 
      ! Save the number of emitting layers for each emissionSpeciesName
@@ -425,8 +425,8 @@
      ! -----------------------------------------------------
 
      ! Fossil fuel
-      call rcEsmfReadLogical(config, self%doScaleNOffEmiss, &
-     &           "doScaleNOffEmiss:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%doScaleNOffEmiss, &
+     &           label="doScaleNOffEmiss:", default=.false., rc=STATUS)
 
       call ESMF_ConfigGetAttribute(config, self%scFactorNOff_infile_name, &
      &                label   = "scFactorNOff_infile_name:", &
@@ -434,8 +434,8 @@
       VERIFY_(STATUS)
 
      ! Biomass burning
-      call rcEsmfReadLogical(config, self%doScaleNObbEmiss, &
-     &           "doScaleNObbEmiss:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%doScaleNObbEmiss, &
+     &           label="doScaleNObbEmiss:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(config, self%scFactorNObb_infile_name, &
@@ -456,73 +456,61 @@
     
       ! turn on Galactic Cosmic ray emmission of N and NO
 
-      call rcEsmfReadLogical(config, self%do_gcr, &
-     &           "do_gcr:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%do_gcr, &
+     &           label="do_gcr:", default=.false., __RC__ )
 
       call ESMF_ConfigGetAttribute(config, self%gcr_infile_name, &
      &                label   = "gcr_infile_name:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = ' ', __RC__ )
 
     !... do Ship Emission Calculations
 
-      call rcEsmfReadLogical(config, self%do_ShipEmission, &
-     &           "do_ShipEmission:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%do_ShipEmission, &
+     &           label="do_ShipEmission:", default=.false., __RC__ )
 
     !... do MEGAN emission calculations
 
-      call rcEsmfReadLogical(config, self%doMEGANemission, &
-     &           "doMEGANemission:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%doMEGANemission, &
+     &           label="doMEGANemission:", default=.false., __RC__ )
 
-      call rcEsmfReadLogical(config, self%doMEGANviaHEMCO, &  
-     &           "doMEGANviaHEMCO:", default=.false., rc=STATUS)
-      VERIFY_(STATUS)
+      call ESMF_ConfigGetAttribute(config, value=self%doMEGANviaHEMCO, &  
+     &           label="doMEGANviaHEMCO:", default=.false., __RC__ )
 
       call ESMF_ConfigGetAttribute(config, self%MEGAN_infile_name, &
      &                label   = "MEGAN_infile_name:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = ' ', __RC__ )
 
       call ESMF_ConfigGetAttribute(config, self%laiMEGAN_InfileName, &
      &                label   = "laiMEGAN_InfileName:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = ' ', __RC__ )
 
       call ESMF_ConfigGetAttribute(config, self%aefMboMEGAN_InfileName, &
      &                label   = "aefMboMEGAN_InfileName:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = ' ', __RC__ )
      
       call ESMF_ConfigGetAttribute(config, self%aefIsopMEGAN_InfileName, &
      &                label   = "aefIsopMEGAN_InfileName:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS) 
+     &                default = ' ', __RC__ )
       
       call ESMF_ConfigGetAttribute(config, self%aefOvocMEGAN_InfileName, &
      &                label   = "aefOvocMEGAN_InfileName:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = ' ', __RC__ )
      
       call ESMF_ConfigGetAttribute(config, self%aefMonotMEGAN_InfileName, &
      &                label   = "aefMonotMEGAN_InfileName:", &
-     &                default = ' ', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = ' ', __RC__ )
      
       call ESMF_ConfigGetAttribute(config, self%soil_infile_name, &
      &                label   = "soil_infile_name:", &
-     &                default = 'soiltype.asc', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = 'soiltype.asc', __RC__ )
 
       call ESMF_ConfigGetAttribute(config, self%isopconv_infile_name, &
      &                label   = "isopconv_infile_name:", &
-     &                default = 'isopconvtable.asc', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = 'isopconvtable.asc', __RC__ )
 
       call ESMF_ConfigGetAttribute(config, self%monotconv_infile_name, &
      &                label   = "monotconv_infile_name:", &
-     &                default = 'monotconvtable.asc', rc=STATUS )
-      VERIFY_(STATUS)
+     &                default = 'monotconvtable.asc', __RC__ )
 
     ! ---------------------------------------------------------------------------------------
     ! lightning_opt = 0 --> default lightning

--- a/GMIchem_GridComp/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
@@ -23,7 +23,6 @@
    USE GmiSpcConcentrationMethod_mod, ONLY : t_SpeciesConcentration
    USE GmiGrid_mod,                   ONLY : t_gmiGrid
    USE GmiTimeControl_mod,            ONLY : t_GmiClock
-   USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadLogical
    USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadTable
    use GmiArrayBundlePointer_mod,     only : t_GmiArrayBundle, CleanArrayPointer
    use GmiSpeciesRegistry_mod,        only : getSpeciesIndex, UNKNOWN_SPECIES
@@ -279,16 +278,16 @@ CONTAINS
       ! Diagnostics related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_diag, &
-     &           "pr_diag:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_diag, &
+     &           label="pr_diag:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%verbose, &
-     &           "verbose:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%verbose, &
+     &           label="verbose:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_synoz, &
-     &           "do_synoz:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_synoz, &
+     &           label="do_synoz:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
 !     ---------------------------

--- a/GMIchem_GridComp/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
@@ -22,7 +22,6 @@
    USE GmiSpcConcentrationMethod_mod, ONLY : t_SpeciesConcentration
    USE GmiGrid_mod,                   ONLY : t_gmiGrid
    USE GmiTimeControl_mod,            ONLY : t_GmiClock
-   USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadLogical
    USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadTable
    use GmiArrayBundlePointer_mod,     ONLY : t_GmiArrayBundle, CleanArrayPointer
    use GmiFieldBundleESMF_mod,        ONLY : updateTracerToBundle
@@ -383,28 +382,28 @@ CONTAINS
       ! Emission related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_synoz, &
-     &           "do_synoz:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_synoz, &
+     &           label="do_synoz:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_semiss_inchem, &
-     &           "do_semiss_inchem:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_semiss_inchem, &
+     &           label="do_semiss_inchem:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_ShipEmission, &
-     &           "do_ShipEmission:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_ShipEmission, &
+     &           label="do_ShipEmission:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       !------------------------------
       ! Diagnostics related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_diag, &
-     &           "pr_diag:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_diag, &
+     &           label="pr_diag:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%verbose, &
-     &           "verbose:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%verbose, &
+     &           label="verbose:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       !-------------------------------------------
@@ -412,8 +411,8 @@ CONTAINS
       ! Useful for mission support and replays.
       !--------------------------------------------
       
-      call rcEsmfReadLogical(gmiConfigFile, self%BCRealTime, &
-     &           "BCRealTime:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%BCRealTime, &
+     &           label="BCRealTime:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
       
       !-----------------------------
@@ -455,7 +454,7 @@ CONTAINS
      &                default = 1, rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_clear_sky, "do_clear_sky:", &
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_clear_sky, label="do_clear_sky:", &
      &                       default=.false., rc=STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, self%fastj_offset_sec, &
@@ -495,7 +494,7 @@ CONTAINS
 
 !... do solar cycle in incoming solar flux?
 
-      CALL rcEsmfReadLogical(gmiConfigFile, self%do_solar_cycle, "do_solar_cycle:", &
+      CALL ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_solar_cycle, label="do_solar_cycle:", &
      &                       default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
@@ -645,8 +644,8 @@ CONTAINS
      &                default = '', rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_ozone_inFastJX, &
-     &              "do_ozone_inFastJX:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_ozone_inFastJX, &
+     &              label="do_ozone_inFastJX:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       !=================================================================
@@ -656,7 +655,7 @@ CONTAINS
       !                 and not do any aerosol/dust calculations.
       !=================================================================
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_AerDust_Calc, "do_AerDust_Calc:", &
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_AerDust_Calc, label="do_AerDust_Calc:", &
      &                       default=.false., rc=STATUS)
 
       !=================================================================
@@ -698,10 +697,10 @@ CONTAINS
 
       !!if (self%num_qjs > 0) self%qj_labels(1:self%num_qjs) = lqjchem(1:self%num_qjs)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_qj_o3_o1d, "pr_qj_o3_o1d:", &
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qj_o3_o1d, label="pr_qj_o3_o1d:", &
      &                       default=.false., rc=STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_qj_opt_depth, "pr_qj_opt_depth:", &
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qj_opt_depth, label="pr_qj_opt_depth:", &
      &                       default=.false., rc=STATUS)
 
 !      if (self%pr_qj_o3_o1d) then
@@ -745,24 +744,24 @@ CONTAINS
       ! Do we want to couple to GOCART aerosols?
       ! ----------------------------------------
       
-      call rcEsmfReadLogical(gmiConfigFile, self%usingGOCART_BC, &
-     &           "usingGOCART_BC:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_BC, &
+     &           label="usingGOCART_BC:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
       
-      call rcEsmfReadLogical(gmiConfigFile, self%usingGOCART_DU, &
-     &           "usingGOCART_DU:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_DU, &
+     &           label="usingGOCART_DU:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
       
-      call rcEsmfReadLogical(gmiConfigFile, self%usingGOCART_OC, &
-     &           "usingGOCART_OC:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_OC, &
+     &           label="usingGOCART_OC:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
       
-      call rcEsmfReadLogical(gmiConfigFile, self%usingGOCART_SS, &
-     &           "usingGOCART_SS:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_SS, &
+     &           label="usingGOCART_SS:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
       
-      call rcEsmfReadLogical(gmiConfigFile, self%usingGOCART_SU, &
-     &           "usingGOCART_SU:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%usingGOCART_SU, &
+     &           label="usingGOCART_SU:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
 
@@ -2200,6 +2199,7 @@ CONTAINS
 
   TYPE(ESMF_State)           :: aero
   TYPE(ESMF_FieldBundle)     :: aerosols
+  TYPE(ESMF_StateItem_Flag)  :: itemtype
 
   rc = 0
   IAm = "Acquire_SU"
@@ -2233,19 +2233,19 @@ CONTAINS
      END IF
 
      ! If volcanic SU exists, use it too:
-     NULLIFY(SO4)
-     CALL MAPL_GetPointer(impChem, SO4, 'GOCART::SO4v')
-     IF( ASSOCIATED(SO4) ) THEN
+     CALL ESMF_StateGet(impChem, 'GOCART::SO4v', itemtype, RC=STATUS)
+     VERIFY_(STATUS)
+
+     IF ( itemtype == ESMF_STATEITEM_FIELD ) THEN
+       CALL MAPL_GetPointer(impChem, SO4, 'GOCART::SO4v', RC=STATUS)
+       VERIFY_(STATUS)
 
        self%wAersl(:,:,km:1:-1,1) = &
        self%wAersl(:,:,km:1:-1,1) + SO4(:,:,1:km)*airdens(:,:,1:km)
 
        IF(self%verbose) THEN
-        CALL pmaxmin('SO4v:', SO4, qmin, qmax, iXj, km, 1. )
+         CALL pmaxmin('SO4v:', SO4, qmin, qmax, iXj, km, 1. )
        END IF
-
-       NULLIFY(SO4)
-
      END IF
 
     END IF

--- a/GMIchem_GridComp/GMI_GridComp/GmiSAD_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiSAD_GridCompClassMod.F90
@@ -23,7 +23,6 @@
    USE GmiSpcConcentrationMethod_mod, ONLY : t_SpeciesConcentration
    USE GmiGrid_mod,                   ONLY : t_gmiGrid
    USE GmiTimeControl_mod,            ONLY : t_GmiClock
-   USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadLogical
    USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadTable
    use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle
    use GmiPrintError_mod,        only : GmiPrintError
@@ -292,17 +291,17 @@ CONTAINS
       call ESMF_ConfigLoadFile(gmiConfigFile, TRIM(rcfilen), rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, importRestartFile, &
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=importRestartFile, &
      &                label   = "importRestartFile:", &
      &                default = ' ', rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, self%chem_mecha, &
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%chem_mecha, &
      &                label   = "chem_mecha:", &
      &                default = 'strat_trop', rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_model, &
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%metdata_name_model, &
      &                label   = "metdata_name_model:", &
      &                default = 'GEOS-5', rc=STATUS )
 
@@ -310,19 +309,19 @@ CONTAINS
       ! Diagnostics related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_diag, &
-     &           "pr_diag:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_diag, &
+     &           label="pr_diag:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%verbose, &
-     &           "verbose:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%verbose, &
+     &           label="verbose:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_synoz, &
-     &           "do_synoz:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_synoz, &
+     &           label="do_synoz:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, self%chem_opt, &
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%chem_opt, &
      &                label   = "chem_opt:", &
      &                default = 2, rc=STATUS )
       VERIFY_(STATUS)
@@ -402,8 +401,8 @@ CONTAINS
      &                default = 0.0d0, rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_sad, &
-     &           "pr_sad:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_sad, &
+     &           label="pr_sad:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
 !     ------------------------------------------------

--- a/GMIchem_GridComp/GMI_GridComp/GmiShared/GmiESMF/GmiESMFrcFileReading_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiShared/GmiESMF/GmiESMFrcFileReading_mod.F90
@@ -20,7 +20,7 @@
 !
 ! !PUBLIC MEMBER FUNCTIONS:
       public  :: rcEsmfReadTable
-      public  :: rcEsmfReadLogical
+!     public  :: rcEsmfReadLogical
       public  :: reconstructPhrase
 
       interface rcEsmfReadTable
@@ -296,60 +296,60 @@
       end subroutine rcEsmfReadTable2String
 !EOC
 !------------------------------------------------------------------------------
-!BOP
+!!BOP
 !
-! !IROUTINE: rcEsmfReadLogical
+!! !IROUTINE: rcEsmfReadLogical     INSTEAD USE: ESMF_ConfigGetAttribute
+!!
+!! !INTERFACE:
+!!
+!      subroutine rcEsmfReadLogical(config, value, label, default, rc)
+!!
+!      implicit none
+!!
+!! !INPUT PARAMETERS:
+!    character(len=*) , intent(in) :: label
+!    logical, optional, intent(in) :: default
+!!
+!! !OUTPUT PARAMETERS:
+!    logical, intent(out) :: value
+!    integer, optional, intent(out) :: rc
+!!
+!! !INPUT/OUTPUT PARAMETERS:
+!    type(ESMF_Config), intent(inOut) :: config
+!!
+!! !DESCRIPTION:
+!! Reads in a logical variable from a resource file.
+!! Note that ESMF does not have a routine to read logical variables.
+!! We assume that the variable in the resource file is character and we
+!! do the conversion after the reading.
+!!
+!! !LOCAL VARIABLES:
+!      integer :: STATUS
+!      character(len=1) :: cDefault, cValue
+!      character(len=ESMF_MAXSTR), parameter :: IAm = "rcEsmfReadLogical"
+!!EOP
+!!------------------------------------------------------------------------------
+!!BOC
+!      cDefault = 'F'
+!      if (present(default)) then
+!         if (default) cDefault = 'T'
+!      end if
 !
-! !INTERFACE:
+!      call ESMF_ConfigGetChar(config, cValue, label=label, default=cDefault, rc=STATUS )
+!      VERIFY_(STATUS)
 !
-      subroutine rcEsmfReadLogical(config, value, label, default, rc)
+!      if (present(rc)) rc = STATUS
 !
-      implicit none
-!
-! !INPUT PARAMETERS:
-    character(len=*) , intent(in) :: label
-    logical, optional, intent(in) :: default
-!
-! !OUTPUT PARAMETERS:
-    logical, intent(out) :: value
-    integer, optional, intent(out) :: rc
-!
-! !INPUT/OUTPUT PARAMETERS:
-    type(ESMF_Config), intent(inOut) :: config
-!
-! !DESCRIPTION:
-! Reads in a logical variable from a resource file.
-! Note that ESMF does not have a routine to read logical variables.
-! We assume that the variable in the resource file is character and we
-! do the conversion after the reading.
-!
-! !LOCAL VARIABLES:
-      integer :: STATUS
-      character(len=1) :: cDefault, cValue
-      character(len=ESMF_MAXSTR), parameter :: IAm = "rcEsmfReadLogical"
-!EOP
-!------------------------------------------------------------------------------
-!BOC
-      cDefault = 'F'
-      if (present(default)) then
-         if (default) cDefault = 'T'
-      end if
-
-      call ESMF_ConfigGetChar(config, cValue, label=label, default=cDefault, rc=STATUS )
-      VERIFY_(STATUS)
-
-      if (present(rc)) rc = STATUS
-
-      if ((cValue == 'T') .or. (cValue == 't')) then
-         value = .true.
-      else
-         value = .false.
-      end if
-      
-      return
-      
-      end subroutine rcEsmfReadLogical
-!EOC
+!      if ((cValue == 'T') .or. (cValue == 't')) then
+!         value = .true.
+!      else
+!         value = .false.
+!      end if
+!      
+!      return
+!      
+!      end subroutine rcEsmfReadLogical
+!!EOC
 !------------------------------------------------------------------------------
 !BOP
 !

--- a/GMIchem_GridComp/GMI_GridComp/GmiSpeciesConcentration/spcConcentrationMethod/GmiSpcConcentrationMethod_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiSpeciesConcentration/spcConcentrationMethod/GmiSpcConcentrationMethod_mod.F90
@@ -12,7 +12,7 @@
 ! !USES:
       use ESMF
       use MAPL
-      use GmiESMFrcFileReading_mod, only : rcEsmfReadTable, rcEsmfReadLogical
+      use GmiESMFrcFileReading_mod, only : rcEsmfReadTable
       use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle, CleanArrayPointer
       use GmiArrayBundlePointer_mod, only : setArrayPointer
       use GmiGrid_mod              , only : t_gmiGrid
@@ -149,8 +149,8 @@
 !BOC
       IAm = "ReadSpcConcentrationResourceFile"
 
-      call rcEsmfReadLogical(config, pr_diag, &
-     &               "pr_diag:", default = .false., rc=STATUS )
+      call ESMF_ConfigGetAttribute(config, value=pr_diag, &
+     &               label="pr_diag:", default = .false., rc=STATUS )
       VERIFY_(STATUS)
 
       if (pr_diag) Write(6,*) IAm, 'called by ', loc_proc

--- a/GMIchem_GridComp/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
@@ -26,7 +26,6 @@
    USE GmiSpcConcentrationMethod_mod, ONLY : t_SpeciesConcentration
    USE GmiGrid_mod,                   ONLY : t_gmiGrid
    USE GmiTimeControl_mod,            ONLY : t_GmiClock
-   USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadLogical
    USE GmiESMFrcFileReading_mod,      ONLY : rcEsmfReadTable
    use GmiArrayBundlePointer_mod, only : t_GmiArrayBundle, CleanArrayPointer
    use GmiFieldBundleESMF_mod,        ONLY : obtainTracerFromBundle
@@ -252,24 +251,24 @@ CONTAINS
      &                default = 'strat_trop', rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_synoz, &
-     &           "do_synoz:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_synoz, &
+     &           label="do_synoz:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       !------------------------------
       ! Diagnostics related variables
       !------------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_diag, &
-     &           "pr_diag:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_diag, &
+     &           label="pr_diag:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%verbose, &
-     &           "verbose:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%verbose, &
+     &           label="verbose:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_wetchem, &
-     &           "do_wetchem:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_wetchem, &
+     &           label="do_wetchem:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_org, &
@@ -287,32 +286,32 @@ CONTAINS
      &                default = 1, rc=STATUS )
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_AerDust_Calc, &
-     &           "do_AerDust_Calc:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_AerDust_Calc, &
+     &           label="do_AerDust_Calc:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%pr_qqjk, &
-     &           "pr_qqjk:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qqjk, &
+     &           label="pr_qqjk:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_qqjk_reset, &
-     &           "do_qqjk_reset:", default=.true., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_qqjk_reset, &
+     &           label="do_qqjk_reset:", default=.true., rc=STATUS)
       VERIFY_(STATUS)
 
       !----------------------------
       ! Chemistry Related Variables
       !----------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_qqjk_inchem, &
-     &           "do_qqjk_inchem:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_qqjk_inchem, &
+     &           label="do_qqjk_inchem:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
 !     -------------------------
 !     Reaction rate adjustment:
 !     -------------------------
 
-      call rcEsmfReadLogical(gmiConfigFile, self%do_rxnr_adjust, &
-     &           "do_rxnr_adjust:", default=.false., rc=STATUS)
+      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_rxnr_adjust, &
+     &           label="do_rxnr_adjust:", default=.false., rc=STATUS)
 
       call ESMF_ConfigGetAttribute(gmiConfigFile, self%rxnr_adjust_infile_name, &
      &                label   = "rxnr_adjust_infile_name:", &

--- a/GMIchem_GridComp/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridComp/GMIchem_GridCompMod.F90
@@ -20,7 +20,6 @@
    USE Chem_UtilMod, ONLY : Chem_UtilNegFiller  ! Eliminates negative vmr
    USE Chem_GroupMod                            ! For Family Transport
    USE OVP,     ONLY:  OVP_init, OVP_end_of_timestep_hms, OVP_mask, OVP_apply_mask
-   USE GmiESMFrcFileReading_mod, only : rcEsmfReadLogical
 
    IMPLICIT NONE
    PRIVATE
@@ -299,8 +298,8 @@ CONTAINS
 
 !   This duplicates the call in the Emissions code; really should only be done once!
 !   call rcEsmfReadLogical(gmiConfig, do_ShipEmission, "do_ShipEmission:", default=.false., __RC__)
-    CALL ESMF_ConfigGetAttribute(gmiConfig, do_ShipEmission, Default=.false., &
-                                  Label="do_ShipEmission:", __RC__)
+    CALL ESMF_ConfigGetAttribute(gmiConfig, value= do_ShipEmission, Default=.false., &
+                                            Label="do_ShipEmission:", __RC__)
 
     IF ( do_ShipEmission ) THEN
        call MAPL_AddImportSpec(GC,                         & 
@@ -334,7 +333,8 @@ CONTAINS
      ! note: might change this later to use GMICHEM_ImportSpec___.h
      gmi_config = ESMF_ConfigCreate(__RC__ )
      call ESMF_ConfigLoadFile(gmi_config, TRIM(gmi_rcfilen), __RC__ )
-     call rcEsmfReadLogical(gmi_config, doMEGANviaHEMCO, "doMEGANviaHEMCO:", default=.false., __RC__ )
+     call ESMF_ConfigGetAttribute(gmi_config, value= doMEGANviaHEMCO, &
+                                              label="doMEGANviaHEMCO:", default=.false., __RC__ )
 
      IF ( doMEGANviaHEMCO ) THEN
         call MAPL_AddImportSpec(GC, &

--- a/TR_GridComp/ChangeLog
+++ b/TR_GridComp/ChangeLog
@@ -1,5 +1,10 @@
 TR_GridComp ChangeLog
 
+2020-05-22 <michael.manyin@nasa.gov>
+        * Fixed memory leak
+        * 3D emissions diagnostic is now kg/m2/s instead of kg/m2
+        * Several diagnostics now account for moist air
+
 2019-07-05 <michael.manyin@nasa.gov>, Tag: Icarus-3_2_p9_MEM_15
         * Added Elliot's aoa_bl tracer, and vertical specification "boundary_layer"
 

--- a/TR_GridComp/TR_GridCompMod.F90
+++ b/TR_GridComp/TR_GridCompMod.F90
@@ -68,6 +68,10 @@
 !   7jul2015  Manyin       Added run_order to replace spaghetti.
 !  27may2016  Manyin       ExtData is now used for 2D and 3D source files, veg/lai files, and masks.
 !  26nov2018  Oman         Renumbered QQK values for GMI, to match the new mechanism.
+!  18may2020  Manyin       Diagnostics for GMI wet and dry removal now assume VMR wrt moist air
+!                          Diagnostics for PR and DK, when units=VMR, now assume wrt moist air
+!                          Diagnostic for 3D emissions is now kg/m2/s instead of kg/m2
+!                          Fixed memory leak (VMR_to_MMR and MMR_to_VMR)
 !
 !EOP
 !-------------------------------------------------------------------------
@@ -3342,8 +3346,10 @@ CONTAINS
    LOGICAL, ALLOCATABLE :: src_mask3d(:,:,:), snk_mask3d(:,:,:)
    INTEGER, ALLOCATABLE :: mask(:,:)
 
-   REAL*8,  ALLOCATABLE :: MMR_to_VMR(:,:,:)
-   REAL*8,  ALLOCATABLE :: VMR_to_MMR(:,:,:)
+   REAL*8,  ALLOCATABLE :: MMR_to_VMR(:,:,:)  ! both wrt MOIST
+   REAL*8,  ALLOCATABLE :: VMR_to_MMR(:,:,:)  ! both wrt MOIST
+   REAL*8,  ALLOCATABLE :: MMR_to_VVV(:,:,:)  ! mass mixing ratio wrt moist -> volume mixing ratio wrt dry
+   REAL*8,  ALLOCATABLE :: VVV_to_MMR(:,:,:)  ! volume mixing ratio wrt dry -> mass mixing ratio wrt moist
    REAL*8,  PARAMETER   :: one = 1.0d0
 
    ! CORBE 07/18/16   
@@ -3426,8 +3432,8 @@ CONTAINS
    REAL*8,         ALLOCATABLE ::            sum_term(:,:,:)
    REAL*8,         ALLOCATABLE ::            dep_term(:,:)
 
-!  For DKtend_ diagnostic
-   REAL                        :: mwt             ! molecular weight
+!  For units conversion
+   REAL                        :: spec_mwt             ! molecular weight
 
 !  For tendency computation
    REAL,           ALLOCATABLE ::        tend_scratch(:,:,:)
@@ -3499,7 +3505,6 @@ CONTAINS
 
    IF(debug_verbose) PRINT *,myname, pet, "DEBUG done setup"
 
-
 !  Get regions mask if needed
    IF ( spec%regions_ExtData_entry == NULL_REGION_MASK ) THEN
      spec%regions_array    => NULL()
@@ -3507,12 +3512,33 @@ CONTAINS
      call MAPL_GetPointer( impChem, spec%regions_array, TRIM(spec%regions_ExtData_entry), __RC__ ) 
    END IF
 
+   ! We do not require mw for tracers like e90
+   ! Check for default value (-1)
+   spec_mwt = spec%mw
+   IF ( spec_mwt < 0.0 ) spec_mwt = MAPL_AIRMW
+
 !! For conversion between mass mixing ratio and volume mixing ratio
    call MAPL_GetPointer( impChem,      Q,            'Q', __RC__ )
    ALLOCATE( MMR_to_VMR( i1:i2, j1:j2, 1:km),         &
              VMR_to_MMR( i1:i2, j1:j2, 1:km), __STAT__)
-   MMR_to_VMR = (one/spec%mw) / ( (one/MAPL_AIRMW)*(one-Q) + (one/MAPL_H2OMW)*Q )
-   VMR_to_MMR = (    spec%mw) * ( (one/MAPL_AIRMW)*(one-Q) + (one/MAPL_H2OMW)*Q )
+   MMR_to_VMR = (one/spec_mwt) / ( (one/MAPL_AIRMW)*(one-Q) + (one/MAPL_H2OMW)*Q )
+   VMR_to_MMR = (    spec_mwt) * ( (one/MAPL_AIRMW)*(one-Q) + (one/MAPL_H2OMW)*Q )
+
+   ! VVV = VMR wrt dry air
+   ALLOCATE( MMR_to_VVV( i1:i2, j1:j2, 1:km),         &
+             VVV_to_MMR( i1:i2, j1:j2, 1:km), __STAT__)
+   MMR_to_VVV = (MAPL_AIRMW/spec_mwt) / (one-Q)
+   VVV_to_MMR = (spec_mwt/MAPL_AIRMW) * (one-Q)
+
+
+! ! initialize test cases to 1 ppm
+! IF ( TRIM(spec%name) == 'test_vmr' ) THEN
+!   DATA3d(:,:,:) = 1.0e-6 * VVV_to_MMR * MMR_to_VMR
+! ENDIF
+! IF ( TRIM(spec%name) == 'test_mmr' ) THEN
+!   DATA3d(:,:,:) = 1.0e-6 * VVV_to_MMR
+! ENDIF
+
 
 !! These may be needed; should we only get pointers under certain conditions (like GOCART wet dep)?
    call MAPL_GetPointer( impChem, rhoWet, 'AIRDENS',      __RC__ )
@@ -3811,21 +3837,14 @@ CONTAINS
 
            IF ( associated(pr_export_3d) ) THEN        !  convert to kg_species / m2 / s
 
+             ! delp/MAPL_GRAV  [kg/m2]
+
              IF ( spec%unit_type == VMR_UNITS ) THEN
-               ! Same units conversion as EM_ when file3d
-
-               ! We do not require mw for tracers like e90
-               ! Check for default value (-1)
-               mwt = spec%mw
-               IF ( mwt < 0.0 ) mwt = MAPL_AIRMW
-
-               pr_export_3d = ((DATA3d - tend_scratch) * (1-Q)*delp/MAPL_GRAV  * mwt / MAPL_AIRMW) / cdt
-
+               pr_export_3d = (DATA3d - tend_scratch) * VMR_to_MMR * delp/(MAPL_GRAV*cdt)
              END IF
 
              IF ( spec%unit_type == MMR_UNITS ) THEN
-
-               pr_export_3d = ((DATA3d - tend_scratch) *       delp/MAPL_GRAV                    ) / cdt
+               pr_export_3d = (DATA3d - tend_scratch) *              delp/(MAPL_GRAV*cdt)
              END IF
 
              DEALLOCATE(tend_scratch, __STAT__)
@@ -3890,6 +3909,8 @@ CONTAINS
          SRC_file2d: &
          IF ( TRIM(spec%src_mode) == "file2d" ) THEN
            IF(debug_verbose) PRINT *,myname, pet, "DEBUG src file2d start"
+
+           ! SRC_2d_  [kg m-2 s-1]
 
            call MAPL_GetPointer( impChem, src_ext_2d, 'SRC_2D_'//TRIM(spec%name), __RC__ ) 
 
@@ -3956,6 +3977,7 @@ CONTAINS
          IF ( TRIM(spec%src_mode) == "file3d" ) THEN
            IF(debug_verbose) PRINT *,myname, pet, "DEBUG src file3d start"
 
+           ! SRC_3D_  [mol/mol/s]
            call MAPL_GetPointer( impChem, src_ext_3d, 'SRC_3D_'//TRIM(spec%name), __RC__ ) 
 
            spec%TRvolFlux = src_ext_3d
@@ -3979,7 +4001,8 @@ CONTAINS
 
 !            WHERE( src_mask3d ) em_export_3d = cdt * spec%TRvolFlux * (1-Q)*airdens*dZ     * spec%mw / MAPL_AIRMW
 
-             WHERE( src_mask3d ) em_export_3d = cdt * spec%TRvolFlux * (1-Q)*delp/MAPL_GRAV * spec%mw / MAPL_AIRMW
+             ! 5.14.20 MEM - corrected the units from kg/m2 to  kg/m2/s
+             WHERE( src_mask3d ) em_export_3d = spec%TRvolFlux * VVV_to_MMR * delp/MAPL_GRAV
 
            ENDIF
 
@@ -4000,8 +4023,11 @@ CONTAINS
              !      rhoWet [kg_moist_air/m3]
              !   TRvolFlux [mol_tracer/mol_dry_air/s -> kg_tracer/kg_moist_air/s]
 
+            !spec%TRvolFlux = &
+            !spec%TRvolFlux * ndDry * spec%mw / (MAPL_AVOGAD*rhoWet)
+
              spec%TRvolFlux = &
-             spec%TRvolFlux * ndDry * spec%mw / (MAPL_AVOGAD*rhoWet)
+             spec%TRvolFlux * VVV_to_MMR
 
            END IF
 
@@ -4009,8 +4035,11 @@ CONTAINS
 
              !! We convert to mol/mol/s (wrt moist)  (note from 4/3/19)
              !   TRvolFlux [mol_tracer/mol_dry_air/s -> mol_tracer/mol_moist_air/s]
+            !spec%TRvolFlux = &
+            !spec%TRvolFlux * (one-Q) / ( (one-Q) + (MAPL_AIRMW/MAPL_H2OMW)*Q )
+
              spec%TRvolFlux = &
-             spec%TRvolFlux * (one-Q) / ( (one-Q) + (MAPL_AIRMW/MAPL_H2OMW)*Q )
+             spec%TRvolFlux * VVV_to_MMR * MMR_to_VMR
 
            END IF
 
@@ -4175,20 +4204,11 @@ CONTAINS
              call MAPL_GetPointer ( impChem,    delp,    'DELP', __RC__ )
 
              IF ( spec%unit_type == VMR_UNITS ) THEN
-               ! Same units conversion as EM_ when file3d
-
-               ! We do not require mw for tracers like e90
-               ! Check for default value (-1)
-               mwt = spec%mw
-               IF ( mwt < 0.0 ) mwt = MAPL_AIRMW
-
-               WHERE( snk_mask3d ) dk_export_3d = ((DATA3d * (decadence - 1.0)) * &
-                                   (1-Q)*delp/MAPL_GRAV  * mwt / MAPL_AIRMW) / cdt
+               WHERE( snk_mask3d ) dk_export_3d = (DATA3d * (decadence - 1.0)) * VMR_to_MMR * delp / (MAPL_GRAV*cdt)
              END IF
 
              IF ( spec%unit_type == MMR_UNITS ) THEN
-               WHERE( snk_mask3d ) dk_export_3d = ((DATA3d * (decadence - 1.0)) * &
-                                   delp/MAPL_GRAV ) / cdt
+               WHERE( snk_mask3d ) dk_export_3d = (DATA3d * (decadence - 1.0)) *              delp / (MAPL_GRAV*cdt)
              END IF
 
            ENDIF
@@ -4284,21 +4304,24 @@ CONTAINS
 
          IF ( (spec%unit_type == MMR_UNITS) .AND.  &
               (spec%GMI_dry_deposition .OR. spec%GMI_wet_removal) ) THEN
+           ! Convert to VMR for the GMI calls
            DATA3d = DATA3d * MMR_to_VMR
          END IF
 
-         IF ( spec%GMI_dry_deposition )    CALL  TR_GMI_settle_and_depos( DATA3d, st_export_3d, st_export_2d, dd_export_2d, impChem, nymd, nhms, kit, cdt, spec)
+         IF ( spec%GMI_dry_deposition )    CALL  TR_GMI_settle_and_depos( DATA3d, st_export_3d, st_export_2d, dd_export_2d, impChem, nymd, nhms, kit, cdt, spec, VMR_to_MMR)
 
-         IF ( spec%GMI_wet_removal    )    CALL  TR_GMI_wet_removal(      DATA3d, wr_export_3d, wr_export_2d,               impChem,             kit, cdt, spec)
+         IF ( spec%GMI_wet_removal    )    CALL  TR_GMI_wet_removal(      DATA3d, wr_export_3d, wr_export_2d,               impChem,             kit, cdt, spec, VMR_to_MMR)
 
          IF ( (spec%unit_type == MMR_UNITS) .AND.  &
               (spec%GMI_dry_deposition .OR. spec%GMI_wet_removal) ) THEN
+           ! Convert back to MMR
            DATA3d = DATA3d * VMR_to_MMR
          END IF
 
 
          IF ( (spec%unit_type == VMR_UNITS) .AND.  &
               (spec%GOCART_settling .OR. spec%GOCART_dry_deposition .OR. spec%GOCART_wet_removal .OR. spec%GOCART_convection) ) THEN
+           ! Convert to MMR for the GOCART calls
            DATA3d = DATA3d * VMR_to_MMR
          END IF
 
@@ -4312,6 +4335,7 @@ CONTAINS
 
          IF ( (spec%unit_type == VMR_UNITS) .AND.  &
               (spec%GOCART_settling .OR. spec%GOCART_dry_deposition .OR. spec%GOCART_wet_removal .OR. spec%GOCART_convection) ) THEN
+           ! Convert back to VMR
            DATA3d = DATA3d * MMR_to_VMR
          END IF
 
@@ -4340,6 +4364,8 @@ CONTAINS
 
      DEALLOCATE(src_mask3d, snk_mask3d, __STAT__)
      DEALLOCATE(    ndDry, __STAT__)
+     DEALLOCATE(MMR_to_VMR, VMR_to_MMR, __STAT__)
+     DEALLOCATE(MMR_to_VVV, VVV_to_MMR, __STAT__)
 !    DEALLOCATE(  massTOT, __STAT__)
      DEALLOCATE( snapshot, __STAT__)
 
@@ -4459,10 +4485,10 @@ CONTAINS
   END SUBROUTINE impose_surface_constraints
 
 
-  SUBROUTINE TR_GMI_settle_and_depos(data3d, settle_tend_3d, settle_tend_2d, drydep_tend_2d, impChem, nymd, nhms, kit, cdt, spec)
+  SUBROUTINE TR_GMI_settle_and_depos(data3d, settle_tend_3d, settle_tend_2d, drydep_tend_2d, impChem, nymd, nhms, kit, cdt, spec, VMR_to_MMR)
     IMPLICIT NONE
 
-    REAL*4,  POINTER, DIMENSION(:,:,:), INTENT(INOUT)    :: data3d
+    REAL*4,  POINTER, DIMENSION(:,:,:), INTENT(INOUT)    :: data3d         ! MEM- presumed mol/mol_of_moist_air
     REAL*4,  POINTER, DIMENSION(:,:,:), INTENT(INOUT)    :: settle_tend_3d ! kg/m2/s
     REAL*4,  POINTER, DIMENSION(:,:),   INTENT(INOUT)    :: settle_tend_2d ! kg/m2/s   column total
     REAL*4,  POINTER, DIMENSION(:,:),   INTENT(INOUT)    :: drydep_tend_2d ! kg/m2/s
@@ -4471,6 +4497,7 @@ CONTAINS
     TYPE(TR_TracerKit),     POINTER,    INTENT(IN)       :: kit            ! A set of values common to all passive tracers
     REAL,                               INTENT(IN)       :: cdt            ! chemical timestep (secs)
     TYPE(TR_TracerSpec),                INTENT(IN)       :: spec           ! Specification for a Passive Tracer
+    REAL*8,           DIMENSION(:,:,:), INTENT(IN)       :: VMR_to_MMR     ! both wrt moist air
 
     integer                      :: STATUS
     CHARACTER(LEN=*), PARAMETER  :: Iam = 'TR_GMI_settle_and_depos'
@@ -4566,19 +4593,17 @@ CONTAINS
 
     IF ( associated(settle_tend_3d) ) then
       DO lev=1,kit%km
-        ! convert units the same way as done in TR_GMI_DryDeposition
-        settle_tend_3d(:,:,lev) = (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * &
-                                  (mass(:,:,lev) / area) * spec%mw / (MAPL_AIRMW*cdt)
+        settle_tend_3d(:,:,lev) = (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * VMR_to_MMR(:,:,lev) * &
+                                     mass(:,:,lev) / (area*cdt)
       END DO
     END IF
 
     IF ( associated(settle_tend_2d) ) then
       settle_tend_2d(:,:) = 0.0
       DO lev=1,kit%km
-        ! convert units the same way as done in TR_GMI_DryDeposition
         settle_tend_2d(:,:) =                                            &
-        settle_tend_2d(:,:) + (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * &
-                              (mass(:,:,lev) / area) * spec%mw / (MAPL_AIRMW*cdt)
+        settle_tend_2d(:,:) +     (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * VMR_to_MMR(:,:,lev) * &
+                                     mass(:,:,lev) / (area*cdt)
       END DO
     END IF
 
@@ -4638,9 +4663,10 @@ CONTAINS
              spec%mw, one_species = data3d(:,:,kit%km) )
 
    IF ( associated(drydep_tend_2d) ) then
-     ! convert units the same way as done in TR_GMI_DryDeposition
-     drydep_tend_2d = (data3d(:,:,kit%km) - snapshot_2d) *              &
-                      (mass(:,:,kit%km) / area) * spec%mw / (MAPL_AIRMW*cdt)
+     ! Previously we converted units the same way as done in TR_GMI_DryDeposition
+     ! Now we use the conversion array provided by the caller
+     drydep_tend_2d = (data3d(:,:,kit%km) - snapshot_2d) * VMR_to_MMR(:,:,kit%km) * &
+                         mass(:,:,kit%km) / (area*cdt)
      deallocate( snapshot_2d, __STAT__)
    END IF
 
@@ -4803,16 +4829,17 @@ CONTAINS
   END SUBROUTINE set_bool_mask
 
 
-  SUBROUTINE TR_GMI_wet_removal(data3d, wr_tend_3d, wr_tend_2d, impChem, kit, cdt, spec)
+  SUBROUTINE TR_GMI_wet_removal(data3d, wr_tend_3d, wr_tend_2d, impChem, kit, cdt, spec, VMR_to_MMR)
     IMPLICIT NONE
 
-    REAL*4,  POINTER, DIMENSION(:,:,:), INTENT(INOUT)    :: data3d
+    REAL*4,  POINTER, DIMENSION(:,:,:), INTENT(INOUT)    :: data3d     ! MEM- presumed mol/mol_of_moist_air
     REAL*4,  POINTER, DIMENSION(:,:,:), INTENT(INOUT)    :: wr_tend_3d ! tendency kg/m2/s
     REAL*4,  POINTER, DIMENSION(:,:),   INTENT(INOUT)    :: wr_tend_2d ! column-sum of tendency kg/m2/s
     TYPE(ESMF_State),                   INTENT(INOUT)    :: impChem    ! Import State
     TYPE(TR_TracerKit),     POINTER,    INTENT(IN)       :: kit        ! A set of values common to all passive tracers
     REAL,                               INTENT(IN)       :: cdt        ! chemical timestep (secs)
     TYPE(TR_TracerSpec),                INTENT(IN)       :: spec       ! Specification for a Passive Tracer
+    REAL*8,           DIMENSION(:,:,:), INTENT(IN)       :: VMR_to_MMR ! both wrt moist air
 
     integer                      :: STATUS
     CHARACTER(LEN=*), PARAMETER  :: Iam = 'TR_GMI_wet_removal'
@@ -4857,6 +4884,11 @@ CONTAINS
     ! odds and ends
     INTEGER  :: lev
 
+!   INTEGER         ::  iXj
+!   REAL            ::  qmin, qmax
+!
+!   iXj   = ( kit%i2 - kit%i1 + 1 ) * ( kit%j2 - kit%j1 + 1 )
+
     ! some var names as found in GmiDepos_GridCompClassMod.F90
 
     CALL MAPL_GetPointer( impChem,   airdens,   'AIRDENS', __RC__ )
@@ -4867,6 +4899,19 @@ CONTAINS
     CALL MAPL_GetPointer( impChem,      dqdt,      'DQDT', __RC__ )
     CALL MAPL_GetPointer( impChem,  pfl_lsan,  'PFL_LSAN', __RC__ )
     CALL MAPL_GetPointer( impChem,    pfl_cn,    'PFL_CN', __RC__ )
+
+!   CALL pmaxmin ( 'TR minmax area:', area, qmin, qmax, iXj,1, 1. )
+!
+!   CALL pmaxmin ( 'TR minmax AIRDENS:', AIRDENS, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax zle:', zle, qmin, qmax, iXj, kit%km+1, 1. )
+!   CALL pmaxmin ( 'TR minmax T:', T, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax ple:', ple, qmin, qmax, iXj, kit%km+1, 1. )
+!   CALL pmaxmin ( 'TR minmax dqdt:', dqdt, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax pfl_lsan:', pfl_lsan, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax pfl_cn:', pfl_cn, qmin, qmax, iXj, kit%km, 1. )
+!
+!   CALL pmaxmin ( 'TR minmax data3d:', data3d, qmin, qmax, iXj, kit%km, 1. )
+
 
       geoht(:,:,1:kit%km) =  zle(:,:, 0:kit%km-1 ) - zle(:,:,  1:kit%km  )
     press3c(:,:,1:kit%km) = (ple(:,:, 0:kit%km-1 ) + ple(:,:,  1:kit%km  ))/2.0   ! convert units below
@@ -4886,6 +4931,16 @@ CONTAINS
 !   Layer edges                                                   GEOS-5 Units       GMI Units
 !   -----------                                                   ------------       -------------
     press3e = ple*Pa2hPa                                          ! Pa               hPa
+
+
+!   CALL pmaxmin ( 'TR minmax mass:', mass, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax geoht:', geoht, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax press3c:', press3c, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax moistq:', moistq, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax rain3Dls:', rain3Dls, qmin, qmax, iXj, kit%km, 1. )
+!   CALL pmaxmin ( 'TR minmax rain3Dcn:', rain3Dcn, qmin, qmax, iXj, kit%km, 1. )
+!
+!   CALL pmaxmin ( 'TR minmax press3e:', press3e, qmin, qmax, iXj, kit%km+1, 1. )
 
 
 !     ------------------------------------------------------------------------
@@ -4912,19 +4967,17 @@ CONTAINS
     IF ( associated(wr_tend_3d) .OR. associated(wr_tend_2d) ) then
       IF ( associated(wr_tend_3d) ) then
         DO lev=1,kit%km
-          ! convert units the same way as done in TR_GMI_DryDeposition
-          wr_tend_3d(:,:,lev) = (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * &
-                                (mass(:,:,lev) / area) * spec%mw / (MAPL_AIRMW*cdt)
+          wr_tend_3d(:,:,lev) = (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * VMR_to_MMR(:,:,lev) * &
+                                   mass(:,:,lev) / (area*cdt)
         END DO
+!       CALL pmaxmin ( 'TR minmax wr_tend_3d:', wr_tend_3d, qmin, qmax, iXj, kit%km, 1. )
       END IF
       IF ( associated(wr_tend_2d) ) then
-        lev=1
-          wr_tend_2d(:,:)     = (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * &
-                                (mass(:,:,lev) / area) * spec%mw / (MAPL_AIRMW*cdt)
-        DO lev=2,kit%km
+          wr_tend_2d(:,:)     = 0.0
+        DO lev=1,kit%km
           wr_tend_2d(:,:)     = &
-          wr_tend_2d(:,:)     + (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * &
-                                (mass(:,:,lev) / area) * spec%mw / (MAPL_AIRMW*cdt)
+          wr_tend_2d(:,:)     + (data3d(:,:,lev) - snapshot_3d(:,:,lev)) * VMR_to_MMR(:,:,lev) * &
+                                   mass(:,:,lev) / (area*cdt)
         END DO
       END IF
       deallocate( snapshot_3d, __STAT__)
@@ -5025,11 +5078,11 @@ CONTAINS
       call MAPL_GetPointer ( impChem, delp,     'DELP',     __RC__ )
 
       if ( associated(tendency3d) ) then
-        tendency3d = (data3d-snapshot) * delp/MAPL_GRAV/cdt
+        tendency3d =     (data3d-snapshot) * delp / (MAPL_GRAV*cdt)
       end if 
 
       if ( associated(tendency2d) ) then
-        tendency2d = SUM((data3d-snapshot) * delp/MAPL_GRAV/cdt, 3)
+        tendency2d = SUM((data3d-snapshot) * delp / (MAPL_GRAV*cdt), 3)
       end if 
 
       deallocate( snapshot, __STAT__)
@@ -5173,7 +5226,7 @@ CONTAINS
     data3d(:,:,km:1:-1) = tc_(:,:,1:km,1)
 
     if ( associated(tendency3d) ) then
-      tendency3d = (data3d-snapshot) * delp/MAPL_GRAV/cdt
+      tendency3d = (data3d-snapshot) * delp / (MAPL_GRAV*cdt)
       deallocate( snapshot, __STAT__)
     end if
 
@@ -5277,11 +5330,11 @@ CONTAINS
     if ( associated(tendency3d) .OR.  associated(tendency2d) ) then
 
       if ( associated(tendency3d) ) then
-        tendency3d = (data3d-snapshot) * w_c%delp/MAPL_GRAV/cdt
+        tendency3d =     (data3d-snapshot) * w_c%delp / (MAPL_GRAV*cdt)
       end if
 
       if ( associated(tendency2d) ) then
-        tendency2d = SUM((data3d-snapshot) * w_c%delp/MAPL_GRAV/cdt, 3)
+        tendency2d = SUM((data3d-snapshot) * w_c%delp / (MAPL_GRAV*cdt), 3)
       end if
 
       deallocate( snapshot, __STAT__)
@@ -5361,7 +5414,7 @@ CONTAINS
     data3d(:,:,km) - dqa
 
     IF ( ASSOCIATED(tendency2d) ) &
-     tendency2d = -1.0 * dqa*delp(:,:,km)/MAPL_GRAV/cdt
+     tendency2d = -1.0 * dqa*delp(:,:,km) / (MAPL_GRAV*cdt)
 
     deallocate( dqa, drydepositionfrequency, __STAT__)
 


### PR DESCRIPTION
* replaced rcEsmfReadLogical with ESMF_ConfigGetAttribute in GMI and Chem GridComp; this allows GMI stubbing, addressing part of issue #79 
* photolysis in GMI no longer reports spurious FAIL messages
* new GMI boundary condition file (2018)
* fixed memory leak in TR
* 3D emissions diagnostic in TR is now kg/m2/s (matching the metadata) instead of kg/m2
* several TR diagnostics now account for moist air
NOTE: TR species in the standard setup are zero-diff