### PR TITLE
Update bundleParser.py to be Python agnostic

### DIFF
--- a/Shared/Chem_Shared/bundleParser.py
+++ b/Shared/Chem_Shared/bundleParser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import re


### PR DESCRIPTION
As far as I can tell, `bundleParser.py` doesn't need to be explicitly `python2`. I tried running it with both Python 2 and 3 against `HISTORY.rc.tmpl` (renamed as `HISTORY.rc`) and both seemed to output the same change to `AGCM.rc`:
```
$ diff AGCM.rc ..
769,782d768
<
<
< # TRI increment tracers
< #-------------------------
< TRI_increments::
< PCHEM::OX
< ::
<
<
< # MTRI increment tracers
< #-------------------------
< MTRI_increments::
< PCHEM::OX
< ::
```

I'll leave it up to @gmao-esherman to be the ultimate arbiter of this, though.