### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/GEOSCHEMchem_GridComp/CMakeLists.txt
+++ b/GEOSCHEMchem_GridComp/CMakeLists.txt
@@ -17,6 +17,7 @@ set (src_directories
    ${geos_chem_dir}/KPP/fullchem
    ${geos_chem_dir}/GeosCore
    ${geos_chem_dir}/Interfaces/GCHP
+   ${geos_chem_dir}/Interfaces/GEOS  
    ${geos_chem_dir}/ObsPack
   )
 include_directories (${geos_chem_dir}/Headers)


### PR DESCRIPTION
Simple update to the GEOS-Chem CMake file in preparation of upcoming versions of GEOS-Chem that have *.F90 files in ${geos_chem_dir}/Interfaces/GEOS. This is zero-diff.