### PR TITLE
Fixes #163. Fix GNU issue with Achem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [1.8.1] - 2021-02-22
+
+### Fixed
+
+- Fix bug with GNU and Achem Finalize when `aqueous_chemistry: .false.`
+
 ## [1.8.0] - 2021-02-14
 
 ### Changed
@@ -31,8 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- HEMCO_GridComp/HEMCOgocart_*.rc as they relate to legacy GOCART 
-  aerosols which have been removed. 
+- HEMCO_GridComp/HEMCOgocart_*.rc as they relate to legacy GOCART
+  aerosols which have been removed.
 
 ### Added
 

--- a/GEOSachem_GridComp/GEOS_AChemGridCompMod.F90
+++ b/GEOSachem_GridComp/GEOS_AChemGridCompMod.F90
@@ -1000,16 +1000,18 @@ contains
    nullify(self%volc_j)
 
    INIT_H2O2: if (self%aqu_phase_chem) then
-!  Initialize the internal copy of H2O2
-!  ------------------------------------
-   allocate(self%h2o2(i1:i2,j1:j2,km), __STAT__)
+      ! Initialize the internal copy of H2O2
+      ! ------------------------------------
+      allocate(self%h2o2(i1:i2,j1:j2,km), __STAT__)
 
-   if (using_GMI_H2O2) then
-       self%h2o2 = 0.0 ! initial value is not important if H2O2 is from GMI
+      if (using_GMI_H2O2) then
+         self%h2o2 = 0.0 ! initial value is not important if H2O2 is from GMI
+      else
+         call MAPL_GetPointer(import, q_H2O2, 'H2O2', __RC__)
+         self%h2o2 = q_H2O2
+      end if
    else
-       call MAPL_GetPointer(import, q_H2O2, 'H2O2', __RC__)
-       self%h2o2 = q_H2O2
-   end if
+      nullify(self%h2o2)
    end if INIT_H2O2
 
 !  All done


### PR DESCRIPTION
Closes #163 

This PR fixes an issue with GNU and achem where a pointer was not nullified in one code path.

Note that as this is a bug in Chem, I'm issuing it as a hotfix against `main`. Once merged into `main`, we'll make a PR from `main` to `develop`.

This is the sort of workflow @tclune and I are trying to use when possible.

Blocking until I can confirm it is zero-diff (it should be obviously so).