### PR TITLE
prc: Fixed pSO2_OCS connectivity to GOCART2G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed bug in GEOS_ChemGridComp.F90 for connectivity of pSO2_OCS
+  from ACHEM to GOCART2G; was erroneously destination ID for legacy
+  GOCART; zero-diff for standard set up
+
 ## [1.9.2] - 2022-04-29
 
 ### Added

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -585,7 +585,7 @@ contains
    IF(chemReg%doing_OCS) THEN
     CALL MAPL_AddConnectivity ( GC, &
          SHORT_NAME  = (/'pSO2_OCS'/), &
-         DST_ID = GOCART, SRC_ID = ACHEM, __RC__  )
+         DST_ID = GOCART2G, SRC_ID = ACHEM, __RC__  )
    ENDIF
    CALL MAPL_AddConnectivity ( GC, &
         SHORT_NAME  = (/'pSOA_ANTHRO_VOC', 'pSOA_BIOB_VOC  '/), &


### PR DESCRIPTION
Corrects erroneous connectivity destination for pSO2_OCS from ACHEM to GOCART2G

- Fixed bug in GEOS_ChemGridComp.F90 for connectivity of pSO2_OCS
  from ACHEM to GOCART2G; was erroneously destination ID for legacy
  GOCART; zero-diff for standard set up
