### PR TITLE
Closes #203. Add QuickChem repo to gitignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+# Anchors to prevent forgetting to update a version
+baselibs_version: &baselibs_version v7.5.0
+bcs_version: &bcs_version v10.22.3
+
 orbs:
   ci: geos-esm/circleci-tools@1
 
@@ -14,6 +18,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
+          baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ GEOSCHEMchem_GridComp/geos-chem@
 /@GOCART/
 /GOCART/
 /GOCART@/
+/@QuickChem/
+/QuickChem/
+/QuickChem@/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+## [1.9.6] - 2022-08-04
+
+### Fixed
+
+- Updated CI to work with latest GEOSgcm
+- Added QuickChem repo to `.gitignore`
+
 ## [1.9.5] - 2022-06-22
 
 ### Fixed


### PR DESCRIPTION
Closes #203 

This is a hotfix on `main` to add QuickChem to the `.gitignore` file so mepo (and git) doesn't see it.

It also updates the CI with changes already in `develop` so that the CI can pass.