### PR TITLE
Update CircleCI to use xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ executors:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMPI_MCA_btl_vader_single_copy_mechanism: none
-    #XLARGE# resource_class: xlarge
-    resource_class: medium
+    resource_class: xlarge
+    #MEDIUM# resource_class: medium
 
 workflows:
   version: 2.1
@@ -56,5 +56,5 @@ jobs:
           name: "Build"
           command: |
             cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm/build
-            #XLARGE# make -j"$(nproc)" install
-            make -j4 install
+            make -j"$(nproc)" install
+            #MEDIUM# make -j4 install


### PR DESCRIPTION
This PR updates the CircleCI to use the `xlarge` resource due to resumption of paid plan.