### PR TITLE
Changes in scavenging efficiency in Chem_Shared Convection and WetRemoval

### DIFF
--- a/CARMAchem_GridComp/CARMA_UtilMod.F90
+++ b/CARMAchem_GridComp/CARMA_UtilMod.F90
@@ -24,6 +24,7 @@
    USE Chem_UtilMod
    USE Chem_ConstMod, only: undef
    USE m_inpak90	     ! Resource file management
+   USE m_die, only: die
 
 !  Utility Modules
    use DustEmissionMod       ! Dust Emissions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Several CHEM children no longer use TPREC, removed Connectivity
+- Updates to the ConvectionMod in Chem_Shared: reduced dust scavenging by 80%; added temperature-dependent scavenging of Pb, Be species
+- Update to the WetRemovalMod in Chem_Shared: added temperature-dependent snow scavenging of Pb, Be species
 
 ### Fixed
 

--- a/Shared/Chem_Shared/WetRemovalMod.F90
+++ b/Shared/Chem_Shared/WetRemovalMod.F90
@@ -266,6 +266,19 @@ CONTAINS
         endif
 
         effRemoval = qa(n1+n-1)%fwet
+
+!       hyl 2018:
+        if (tmpu(i,j,k) < 258d0 .and. snow_scavenging) then
+!           effRemoval = 1.
+          if  (aero_type == 'Pb210' .or. aero_type == 'Pb210s' .or. &
+               aero_type == 'Be7'   .or. aero_type == 'Be7s'   .or. &
+               aero_type == 'Be10'  .or. aero_type == 'Be10s'  ) then
+            if (tmpu(i,j,k) >= 237d0 ) then
+              effRemoval = 0.5
+            endif
+          endif
+        endif
+
         DC(n) = qa(n1+n-1)%data3d(i,j,k) * F * effRemoval *(1.-exp(-BT))
         if (DC(n).lt.0.) DC(n) = 0.
         qa(n1+n-1)%data3d(i,j,k) = qa(n1+n-1)%data3d(i,j,k)-DC(n)


### PR DESCRIPTION
This PR is ZeroDiff; it only affects passive tracers that are not active by default.

The scavenging of Pb and Be has been changed, in ConvectionMod and WetRemovalMod under Chem_Shared/.
This brings the modules in line with the custom Icarus version that the Atmospheric Chemistry group has historically used.

The convective scavenging of dust has also been modified, but because GOCART2G dust no longer uses the ConvectionMod, this change is also zero diff.  It is merely included to reflect the historic implementation.

Lastly, the routines disable_convection & enable_convection have been removed from ConvectionMod, because (with the introduction of GOCART2G) they are no longer called.