### PR TITLE
Use CONFIGURE_DEPENDS with GLOB

### DIFF
--- a/CARMAchem_GridComp/CMakeLists.txt
+++ b/CARMAchem_GridComp/CMakeLists.txt
@@ -8,7 +8,7 @@ set (src_directories
 
 set (srcs)
 foreach (dir ${src_directories})
-  file (GLOB tmpsrcs ${dir}/*.[fF] ${dir}/*.[fF]90 ${dir}/*.c)
+  file (GLOB tmpsrcs CONFIGURE_DEPENDS ${dir}/*.[fF] ${dir}/*.[fF]90 ${dir}/*.c)
   list (APPEND srcs ${tmpsrcs})
 endforeach()
 

--- a/GAAS_GridComp/CMakeLists.txt
+++ b/GAAS_GridComp/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories (${this} PUBLIC ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} -F)
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GEOSCHEMchem_GridComp/CMakeLists.txt
+++ b/GEOSCHEMchem_GridComp/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR}/gc_column/Headers)
 
 set (srcs)
 foreach (dir ${src_directories})
-  file (GLOB tmpsrcs ${dir}/*.[fF] ${dir}/*.[fF]90 ${dir}/*.c)
+  file (GLOB tmpsrcs CONFIGURE_DEPENDS ${dir}/*.[fF] ${dir}/*.[fF]90 ${dir}/*.c)
   list (APPEND srcs ${tmpsrcs})
 endforeach()
 
@@ -100,7 +100,7 @@ new_esma_generate_automatic_code (
    "-v;-F"
    )
 
-file (GLOB resource_files "*.rc")
+file (GLOB resource_files CONFIGURE_DEPENDS "*.rc")
 
 install(
    FILES ${resource_files}

--- a/GMIchem_GridComp/CMakeLists.txt
+++ b/GMIchem_GridComp/CMakeLists.txt
@@ -38,7 +38,7 @@ set (src_directories
 
 set (srcs)
 foreach (dir ${src_directories})
-  file (GLOB tmpsrcs ${dir}/*.[fF] ${dir}/*.[fF]90 ${dir}/*.c)
+  file (GLOB tmpsrcs CONFIGURE_DEPENDS ${dir}/*.[fF] ${dir}/*.[fF]90 ${dir}/*.c)
   list (APPEND srcs ${tmpsrcs})
 endforeach()
 

--- a/GOCART_GridComp/BC_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/BC_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/BRC_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/BRC_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/CFC_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/CFC_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/CH4_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/CH4_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ esma_add_library (${this}
 target_include_directories (${this} PUBLIC ${INC_NETCDF})
 esma_generate_gocart_code (${this} "-B\;-E\;-F\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/CO2_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/CO2_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/CO_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/CO_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-F\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/DU_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/DU_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/NI_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/NI_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/O3_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/O3_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/OC_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/OC_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/Rn_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/Rn_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-F\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/SS_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/SS_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/GOCART_GridComp/SU_GridComp/CMakeLists.txt
+++ b/GOCART_GridComp/SU_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 esma_generate_gocart_code (${this} "-B\;-E\;-C\;-N\;GOCART")
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/HEMCO_GridComp/CMakeLists.txt
+++ b/HEMCO_GridComp/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_command (
 add_custom_target (phony_HEMCO DEPENDS ${acg_headers})
 add_dependencies (${this} phony_HEMCO)
 
-file (GLOB resource_files "*.rc")
+file (GLOB resource_files CONFIGURE_DEPENDS "*.rc")
 
 install(
    FILES ${resource_files}

--- a/MAMchem_GridComp/CMakeLists.txt
+++ b/MAMchem_GridComp/CMakeLists.txt
@@ -61,7 +61,7 @@ target_compile_definitions (${this} PRIVATE GEOS5 MODAL_AERO MODAL_AERO_7MODE GE
 
 esma_generate_gocart_code (${this} -F)
 
-file (GLOB resource_files "*.rc")
+file (GLOB resource_files CONFIGURE_DEPENDS "*.rc")
 
 set (mamscripts mam_optics_calculator.py mam_optics_calculator.csh)
 

--- a/MATRIXchem_GridComp/CMakeLists.txt
+++ b/MATRIXchem_GridComp/CMakeLists.txt
@@ -31,7 +31,7 @@ target_compile_definitions (${this} PRIVATE TRACERS_AMP TRACERS_AMP_M1 GEOS5_POR
 
 esma_generate_gocart_code (${this} -F)
 
-file (GLOB resource_files "*.rc")
+file (GLOB resource_files CONFIGURE_DEPENDS "*.rc")
 
 install(
    FILES ${resource_files}

--- a/Shared/Chem_Base/CMakeLists.txt
+++ b/Shared/Chem_Base/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach (exe Chem_Aod.x Chem_Aod3d.x ctl_crst.x Chem_BundleToG5rs.x reff_calcula
 endforeach ()
 
 # Copy RC files to build tree
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )

--- a/Shared/HEMCO/CMakeLists.txt
+++ b/Shared/HEMCO/CMakeLists.txt
@@ -10,7 +10,7 @@ set (src_directories
 
 set (srcs)
 foreach (dir ${src_directories})
-  file (GLOB tmpsrcs ${dir}/*.[fF] ${dir}/*.[fF]90 ${dir}/*.c)
+  file (GLOB tmpsrcs CONFIGURE_DEPENDS ${dir}/*.[fF] ${dir}/*.[fF]90 ${dir}/*.c)
   list (APPEND srcs ${tmpsrcs})
 endforeach()
 

--- a/TR_GridComp/CMakeLists.txt
+++ b/TR_GridComp/CMakeLists.txt
@@ -14,7 +14,7 @@ esma_add_library (${this}
 
 #esma_generate_gocart_code (${this} -F)
 
-file (GLOB_RECURSE rc_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
+file (GLOB_RECURSE rc_files CONFIGURE_DEPENDS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.rc)
 foreach ( file ${rc_files} )
    get_filename_component( dir ${file} DIRECTORY )
    install( FILES ${file} DESTINATION etc/${dir} )


### PR DESCRIPTION
When a `GLOB` is used in CMake, the CMake system doesn't check to see if files in the `GLOB` change when re-running `cmake`. Thus if someone adds/removes a file that the `GLOB` would pick up, say, CMake might not see there is a change and things go a bit pear-shaped. But there is [a `CONFIGURE_DEPENDS` flag](https://cmake.org/cmake/help/latest/command/file.html#glob):

> If the CONFIGURE_DEPENDS flag is specified, CMake will add logic to the main build system check target to rerun the flagged GLOB commands at build time. If any of the outputs change, CMake will regenerate the build system.

While CMake prefers no `GLOB` at all (as `CONFIGURE_DEPENDS` isn't supported for all generators), for now this is a possible partial solution until the CMake could be rewritten to explicitly list all files. 