### PR TITLE
Feature/mmanyin/fix gmi import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Several CHEM children no longer use TPREC, removed Connectivity
+
 ### Fixed
 
 - Fixed bug related to recent Precip change, to satisfy GMI import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bug related to recent Precip change, to satisfy GMI import
+
 ### Changed
 
 - More updates to CMake for spack

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -481,7 +481,8 @@ contains
 
   IF(myState%enable_GMICHEM) then
      CALL MAPL_AddConnectivity ( GC, &
-          SHORT_NAME  = (/'AIRDENS      ', 'DELP         ', 'LFR          ', 'LIGHT_NO_PROD'/), &
+          SHORT_NAME  = (/'AIRDENS      ', 'DELP         ', 'LFR          ', &
+                          'TPREC        ', 'LIGHT_NO_PROD'/),                &
           DST_ID = GMICHEM, SRC_ID = CHEMENV, __RC__  )
   ENDIF
 

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -428,7 +428,7 @@ contains
 ! -------------------------------
   IF(myState%enable_GOCART) then
      CALL MAPL_AddConnectivity ( GC, &
-          SHORT_NAME  = (/'AIRDENS     ','AIRDENS_DRYP', 'DELP        ', 'TPREC       ', 'CN_PRCP     ', 'NCN_PRCP    '/), &
+          SHORT_NAME  = (/'AIRDENS     ','AIRDENS_DRYP', 'DELP        ', 'CN_PRCP     ', 'NCN_PRCP    '/), &
           DST_ID = GOCART, SRC_ID = CHEMENV, __RC__  )
   ENDIF
 
@@ -460,7 +460,7 @@ contains
 
   IF(myState%enable_CARMA) then
       CALL MAPL_AddConnectivity ( GC, &
-           SHORT_NAME  = (/'AIRDENS ', 'TPREC   ', 'CN_PRCP ', 'NCN_PRCP'/), &
+           SHORT_NAME  = (/'AIRDENS ', 'CN_PRCP ', 'NCN_PRCP'/), &
            DST_ID = CARMA, SRC_ID = CHEMENV, __RC__  )
            
       if(myState%enable_GOCART) then
@@ -474,8 +474,8 @@ contains
 
   IF(myState%enable_STRATCHEM) then
      CALL MAPL_AddConnectivity ( GC, &
-          SHORT_NAME  = (/ 'AIRDENS     ', 'AIRDENS_DRYP', 'DELP        ', 'TPREC       ', &
-                           'CN_PRCP     ', 'NCN_PRCP    ', 'LFR         ' /),              &
+          SHORT_NAME  = (/ 'AIRDENS     ', 'AIRDENS_DRYP', 'DELP        ',    &
+                           'CN_PRCP     ', 'NCN_PRCP    ', 'LFR         ' /), &
           DST_ID = STRATCHEM, SRC_ID = CHEMENV, __RC__  )
   ENDIF
 
@@ -494,13 +494,13 @@ contains
 
   IF(myState%enable_MAM) then
      CALL MAPL_AddConnectivity ( GC, &
-          SHORT_NAME  = (/'AIRDENS ', 'DELP    ', 'TPREC   ', 'CN_PRCP ', 'NCN_PRCP'/), &
+          SHORT_NAME  = (/'AIRDENS ', 'DELP    ', 'CN_PRCP ', 'NCN_PRCP'/), &
           DST_ID = MAM, SRC_ID = CHEMENV, __RC__  )
   ENDIF
 
   IF(myState%enable_ACHEM) then
      CALL MAPL_AddConnectivity ( GC, &
-          SHORT_NAME  = (/'AIRDENS ', 'DELP    ', 'TPREC   ', 'CN_PRCP ', 'NCN_PRCP'/), &
+          SHORT_NAME  = (/'AIRDENS ', 'DELP    ', 'CN_PRCP ', 'NCN_PRCP'/), &
           DST_ID = ACHEM, SRC_ID = CHEMENV, __RC__  )
   ENDIF
 

--- a/StratChem_GridComp/SC_GridComp/SC_Registry.rc
+++ b/StratChem_GridComp/SC_GridComp/SC_Registry.rc
@@ -49,7 +49,6 @@
   CNV_MFD            |  kg m-2 s-1 | xyz | C |    |   |   |     |      |    | detraining_mass_flux 
   PFL_LSAN           |  kg m-2 s-1 | xyz | E |    |   |   |     |      |    | 3D_flux_of_liquid_nonconvective_precipitation 
   PFI_LSAN           |  kg m-2 s-1 | xyz | E |    |   |   |     |      |    | 3D_flux_of_ice_nonconvective_precipitation
-  TPREC              |  kg m-2 s-1 | xy  |   |    |   |   |     |      |    | total_precipitation
   DQDT               |  s-1        | xyz | C |    |   |   |     |      |    | specific_humidity_tendency_due_to_moist
   F11FLUX   	     |  kg m-2 s-1 | xy  |   |    |   |   |	|      |  x | flux_of_cfc11
   F12FLUX            |  kg m-2 s-1 | xy  |   |    |   |   |     |      |  x | flux_of_cfc11


### PR DESCRIPTION
Zero diff for all runs except those using GMI.
GMI now gets TPREC from ChemEnv, which gets it from SURFACE::PRECTOT .   This is not zero diff, but very close, to MOIST::TPREC.
Also, none of the other Chemistry children are using TPREC, so the AddConnectivity from ChemEnv to GOCART, CARMA, StratChem, MAM and ACHEM  no longer includes TPREC.