### PR TITLE
TR and GMI - minor modifications

### DIFF
--- a/GMIchem_GridComp/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridComp/GMIchem_GridCompMod.F90
@@ -1996,7 +1996,12 @@ CONTAINS
 !  -------------------------------------------------------------------
    IF ( phase == 2 .OR. phase == 99 ) THEN
      CALL MAPL_GetPointer(expChem,   WATER, 'GMIH2O', __RC__)
-     IF(ASSOCIATED(WATER)) WATER(:,:,:) = SPECHUM(:,:,:)*MAPL_AIRMW/MAPL_H2OMW
+!    IF(ASSOCIATED(WATER)) WATER(:,:,:) = SPECHUM(:,:,:)*MAPL_AIRMW/MAPL_H2OMW
+!    11.25.20 mem: Convert from kg_vapor/kg_moist_air to mol_vapor/mol_moist_air
+     IF(ASSOCIATED(WATER)) WATER(:,:,:) = &
+          ( SPECHUM(:,:,:)*(1.0/MAPL_H2OMW) )  /     &
+              (  SPECHUM(:,:,:) *(1.0/MAPL_H2OMW) +  &
+            (1.0-SPECHUM(:,:,:))*(1.0/MAPL_AIRMW) )
    END IF
 
 !  Total ozone: In each layer

--- a/TR_GridComp/TR_GridCompMod.F90
+++ b/TR_GridComp/TR_GridCompMod.F90
@@ -1040,20 +1040,20 @@ CONTAINS
 !MEM
 !    IF ( wet_removal )  THEN
 
-       call MAPL_AddExportSpec(GC,                                                                     &
-          SHORT_NAME         = 'WRtend_'//TRIM(r%vname(n)),                                            &
-          LONG_NAME          = 'Tendency of '//TRIM(r%vtitle(n))//' due to Wet Removal',               &
-          UNITS              = 'kg m-2 s-1',                                                           &
-          DIMS               = MAPL_DimsHorzVert,                                                      &
-          VLOCATION          = MAPL_VLocationCenter,                                                   &
+       call MAPL_AddExportSpec(GC,                                                                                 &
+          SHORT_NAME         = 'WRtend_'//TRIM(r%vname(n)),                                                        &
+          LONG_NAME          = 'Tendency of '//TRIM(r%vtitle(n))//' due to Large-Scale Wet Removal',               &
+          UNITS              = 'kg m-2 s-1',                                                                       &
+          DIMS               = MAPL_DimsHorzVert,                                                                  &
+          VLOCATION          = MAPL_VLocationCenter,                                                               &
                                                           __RC__ )
 
-       call MAPL_AddExportSpec(GC,                                                                     &
-          SHORT_NAME         = 'WRtendVsum_'//TRIM(r%vname(n)),                                        &
-          LONG_NAME          = 'Tendency of '//TRIM(r%vtitle(n))//' due to Wet Removal, column total', &
-          UNITS              = 'kg m-2 s-1',                                                           &
-          DIMS               = MAPL_DimsHorzOnly,                                                      &
-          VLOCATION          = MAPL_VLocationNone,                                                     &
+       call MAPL_AddExportSpec(GC,                                                                                 &
+          SHORT_NAME         = 'WRtendVsum_'//TRIM(r%vname(n)),                                                    &
+          LONG_NAME          = 'Tendency of '//TRIM(r%vtitle(n))//' due to Large-Scale Wet Removal, column total', &
+          UNITS              = 'kg m-2 s-1',                                                                       &
+          DIMS               = MAPL_DimsHorzOnly,                                                                  &
+          VLOCATION          = MAPL_VLocationNone,                                                                 &
                                                           __RC__ )
 !    END IF
 


### PR DESCRIPTION
Zero-diff for all fields outside of TR;  within TR, only non-zero-diff for the following passive tracers: CH3I, SF6, stOX (strat ozone) and the CO tracers.  Changes are due to slightly better treatment of moist vs dry air in units calculations.

These updates are from two CVS tags:
 **Icarus-3_2_p9_MEM_21-ALPHA**: Better distinction between VMR wrt MOIST (internal fields) and wrt DRY (for emissions)
 **Icarus-3_2_p9_MEM_21-ALPHA-r1**: slight improvement of stOX, and new Chem Loss diagnostics; better units conversion for GMIH2O diagnostic