### PR TITLE
Made RI and RL imports conditional on running Cloud-J

### DIFF
--- a/GMIchem_GridComp/GMI_GridComp/GMI_Registry.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_Registry.rc
@@ -38,8 +38,6 @@
   TAUCLI 	     |  1              | xyz | C |    |   |   |     |      |    | optical_thickness_for_ice_clouds
   QL    	     |	kg kg-1	       | xyz | C |    |   |   |     |      |    | cloud_liquid_for_radiation
   QI    	     |	kg kg-1	       | xyz | C |    |   |   |     |      |    | cloud_ice_for_radiation
-  RI    	     |	m      	       | xyz | C |    |   |   |     |      |    | ice_phase_cloud_particle_effective_radius
-  RL    	     |	m      	       | xyz | C |    |   |   |     |      |    | liquid_cloud_particle_effective_radius
   CNV_MFC	     |	kg m-2 s-1     | xyz | E |    |   |   |     |      |    | cumulative_mass_flux
   CNV_MFD	     |	kg m-2 s-1     | xyz | C |    |   |   |     |      |    | detraining_mass_flux
   RH2   	     |	1              | xyz | C |    |   |   |     |      |    | relative_humidity_after_moist

--- a/GMIchem_GridComp/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
@@ -1208,7 +1208,8 @@ CONTAINS
    REAL, POINTER, DIMENSION(:,:,:) :: airdens, ple, Q, T, zle
    REAL, POINTER, DIMENSION(:,:,:) :: fcld, taucli, tauclw, ql, cnv_mfc
    REAL, POINTER, DIMENSION(:,:,:) :: qi
-   REAL, POINTER, DIMENSION(:,:,:) :: ri, rl
+   REAL, POINTER, DIMENSION(:,:,:) :: ri => NULL()
+   REAL, POINTER, DIMENSION(:,:,:) :: rl => NULL()
    REAL, POINTER, DIMENSION(:,:,:) :: rh2,dqdt
 
 !  Dust and aerosols.  May serve as imports from GOCART
@@ -2455,10 +2456,12 @@ CONTAINS
    VERIFY_(STATUS)
    CALL MAPL_GetPointer(impChem,        qi,      'QI', RC=STATUS)
    VERIFY_(STATUS)
-   CALL MAPL_GetPointer(impChem,        ri,      'RI', RC=STATUS)
-   VERIFY_(STATUS)
-   CALL MAPL_GetPointer(impChem,        rl,      'RL', RC=STATUS)
-   VERIFY_(STATUS)
+   IF ( self%fastj_opt == 5 ) THEN
+     CALL MAPL_GetPointer(impChem,        ri,      'RI', RC=STATUS)
+     VERIFY_(STATUS)
+     CALL MAPL_GetPointer(impChem,        rl,      'RL', RC=STATUS)
+     VERIFY_(STATUS)
+   END IF
 !  CALL MAPL_GetPointer(impChem,   cnv_frc, 'CNV_FRC', RC=STATUS)
 !  VERIFY_(STATUS)
 !  CALL MAPL_GetPointer(impChem,    frland,  'FRLAND', RC=STATUS)
@@ -2524,8 +2527,10 @@ CONTAINS
     CALL pmaxmin('RH2:', rh2, qmin, qmax, iXj, km, 1. )
     CALL pmaxmin('DQ/DT:', dqdt, qmin, qmax, iXj, km, 1. )
     CALL pmaxmin('QI:', qi, qmin, qmax, iXj, km, 1. )
+   IF ( self%fastj_opt == 5 ) THEN
     CALL pmaxmin('RI:', ri, qmin, qmax, iXj, km, 1. )
     CALL pmaxmin('RL:', rl, qmin, qmax, iXj, km, 1. )
+   ENDIF
 
     i = w_c%reg%j_XX
     CALL pmaxmin('TROPP:', w_c%qa(i)%data3d(:,:,km), qmin, qmax, iXj, 1, 0.01 )
@@ -2632,8 +2637,13 @@ CONTAINS
 !...parameters for CloudJ
        qi_(i1:i2,j1:j2,kReverse) =      qi(i1:i2,j1:j2,k)
        ql_(i1:i2,j1:j2,kReverse) =      ql(i1:i2,j1:j2,k)
+   IF ( self%fastj_opt == 5 ) THEN
        ri_(i1:i2,j1:j2,kReverse) =      ri(i1:i2,j1:j2,k)
        rl_(i1:i2,j1:j2,kReverse) =      rl(i1:i2,j1:j2,k)
+   ELSE
+       ri_ = 0.0
+       rl_ = 0.0
+   ENDIF
   END DO
 !...parameter for CloudJ
 ! cnv_frc_(i1:i2,j1:j2)          = cnv_frc(i1:i2,j1:j2)

--- a/GMIchem_GridComp/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridComp/GMIchem_GridCompMod.F90
@@ -136,6 +136,7 @@ CONTAINS
     CHARACTER(LEN=ESMF_MAXSTR) :: name
 
     LOGICAL :: do_ShipEmission
+    INTEGER :: fastj_opt
     TYPE(ESMF_Config)  :: gmiConfig
 
     ! HEMCO isoprene related -sas
@@ -291,6 +292,7 @@ CONTAINS
     END SELECT
 
 ! Import NO from Ships, only if using the parameterization
+! Import RI and RL, only if using Cloud-J
 
     gmiConfig = ESMF_ConfigCreate(__RC__)
 
@@ -308,6 +310,27 @@ CONTAINS
           UNITS      = 'kg NO m^(-2) s^(-1)',              &
           DIMS       = MAPL_DimsHorzOnly,                  &
           VLOCATION  = MAPL_VLocationNone,   __RC__) 
+    END IF
+
+    CALL ESMF_ConfigGetAttribute(gmiConfig, value= fastj_opt, Default=4, &
+                                            Label="fastj_opt:", __RC__)
+
+    ! We need RI and RL for Cloud-J
+    ! The fields may not be available in CTM, so we import them conditionally
+    IF ( fastj_opt == 5 ) THEN
+       call MAPL_AddImportSpec(GC,                                           &
+          SHORT_NAME         = 'RI',                                         &
+          LONG_NAME          = 'ice_phase_cloud_particle_effective_radius',  &
+          UNITS              = 'm',                                          &
+          DIMS               = MAPL_DimsHorzVert,                            &
+          VLOCATION          = MAPL_VLocationCenter,    __RC__)
+
+       call MAPL_AddImportSpec(GC,                                           &
+          SHORT_NAME         = 'RL',                                         &
+          LONG_NAME          = 'liquid_cloud_particle_effective_radius',     &
+          UNITS              = 'm',                                          &
+          DIMS               = MAPL_DimsHorzVert,                            &
+          VLOCATION          = MAPL_VLocationCenter,    __RC__)
     END IF
 
     call ESMF_ConfigDestroy(gmiConfig, __RC__)


### PR DESCRIPTION
GMI imports RI and RL, for use only by the Cloud-J photolysis routine (not the default scheme).
RI and RL are provided by MOIST, in the context of the AGCM.
RI and RL were not saved in MERRA2, so CTM will need to generate values for them.
Until that code is in place, we give CTM the capability of ignoring them:
the imports are requested only when GMI is using Cloud-J.
CTM users should use FastJX 6.5 for now.
