### PR TITLE
Updates for Spack Support, Round 2

### DIFF
--- a/CARMAchem_GridComp/CMakeLists.txt
+++ b/CARMAchem_GridComp/CMakeLists.txt
@@ -12,10 +12,9 @@ foreach (dir ${src_directories})
   list (APPEND srcs ${tmpsrcs})
 endforeach()
 
-set (dependencies Chem_Shared Chem_Base GMAO_mpeu)
+set (dependencies Chem_Shared Chem_Base GMAO_mpeu esmf)
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies})
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CARMA/source/base>)
-target_include_directories (${this} PUBLIC ${INC_ESMF})
 
 new_esma_generate_automatic_code (
   ${this} CARMAchem_Registry.rc
@@ -31,7 +30,7 @@ set (resource_files
    CARMAchem_Registry.rc
    )
 
-install( 
-   FILES ${resource_files} 
+install(
+   FILES ${resource_files}
    DESTINATION etc
    )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- More updates to CMake for spack
+
 ## [1.9.1] - 2022-03-18
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,12 @@ set (alldirs
   StratChem_GridComp
   GMIchem_GridComp
   CARMAchem_GridComp
-  GEOSCHEMchem_GridComp 
+  GEOSCHEMchem_GridComp
   MATRIXchem_GridComp
-  MAMchem_GridComp 
+  MAMchem_GridComp
   GAAS_GridComp
   H2O_GridComp
-  TR_GridComp 
+  TR_GridComp
   GEOSachem_GridComp
   DNA_GridComp
   HEMCO_GridComp
@@ -28,8 +28,7 @@ set (srcs
 esma_add_library (${this}
   SRCS ${srcs}
   SUBCOMPONENTS ${alldirs}
-  DEPENDENCIES MAPL Chem_Shared Chem_Base GOCART_GridComp GOCART2G_GridComp
-  INCLUDES ${INC_ESMF})
+  DEPENDENCIES MAPL Chem_Shared Chem_Base GOCART_GridComp GOCART2G_GridComp esmf)
 
 install(
    FILES GEOS_ChemGridComp.rc ChemEnv_ExtData.rc  ChemEnv.rc

--- a/GMIchem_GridComp/CMakeLists.txt
+++ b/GMIchem_GridComp/CMakeLists.txt
@@ -57,7 +57,7 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
    endif ()
 endif ()
 if (CMAKE_BUILD_TYPE MATCHES Release)
-   set_source_files_properties( GMI_GridComp/GmiChem_GridCompMod.F90 
+   set_source_files_properties( GMI_GridComp/GmiChem_GridCompMod.F90
       PROPERTIES COMPILE_FLAGS "-O2 ${common_Fortran_flags} ${GEOS_Fortran_Release_FPE_Flags} ${ALIGNCOM}")
    set_source_files_properties( GMI_GridComp/GmiChem_GridCompClassMod.F90
       PROPERTIES COMPILE_FLAGS "-O1 ${common_Fortran_flags} ${GEOS_Fortran_Release_FPE_Flags} ${ALIGNCOM}")
@@ -65,7 +65,7 @@ endif ()
 
 
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES Chem_Shared GEOS_Shared)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES Chem_Shared GEOS_Shared esmf)
 
 target_include_directories (${this}
   PUBLIC
@@ -83,7 +83,6 @@ target_include_directories (${this}
   )
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/GMI_GridComp>)
-target_include_directories (${this} PUBLIC ${INC_ESMF})
 
 
 
@@ -142,7 +141,7 @@ add_dependencies (${this} phony_gmi)
 #  OUTPUT something
 #  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/gmi_acg.pl -v
 #  MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/gmi_acg.pl
-#  DEPENDS 
+#  DEPENDS
 #  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 #  COMMENT "2nd stage generation of automatic code in GMI"
 #  )

--- a/MATRIXchem_GridComp/CMakeLists.txt
+++ b/MATRIXchem_GridComp/CMakeLists.txt
@@ -22,8 +22,7 @@ set (srcs
   MATRIXchem_GridCompMod.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES Chem_Shared MAPL)
-target_include_directories (${this} PUBLIC ${INC_ESMF}) # ${esma_include}/MAPL_Base)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES Chem_Shared MAPL esmf)
 if (EXTENDED_SOURCE)
   set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${EXTENDED_SOURCE})
 endif ()
@@ -36,4 +35,4 @@ file (GLOB resource_files CONFIGURE_DEPENDS "*.rc")
 install(
    FILES ${resource_files}
    DESTINATION etc
-   ) 
+   )

--- a/TR_GridComp/CMakeLists.txt
+++ b/TR_GridComp/CMakeLists.txt
@@ -7,10 +7,9 @@ set (srcs
   TR_GridCompMod.F90
   )
 
-esma_add_library (${this} 
-   SRCS ${srcs} 
-   DEPENDENCIES MAPL GMAO_mpeu Chem_Shared GEOS_Shared
-   INCLUDES ${INC_ESMF})
+esma_add_library (${this}
+   SRCS ${srcs}
+   DEPENDENCIES MAPL GMAO_mpeu Chem_Shared GEOS_Shared esmf)
 
 #esma_generate_gocart_code (${this} -F)
 


### PR DESCRIPTION
Due to insufficient grepping on my part, some remnants of the
"non-canonical" CMake still remain. Apparently these were not necessary
changes for Spack, but they are changes that unify the CMake style of
GEOS to be more like "correct" CMake.

In this go-around, it is mainly finding `INC_ESMF` which I apparently
forgot to grep for last time (I was focused on NetCDF), and some
non-canonical OpenMP calls.

See https://github.com/GEOS-ESM/GEOSgcm/issues/387 for the meta-issue.