### PR TITLE
Added overpass diagnostics, and fixed DT issue w/ H2O_TEND from GMI

### DIFF
--- a/GEOS_ChemEnvGridComp.F90
+++ b/GEOS_ChemEnvGridComp.F90
@@ -508,7 +508,7 @@ contains
 
 !!!! >>>>>>>>>>>>>>>>  OVP
 
-    IF ( ovp_setup_done == .FALSE. ) THEN
+    IF ( ovp_setup_done .eqv. .FALSE. ) THEN
 
 !     Set up Overpass Masks
 !     --------------------

--- a/GMIchem_GridComp/GMI_GridComp/GmiChemistry/GmiThermalRateConstants_mod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChemistry/GmiThermalRateConstants_mod.F90
@@ -88,9 +88,12 @@
                              ! current year/month/day (YYYYMMDD)
       integer, intent(in) :: nymd
       integer, intent(in) :: phot_opt
-                             ! mapping of reaction rate adjustment number to 
+
+                             ! mapping of reaction rate adjustment number to
                              ! reaction rate number
-      integer, intent(in) :: rxnr_adjust_map(num_rxnr_adjust)
+!     integer, intent(in) :: rxnr_adjust_map(num_rxnr_adjust)
+      INTEGER, POINTER, intent(in)    :: rxnr_adjust_map(:)
+
       integer, intent(in) :: conPBLFlag(i1:i2,   ju1:j2,   k1:k2)
                              ! atmospheric pressure at the center of each grid 
                              ! box (mb)

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -1775,6 +1775,18 @@ CONTAINS
  !! AIRMASS
     CALL MAPL_GetPointer(expChem, EM_pointer, "AIRMASS", __RC__)
     IF(ASSOCIATED(EM_pointer))   EM_pointer(i1:i2, j1:j2, 1:km) = AIRDENS(i1:i2, j1:j2, 1:km) * gridBoxThickness(i1:i2, j1:j2, km:1:-1)
+
+!!!! >>>>>>>>>>>>>>>>  OVP
+    IF(ASSOCIATED(EM_pointer)) THEN
+       DATA_FOR_OVP_3D => EM_pointer
+
+       CALL MAPL_GetPointer(expChem, OVP10_OUTPUT_3D, 'OVP10_AIRMASS', __RC__)
+       CALL MAPL_GetPointer(expChem, OVP14_OUTPUT_3D, 'OVP14_AIRMASS', __RC__)
+
+       CALL OVP_apply_mask( DATA_FOR_OVP_3D, OVP10_OUTPUT_3D, MASK_10AM, OVP_FIRST_HMS, CURRENT_HMS, K_EDGES=.FALSE., __RC__ )
+       CALL OVP_apply_mask( DATA_FOR_OVP_3D, OVP14_OUTPUT_3D, MASK_2PM,  OVP_FIRST_HMS, CURRENT_HMS, K_EDGES=.FALSE., __RC__ )
+    END IF
+!!!! <<<<<<<<<<<<<<<<  OVP
 !!!!!
 
 

--- a/GMIchem_GridComp/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridComp/GMIchem_GridCompMod.F90
@@ -907,6 +907,27 @@ CONTAINS
                                                        RC=STATUS  )
     VERIFY_(STATUS)
 
+! Overpass fields for AIRMASS  (set in GmiEmiss_GridCompClassMod.F90)
+! ----------------------------
+
+    CALL MAPL_AddExportSpec(GC,                                         &
+        SHORT_NAME         = 'OVP10_AIRMASS',                           &
+        LONG_NAME          = 'mass_of_air_in_layer_10am_local',         &
+        UNITS              = 'kg m-2',                                  &
+        DIMS               = MAPL_DimsHorzVert,                         &
+        VLOCATION          = MAPL_VLocationCenter,                      &
+                                                       RC=STATUS  )
+    VERIFY_(STATUS)
+
+    CALL MAPL_AddExportSpec(GC,                                         &
+        SHORT_NAME         = 'OVP14_AIRMASS',                           &
+        LONG_NAME          = 'mass_of_air_in_layer_2pm_local',          &
+        UNITS              = 'kg m-2',                                  &
+        DIMS               = MAPL_DimsHorzVert,                         &
+        VLOCATION          = MAPL_VLocationCenter,                      &
+                                                       RC=STATUS  )
+    VERIFY_(STATUS)
+
 #include "GMICHEM_ExportSpec___.h"
 #include "Deposition_ExportSpec___.h"
 #include "Reactions_ExportSpec___.h"
@@ -1670,6 +1691,8 @@ CONTAINS
    CALL extract_(GC, clock, chemReg, gcGMI, w_c, nymd, nhms, gmiDt, runDt, STATUS)
    VERIFY_(STATUS)
 
+  dtInverse = 1.00/runDt
+
 !  Layer interface pressures
 !  -------------------------
    CALL MAPL_GetPointer(impChem, PLE, 'PLE', __RC__)
@@ -2259,7 +2282,6 @@ CONTAINS
     k = 1
     m = ChemReg%i_GMI
     n = ChemReg%j_GMI
-    dtInverse = 1.00/runDt
 
     DO i = m,n
 

--- a/GOCART_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/CMakeLists.txt
@@ -16,6 +16,7 @@ set (alldirs
   BRC_GridComp
   )
 
+
 set (srcs
   GOCART_GridCompMod.F90
   Aero_GridCompMod.F90
@@ -30,10 +31,9 @@ install( FILES ${resource_files}
    DESTINATION etc
    )
 
-set (dependencies Chem_Base Chem_Shared MAPL GMAO_mpeu)
+set (dependencies Chem_Base Chem_Shared MAPL GMAO_mpeu GEOS_Shared)
 esma_add_library (${this}
   SRCS ${srcs}
   SUBCOMPONENTS ${alldirs}
   DEPENDENCIES ${dependencies}
-  INCLUDES ${INC_ESMF})
-
+  INCLUDES ${INC_ESMF} )

--- a/GOCART_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/CMakeLists.txt
@@ -16,7 +16,6 @@ set (alldirs
   BRC_GridComp
   )
 
-
 set (srcs
   GOCART_GridCompMod.F90
   Aero_GridCompMod.F90
@@ -31,9 +30,10 @@ install( FILES ${resource_files}
    DESTINATION etc
    )
 
-set (dependencies Chem_Base Chem_Shared MAPL GMAO_mpeu GEOS_Shared)
+set (dependencies Chem_Base Chem_Shared MAPL GMAO_mpeu)
 esma_add_library (${this}
   SRCS ${srcs}
   SUBCOMPONENTS ${alldirs}
   DEPENDENCIES ${dependencies}
-  INCLUDES ${INC_ESMF} )
+  INCLUDES ${INC_ESMF})
+


### PR DESCRIPTION
Zero diff for PCHEM. Added changes that went into the CCM benchmark **bench_10-14-1_gmi_free_c180_72lev**,
primarily OVP diagnostics and a small bug in a GMI diagnostic (H2O_TEND).   Edits only made in GMI and ChemEnv files.