### PR TITLE
Update gitignore for mepo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 Shared/HEMCO/@HEMCO
+Shared/HEMCO/HEMCO
+Shared/HEMCO/HEMCO@
 GEOSCHEMchem_GridComp/@geos-chem
+GEOSCHEMchem_GridComp/geos-chem
+GEOSCHEMchem_GridComp/geos-chem@
 /@GOCART/
+/GOCART/
+/GOCART@/


### PR DESCRIPTION
Soon, `mepo` will have the ability to checkout subrepos as `repo`, `repo@`, or `@repo`. This commit updates the `.gitignore` files to support this flexibility.