### PR TITLE
Use Ubuntu20 GCC10 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,8 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: gmao/geos-build-env-gcc-source:6.0.13-openmpi_4.0.3-gcc_9.3.0
+      - image: gmao/ubuntu20-geos-env-mkl:6.0.13-openmpi_4.0.4-gcc_10.2.0
     resource_class: xlarge
-    working_directory: /root/project
     steps:
       - run:
           name: "GEOSchem_GridComp branch"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
       - image: gmao/ubuntu20-geos-env-mkl:6.0.13-openmpi_4.0.4-gcc_10.2.0
     resource_class: xlarge
+    working_directory: /root/project
     steps:
       - run:
           name: "GEOSchem_GridComp branch"


### PR DESCRIPTION
As GNU's default compiler is version 10, the CI should use that.

Plus, the image is slightly smaller so the CI test might be, oh, 1 minute faster?