### PR TITLE
Use MAPL not MAPL_Base for f2py

### DIFF
--- a/Shared/Chem_Base/CMakeLists.txt
+++ b/Shared/Chem_Base/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories (${esma_include}/${this})
 if (F2PY_FOUND)
    add_f2py_module(MieObs_ SOURCES MieObs_py.F90 
       DESTINATION lib/Python
-      LIBRARIES Chem_Base MAPL_Base GMAO_mpeu ${NETCDF_LIBRARIES} ${ESMF_LIBRARY}
+      LIBRARIES Chem_Base MAPL GMAO_mpeu ${NETCDF_LIBRARIES} ${ESMF_LIBRARY}
       INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
       USE_MPI
       )


### PR DESCRIPTION
A simple change of a missed `MAPL_Base` that should have been `MAPL`. Testing with MAPL development discovered this.