### PR TITLE
CMake edit from the GEOSadas development

### DIFF
--- a/GMIchem_GridComp/CMakeLists.txt
+++ b/GMIchem_GridComp/CMakeLists.txt
@@ -93,7 +93,7 @@ set (mechanism ${gmi_gc}/GmiChemistry/stratTropMech/setkin_lchem.h)
 set (deposParam ${gmi_gc}/GmiChemistry/stratTropMech/setkin_depos.h)
 set (mechParam ${gmi_gc}/GmiChemistry/stratTropMech/setkin_par.h)
 set (mechRC ${gmi_gc}/GmiChemistry/stratTropMech/setkin_chem_mech.txt)
-set (first_stage_files Deposition_Registry___.rc Reactions_Registry___.rc GMI_Tendency_Registry___.rc setkin_chem_mech.txt___.rc)
+set (first_stage_files Deposition_Registry___.rc Reactions_Registry___.rc GMI_Tendency_Registry___.rc setkin_chem_mech.txt___.rc GMICHEM_History___.rc)
 
 find_file (generator
   NAME mapl_acg.pl
@@ -127,6 +127,7 @@ add_custom_command (
 
   COMMAND ${generator} ${acg_flags} -N ${name} ${gmi_gc}/GMI_Registry.rc
   COMMAND ${CMAKE_COMMAND} -E copy ${name}_DeclarePointer___.h GMI_GridComp/Tendency_DeclarePointer___.h
+  COMMAND ${CMAKE_COMMAND} -E copy ${name}_History___.rc GMI_GridComp/${name}_History___.rc
 
   MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/gmi_acg.pl
   DEPENDS ${registry} ${mechanism} ${deposParam} ${mechParam} ${mechRC}


### PR DESCRIPTION
This is a fix from @bena-nasa found during our GEOSadas-to-Git work. Essentially some script in GEOSadas seems to expect the `GMIchem_HISTORY___.rc` file even though nothing will ever use it. This update just copies that file. I guess?