### PR TITLE
Add changelog enforcer. Update CI to orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,7 @@
 version: 2.1
 
-executors:
-  gfortran:
-    docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_AUTH_TOKEN
-    environment:
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-      MPIEXEC_PREFLAGS: --oversubscribe
-    resource_class: large
-    #MEDIUM# resource_class: medium
-
-  ifort:
-    docker:
-      - image: gmao/ubuntu20-geos-env:v6.2.8-intelmpi_2021.3.0-intel_2021.3.0
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_AUTH_TOKEN
-    resource_class: large
-    #MEDIUM# resource_class: medium
+orbs:
+  circleci-tools: geos-esm/circleci-tools@0.13.0
 
 workflows:
   build-test:
@@ -35,140 +14,21 @@ workflows:
           context: 
             - docker-hub-creds
 
-commands:
-  versions:
-    description: "Versions, etc."
-    parameters:
-      compiler:
-        type: string
-    steps:
-      - run:
-          name: "Versions, etc."
-          command: |
-            mpirun --version && << parameters.compiler >> --version && echo $BASEDIR && pwd && ls && echo "$(nproc)"
-
-  compress_artifacts:
-    description: "Compress artifacts"
-    steps:
-      - run:
-          name: "Compress artifacts"
-          command: |
-            gzip -9 /logfiles/*
-
-  checkout_fixture:
-    description: "Checkout fixture"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Checkout fixture"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}
-            git clone https://github.com/GEOS-ESM/<< parameters.repo >>.git
-
-  mepoclone:
-    description: "Mepo clone external repos"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Mepo clone external repos"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-            mepo clone
-            mepo status
-
-  mepodevelop:
-    description: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-            mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared
-            mepo status
-
-  checkout_feature_branch:
-    description: "Mepo checkout-if-exists feature branch"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Mepo checkout-if-exists feature branch"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-            echo "${CIRCLE_BRANCH}"
-            if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "main" ]
-            then
-                mepo checkout-if-exists ${CIRCLE_BRANCH}
-            elif [ "${CIRCLE_BRANCH}" == "develop" ]
-            then
-                mepo checkout ${CIRCLE_BRANCH} ${CIRCLE_PROJECT_REPONAME}
-            fi
-            mepo status
-
-  cmake:
-    description: "Run CMake"
-    parameters:
-      repo:
-        type: string
-      compiler:
-        type: string
-    steps:
-      - run:
-          name: "Run CMake"
-          command: |
-            mkdir -p /logfiles
-            cd ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >>
-            mkdir -p ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-            cmake ${CIRCLE_WORKING_DIRECTORY}/<< parameters.repo >> -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=<< parameters.compiler >> -DCMAKE_BUILD_TYPE=Debug -DUSE_F2PY=OFF -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS} -DCMAKE_INSTALL_PREFIX=${CIRCLE_WORKING_DIRECTORY}/workspace/install-<< parameters.repo >> |& tee /logfiles/cmake.log
-
-  buildinstall:
-    description: "Build and install"
-    parameters:
-      repo:
-        type: string
-    steps:
-      - run:
-          name: "Build and install"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
-            make -j"$(nproc)" install |& tee /logfiles/make.log
-            #MEDIUM# make -j4 install |& tee /logfiles/make.log
-
 jobs:
   build-GEOSgcm:
     parameters:
       compiler:
         type: string
-    executor: << parameters.compiler >>
+    executor: circleci-tools/<< parameters.compiler >>
     working_directory: /root/project
     steps:
-      - run:
-          name: "GEOSchem_GridComp branch"
-          command: echo ${CIRCLE_BRANCH}
-      - checkout_fixture:
-          repo: GEOSgcm
-      - versions:
+      - circleci-tools/checkout_fixture
+      - circleci-tools/mepoclone
+      - circleci-tools/mepodevelop
+      - circleci-tools/checkout_if_exists
+      - circleci-tools/cmake:
           compiler: << parameters.compiler >>
-      - mepoclone:
-          repo: GEOSgcm
-      - mepodevelop:
-          repo: GEOSgcm
-      - checkout_feature_branch:
-          repo: GEOSgcm
-      - cmake:
-          repo: GEOSgcm
-          compiler: << parameters.compiler >>
-      - buildinstall:
-          repo: GEOSgcm
-      - compress_artifacts
+      - circleci-tools/buildinstall
+      - circleci-tools/compress_artifacts
       - store_artifacts:
           path: /logfiles

--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -1,0 +1,22 @@
+name: "Enforce Changelog"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabels: 'Skip Changelog,0 diff trivial,automatic'
+        missingUpdateErrorMessage: >
+            No update to CHANGELOG.md found! Please add a changelog
+            entry to it describing your change.  Please note that the
+            keepachangelog (https://keepachangelog.com) format is
+            used. If your change is very trivial not applicable for a
+            changelog entry, add a 'Skip Changelog' label to the pull
+            request to skip the changelog enforcer.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved CircleCI to use circleci-tools orb
+
 ### Removed
 
 ### Added
+
+- Added Changelog Enforcer GitHub Action
 
 ### Fixed
 


### PR DESCRIPTION
This PR does a couple things:

1. Adds the changelog enforcer. This means every PR to this repo (that isn't trivial) will require an entry in `CHANGELOG.md`
2. Updates the CircleCI to use the circleci-tools orb. This just makes the file be cleaner since much of GEOS CI is the same commands over and over. 