### PR TITLE
Updates to support Spack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updates to CMake to support Spack
+
 ### Removed
 
 ### Added

--- a/DNA_GridComp/CMakeLists.txt
+++ b/DNA_GridComp/CMakeLists.txt
@@ -4,9 +4,8 @@ set (srcs
   DNA_GridCompMod.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
 target_compile_definitions (${this} PRIVATE MAPL_MODE GEOS5)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 set (resource_files
    DNA_ExtData.rc

--- a/GAAS_GridComp/CMakeLists.txt
+++ b/GAAS_GridComp/CMakeLists.txt
@@ -7,8 +7,7 @@ set (srcs
   )
 
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL Chem_Base Chem_Shared GMAO_mpeu FVdycoreCubed_GridComp)
-target_include_directories (${this} PUBLIC ${INC_NETCDF})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL Chem_Base Chem_Shared GMAO_mpeu FVdycoreCubed_GridComp NetCDF::NetCDF_Fortran)
 
 esma_generate_gocart_code (${this} -F)
 

--- a/GEOSCHEMchem_GridComp/CMakeLists.txt
+++ b/GEOSCHEMchem_GridComp/CMakeLists.txt
@@ -76,12 +76,8 @@ endif ()
 esma_add_library (${this}
    SRCS ${srcs}
    DEPENDENCIES MAPL MAPL_cfio_r4 Chem_Base Chem_Shared HEMCO
+                OpenMP::OpenMP_Fortran esmf NetCDF::NetCDF_Fortran
    )
-
-# Enable OpenMP
-target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 target_compile_definitions(${this} PRIVATE
    ESMF_ UCX EXTERNAL_GRID EXTERNAL_FORCING USE_REAL8 MODEL_GEOS)

--- a/GEOSachem_GridComp/CMakeLists.txt
+++ b/GEOSachem_GridComp/CMakeLists.txt
@@ -16,7 +16,7 @@ set (srcs
   ${kpp_gas_dir}/kpp_achem_gas_Monitor.f90
   ${kpp_gas_dir}/kpp_achem_gas_Util.f90
   ${kpp_gas_dir}/kpp_achem_gas_LinearAlgebra.f90
-  ${kpp_gas_dir}/kpp_achem_gas_Integrator.f90  
+  ${kpp_gas_dir}/kpp_achem_gas_Integrator.f90
   GACL_ConstantsMod.F90
   GACL_EmissionsMod.F90
   GACL_ReactionRatesMod.F90
@@ -27,11 +27,10 @@ set (srcs
 esma_add_library (
   ${this}
   SRCS ${srcs}
-  DEPENDENCIES Chem_Shared MAPL GMAO_mpeu
+  DEPENDENCIES Chem_Shared MAPL GMAO_mpeu esmf NetCDF::NetCDF_Fortran
   )
 target_compile_definitions (${this} PRIVATE MAPL_MODE GEOS5)
 set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${PP})
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 new_esma_generate_automatic_code (
   ${this} GEOSachem_Registry.rc

--- a/GEOSpchem_GridComp/CMakeLists.txt
+++ b/GEOSpchem_GridComp/CMakeLists.txt
@@ -2,5 +2,4 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS GEOS_PChemGridComp.F90
-  DEPENDENCIES MAPL MAPL_cfio_r4 Chem_Base)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+  DEPENDENCIES MAPL MAPL_cfio_r4 Chem_Base esmf NetCDF::NetCDF_Fortran)

--- a/HEMCO_GridComp/CMakeLists.txt
+++ b/HEMCO_GridComp/CMakeLists.txt
@@ -7,10 +7,9 @@ set (srcs
 esma_add_library (
   ${this}
   SRCS ${srcs}
-  DEPENDENCIES Chem_Shared MAPL HEMCO
+  DEPENDENCIES Chem_Shared MAPL HEMCO esmf NetCDF::NetCDF_Fortran
   )
 target_compile_definitions (${this} PRIVATE ESMF_ DEVEL GEOS_FP)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 set (acg_headers
   HEMCO_InternalSpec___.h HEMCO_DeclarePointer___.h HEMCO_GetPointer___.h
@@ -26,7 +25,7 @@ add_custom_command (
   OUTPUT ${acg_headers}
   COMMAND ${generator} ${acg_flags} -v -F ${CMAKE_CURRENT_SOURCE_DIR}/HEMCO_Registry.rc
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  MAIN_DEPENDENCY HEMCO_Registry.rc 
+  MAIN_DEPENDENCY HEMCO_Registry.rc
 #  DEPENDS ${include_MAPL_Base}/mapl_acg.pl
   COMMENT "Generating automated code for HEMCO"
   )

--- a/MAMchem_GridComp/CMakeLists.txt
+++ b/MAMchem_GridComp/CMakeLists.txt
@@ -54,9 +54,8 @@ set (srcs
   )
 
 
-set (dependencies MAPL Chem_Shared GMAO_mpeu)
+set (dependencies MAPL Chem_Shared GMAO_mpeu esmf NetCDF::NetCDF_Fortran)
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies} SUBDIRS optics)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 target_compile_definitions (${this} PRIVATE GEOS5 MODAL_AERO MODAL_AERO_7MODE GEOS5_PORT)
 
 esma_generate_gocart_code (${this} -F)

--- a/Shared/Chem_Base/CMakeLists.txt
+++ b/Shared/Chem_Base/CMakeLists.txt
@@ -11,8 +11,7 @@ set (srcs
   Chem_AodMod.F90
   Chem_SimpleBundleMod.F90
   )
-esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu MAPL GMAO_gfio_r4)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu MAPL GMAO_gfio_r4 esmf NetCDF::NetCDF_Fortran)
 target_compile_definitions (${this} PRIVATE GEOS5)
 
 ecbuild_add_executable(TARGET gogo.x SOURCES gogo.F90 LIBS ${this})
@@ -24,9 +23,9 @@ if (USE_F2PY)
    if (F2PY2_FOUND)
       add_f2py2_module(MieObs_ SOURCES MieObs_py.F90
          DESTINATION lib/Python2
-         LIBRARIES Chem_Base MAPL GMAO_mpeu ${NETCDF_LIBRARIES} ${ESMF_LIBRARY}
-         INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
-         USE_MPI
+         LIBRARIES Chem_Base MAPL GMAO_mpeu ${ESMF_LIBRARY}
+         INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
+         USE_MPI USE_NETCDF
          )
       add_dependencies(MieObs_ ${this})
    endif ()
@@ -38,9 +37,7 @@ foreach (exe Chem_Aod.x Chem_Aod3d.x ctl_crst.x Chem_BundleToG5rs.x reff_calcula
   ecbuild_add_executable (
     TARGET ${exe}
     SOURCES ${basename}.F90
-    LIBS ${this} ${OpenMP_Fortran_LIBRARIES})
-  # Do not know how to propagate the flags for OpenMP link step from lower libraries.
-  set_target_properties(${exe} PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
+    LIBS ${this} OpenMP::OpenMP_Fortran)
 endforeach ()
 
 # Copy RC files to build tree

--- a/Shared/Chem_Shared/CMakeLists.txt
+++ b/Shared/Chem_Shared/CMakeLists.txt
@@ -32,10 +32,9 @@ else ()
   list (APPEND srcs Chem_UtilMod_geos4.F90)
 endif ()
 
-esma_add_library(${this} 
-   SRCS ${srcs} 
-   DEPENDENCIES GMAO_mpeu MAPL Chem_Base GEOS_Shared GMAO_hermes)
-target_include_directories(${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
+esma_add_library(${this}
+   SRCS ${srcs}
+   DEPENDENCIES GMAO_mpeu MAPL Chem_Base GEOS_Shared GMAO_hermes esmf NetCDF::NetCDF_Fortran)
 #add_definitions(-DDEBUG)
 add_definitions(-DSPMD -DFVCHEM)
 
@@ -48,5 +47,5 @@ install(
   PROGRAMS bundleParser.py
   DESTINATION bin
 )
-  
-  
+
+

--- a/Shared/HEMCO/CMakeLists.txt
+++ b/Shared/HEMCO/CMakeLists.txt
@@ -44,10 +44,8 @@ list (REMOVE_ITEM srcs
 
 esma_add_library (${this}
    SRCS ${srcs}
-   DEPENDENCIES MAPL
+   DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran
    )
-
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
 
 target_compile_definitions (${this} PRIVATE ESMF_ USE_REAL8 MODEL_GEOS)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/StratChem_GridComp/CMakeLists.txt
+++ b/StratChem_GridComp/CMakeLists.txt
@@ -72,9 +72,8 @@ include_directories (${include_Chem_Shared})
 include_directories (${CMAKE_CURRENT_BINARY_DIR})
 include_directories (${include_GMAO_mpeu})
 
-set (dependencies Chem_Shared MAPL MAPL_cfio_r4 GMAO_mpeu)
+set (dependencies Chem_Shared MAPL MAPL_cfio_r4 GMAO_mpeu NetCDF::NetCDF_Fortran)
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies})
-target_include_directories (${this} PUBLIC ${INC_NETCDF})
 
 if (STRATCHEM_REDUCED_MECHANISM)
    target_compile_definitions(${this} PRIVATE REDUCED)


### PR DESCRIPTION
This zero-diff PR has build system changes to support the use of Spack. Most of the changes just make the GEOS CMake look more like canonical CMake. GEOS previously couldn't support this, but it now can.

See https://github.com/GEOS-ESM/GEOSgcm/issues/387 for overall issue.