### PR TITLE
GMI now uses CMIP6 emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+
+## [Unreleased]
+
 ### Added
 
 - Add YAML validator GitHub Action
@@ -25,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed GMI from internal SZA calculation to using MAPL SZA.
+- Changed GMI to use (CMIP6) emissions and boundary conditions from CCMI REF-D1
+- Moved external data files (like emissions) from personal space to GMAO shared space
 
 ## [1.9.6] - 2022-08-04
 

--- a/ChemEnv_ExtData.rc
+++ b/ChemEnv_ExtData.rc
@@ -6,9 +6,9 @@ PrimaryExports%%
 #  Name      |     Units    |Clim |Mth|     Time Template    | Offset | Scale |     Variable    |      Template
 # -----------|--------------|-----|---|----------------------|--------|-------|-----------------|----------------------   
 # For lightning:
-RATIO_LOCAL         '1'         N   N   F0                       none    none  ratio_local       /discover/nobackup/mmanyin/Lightning/FlashRatio_x288_y181_t1.%y4%m201.nc
-MIDLAT_ADJ          '1'         Y   N   -                        none    none  midlat            /discover/nobackup/mmanyin/Lightning/FlashRatio_const_x288_y181_2005.nc
-MCOR                'm2'        Y   N   -                        none    none  mcor              /discover/nobackup/mmanyin/Lightning/mcor_x288_y181_2005.nc
+RATIO_LOCAL         '1'         N   N   F0                       none    none  ratio_local       ExtData/g5chem/x/lightning/FlashRatio_x288_y181_t1.%y4%m201.nc
+MIDLAT_ADJ          '1'         Y   N   -                        none    none  midlat            ExtData/g5chem/x/lightning/FlashRatio_const_x288_y181_2005.nc
+MCOR                'm2'        Y   N   -                        none    none  mcor              ExtData/g5chem/x/lightning/mcor_x288_y181_2005.nc
 # -----------|--------------|-----|---|----------------------|--------|-------|-----------------|----------------------   
 %%
 

--- a/ChemEnv_ExtData.yaml
+++ b/ChemEnv_ExtData.yaml
@@ -1,10 +1,10 @@
 Collections:
   ChemEnv_FlashRatio_const_x288_y181_2005.nc:
-    template: /discover/nobackup/mmanyin/Lightning/FlashRatio_const_x288_y181_2005.nc
+    template: ExtData/g5chem/x/lightning/FlashRatio_const_x288_y181_2005.nc
   ChemEnv_FlashRatio_x288_y181_t1.%y4%m201.nc:
-    template: /discover/nobackup/mmanyin/Lightning/FlashRatio_x288_y181_t1.%y4%m201.nc
+    template: ExtData/g5chem/x/lightning/FlashRatio_x288_y181_t1.%y4%m201.nc
   ChemEnv_mcor_x288_y181_2005.nc:
-    template: /discover/nobackup/mmanyin/Lightning/mcor_x288_y181_2005.nc
+    template: ExtData/g5chem/x/lightning/mcor_x288_y181_2005.nc
 
 Samplings:
   ChemEnv_sample_0:

--- a/GMIchem_GridComp/GMI_GridComp/GMI_ExtData.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_ExtData.rc
@@ -6,79 +6,79 @@ PrimaryExports%%
 #  Import    |              |	  |Rgr|_______ Refresh ______|____ Factors ___|___________ External File __________
 #  Name      |     Units    |Clim |Mth|     Time Template    | Offset | Scale |     Variable    |      Template
 # -----------|--------------|-----|---|----------------------|--------|-------|-----------------|----------------------   
-ACET_FIXED       'mol mol-1' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  ACET		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
-SAD              'cm+2 cm-3' 	N   N	%y4-%m2-%d2T12:00:00	 none	 none  lbssad            /discover/nobackup/mmanyin/CCM/emissions/CMIP6/SAD/L72/sad_wt_CMIP6_x288_y181_z72_%y4.nc
+ACET_FIXED       'mol mol-1' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  ACET		 ExtData/g5chem/L72/acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
+SAD              'cm+2 cm-3' 	N   N	%y4-%m2-%d2T12:00:00	 none	 none  lbssad            ExtData/CMIP6/L72/SAD/sad_wt_CMIP6_288x181x72_%y4.nc
 VEG_FRAC               'mil' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  VEG_FRAC 	 ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc
 LAI_FRAC                 '1' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  LAI_FRAC 	 ExtData/g5chem/sfc/LAI/lai_x720_y360_v72_t12_2008.nc
-SOILFERT      'ng N m-2 s-1' 	Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  soilFert 	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/fertilizer_GMI.x288_y181_t12.2006.nc
-SOILPRECIP          'mm d-1' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  soilPrecip	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/precipitation_GMI.x288_y181_t12.2006.nc
-OCS_CLIMO        'mol mol-1'    Y   N   %y4-%m2-%d2T12:00:00     none    none  ocs               /discover/nobackup/mmanyin/CCM/bc/OCS/OCS_vmr.x360_y181.t12.2016.nc4
+SOILFERT      'ng N m-2 s-1' 	Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  soilFert 	 ExtData/g5chem/sfc/fertilizer_GMI.x288_y181_t12.2006.nc
+SOILPRECIP          'mm d-1' 	Y   N	%y4-%m2-%d2T12:00:00	 none	 none  soilPrecip	 ExtData/g5chem/sfc/precipitation_GMI.x288_y181_t12.2006.nc
+OCS_CLIMO        'mol mol-1'    Y   N   %y4-%m2-%d2T12:00:00     none    none  ocs               ExtData/g5chem/L72/OCS_vmr.x360_y181_z72.t12.2016.nc4
 #
-ALD2_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_ald2.006.%y4%m2%d2.nc4
-ALD2_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biofuel  	 /dev/null
-ALK4_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_alk4.006.%y4%m2%d2.nc4
-ALK4_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biofuel  	 /dev/null
-ALK4_fosf       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  fossil_fuel	 /dev/null
-C2H6_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_c2h6.006.%y4%m2%d2.nc4
-C2H6_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biofuel  	 /dev/null
-C2H6_fosf       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  fossil_fuel	 /dev/null
-PRPE_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_c3h6.006.%y4%m2%d2.nc4
-PRPE_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biofuel  	 /dev/null
-PRPE_fosf       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  fossil_fuel	 /dev/null
-C3H8_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_c3h8.006.%y4%m2%d2.nc4
-C3H8_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biofuel  	 /dev/null
-C3H8_fosf       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  fossil_fuel	 /dev/null
-CH2O_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_ch2o.006.%y4%m2%d2.nc4
-CH2O_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biofuel  	 /dev/null
-MEK_biom        'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_mek.006.%y4%m2%d2.nc4
-MEK_biof        'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biofuel  	 /dev/null
-MEK_fosf        'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  fossil_fuel	 /dev/null
-CO_biom      'kg CO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_co.006.%y4%m2%d2.nc4
-CO_biof      'kg CO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	  1.2  CO_bf		 /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_co.fossil_biofuel.x1152_y721.t12.2008.nc
-CO_fosf      'kg CO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	  1.2  CO_ff		 /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_co.fossil_biofuel.x1152_y721.t12.2008.nc
-NO_biom      'kg NO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_no.006.%y4%m2%d2.nc4
-NO_biof      'kg NO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_bf		 /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
-NO_fosf      'kg NO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_ff		 /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
-NO_air       'kg NO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_air		 ExtData/g5chem/sfc/GMI/emisb/CCMI_emisb_m-2_2008_t12.nc
-NO_lgt       'kg NO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_lgt		 /dev/null
-NO_pwrp      'kg NO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_pp		 /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
-NO_ship      'kg NO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_ship  	 /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
-SHIP_NO      'kg NO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_ship  	 /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
-CH4_biom    'kg CH4 m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  biomass  	 ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_ch4.006.%y4%m2%d2.nc4
-CH4_aggr    'kg CH4 m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  CH4_TOT  	 /discover/nobackup/lott/g5input/hires/GMI/TRANSCOM_EDGAR_GMI.emis_ch4.x1152_y721.t12.2005.nc
-MEGAN_ISOP    'mg C m-2 h-1'    Y   Y	-			 none	 none  BIOGSRCE_AEF_ISOP /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_MBO     'mg C m-2 h-1'    Y   Y	-			 none	 none  BIOGSRCE_AEF_MBO  /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_MPE     'mg C m-2 h-1'    Y   Y	-			 none	 none  BIOGSRCE_AEF_MPE  /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_OVOC    'mg C m-2 h-1'    Y   Y	-			 none	 none  BIOGSRCE_AEF_OVC  /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_001      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_001	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_002      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_002	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_003      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_003	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_004      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_004	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_005      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_005	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_006      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_006	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_007      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_007	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_008      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_008	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_009      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_009	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_010      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_010	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_011      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_011	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-MEGAN_LAI_012      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_012	 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-BC1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  BC1		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-BC2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  BC2		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-OC1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  OC1		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-OC2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  OC2		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-SS1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS1		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-SS2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS2		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-SS3                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS3		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-SS4                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS4		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-SO4                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SO4		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
+ALD2_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  ALD2_bb           ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+ALD2_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  ALD2_bf-UNUSED    /dev/null
+ALK4_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  ALK4_bb           ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+ALK4_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  ALK4_bf-UNUSED    /dev/null
+ALK4_fosf       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  ALK4_ff           ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
+C2H6_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  C2H6_bb           ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+C2H6_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  C2H6_bf-UNUSED    /dev/null
+C2H6_fosf       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  C2H6_ff           ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
+PRPE_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  PRPE_bb           ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+PRPE_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  PRPE_bf-UNUSED    /dev/null
+PRPE_fosf       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  PRPE_ff           ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
+C3H8_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  C3H8_bb           ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+C3H8_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  C3H8-UNUSED       /dev/null
+C3H8_fosf       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  C3H8_ff           ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
+CH2O_biom       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  CH2O_bb           ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+CH2O_biof       'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  CH2O_bf-UNUSED    /dev/null
+MEK_biom        'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  MEK_bb            ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+MEK_biof        'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  MEK_bf-UNUSED     /dev/null
+MEK_fosf        'kg m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  MEK_ff            ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
+CO_biom      'kg CO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  CO_bb             ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+CO_biof      'kg CO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  CO_bf-UNUSED      /dev/null
+CO_fosf      'kg CO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  CO_ff             ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
+NO_biom      'kg NO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_bb             ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+NO_biof      'kg NO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_bf-UNUSED      /dev/null
+NO_fosf      'kg NO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_ff             ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
+NO_air       'kg NO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_air            ExtData/CMIP6/L72/aircraft/CMIP6_CEDS.airNOemis.x720_y360_z72_t12.%y4.nc4
+NO_lgt       'kg NO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_lgt-UNUSED     /dev/null
+NO_pwrp      'kg NO m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_pp-UNUSED      /dev/null
+NO_ship      'kg NO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_shp-UNUSED     /dev/null
+SHIP_NO      'kg NO m-2 s-1'    N   Y	%y4-%m2-%d2T12:00:00	 none	 none  NO_shp            ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
+CH4_biom    'kg CH4 m-2 s-1'    N   Y   %y4-%m2-%d2T12:00:00     none    none  CH4_bb-UNUSED     /dev/null
+CH4_aggr    'kg CH4 m-2 s-1'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  CH4_TOT-UNUSED    /dev/null
+MEGAN_ISOP    'mg C m-2 h-1'    Y   Y	-			 none	 none  BIOGSRCE_AEF_ISOP ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_MBO     'mg C m-2 h-1'    Y   Y	-			 none	 none  BIOGSRCE_AEF_MBO  ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_MPE     'mg C m-2 h-1'    Y   Y	-			 none	 none  BIOGSRCE_AEF_MPE  ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_OVOC    'mg C m-2 h-1'    Y   Y	-			 none	 none  BIOGSRCE_AEF_OVC  ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_001      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_001	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_002      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_002	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_003      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_003	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_004      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_004	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_005      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_005	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_006      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_006	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_007      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_007	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_008      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_008	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_009      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_009	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_010      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_010	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_011      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_011	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+MEGAN_LAI_012      'cm cm-1'    Y   N	-			 none	 none  AVHRR_LAI_012	 ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+BC1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  BC1		 /dev/null
+BC2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  BC2		 /dev/null
+OC1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  OC1		 /dev/null
+OC2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  OC2		 /dev/null
+SS1                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS1		 /dev/null
+SS2                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS2		 /dev/null
+SS3                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS3		 /dev/null
+SS4                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SS4		 /dev/null
+SO4                 'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SO4		 /dev/null
 SO4v                'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  SO4v		 /dev/null
-MDUST1              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST1		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/dust_GMI.x288_y181_z72_t12.2006.nc
-MDUST2              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST2		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/dust_GMI.x288_y181_z72_t12.2006.nc
-MDUST3              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST3		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/dust_GMI.x288_y181_z72_t12.2006.nc
-MDUST4              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST4		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/dust_GMI.x288_y181_z72_t12.2006.nc
-MDUST5              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST5		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/dust_GMI.x288_y181_z72_t12.2006.nc
-MDUST6              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST6		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/dust_GMI.x288_y181_z72_t12.2006.nc
-MDUST7              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST7		 /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/dust_GMI.x288_y181_z72_t12.2006.nc
+MDUST1              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST1		 /dev/null
+MDUST2              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST2		 /dev/null
+MDUST3              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST3		 /dev/null
+MDUST4              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST4		 /dev/null
+MDUST5              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST5		 /dev/null
+MDUST6              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST6		 /dev/null
+MDUST7              'kg m-3'    Y   Y	%y4-%m2-%d2T12:00:00	 none	 none  MDUST7		 /dev/null
 # -----------|--------------|-----|---|----------------------|--------|-------|-----------------|----------------------   
 %%
 

--- a/GMIchem_GridComp/GMI_GridComp/GMI_ExtData.yaml
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_ExtData.yaml
@@ -1,50 +1,24 @@
 Collections:
-  GMI_CCMI_emisb_m-2_2008_t12.nc:
-    template: ExtData/g5chem/sfc/GMI/emisb/CCMI_emisb_m-2_2008_t12.nc
-  GMI_EDGAR_GMI.emis_co.fossil_biofuel.x1152_y721.t12.2008.nc:
-    template: /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_co.fossil_biofuel.x1152_y721.t12.2008.nc
-  GMI_EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc:
-    template: /discover/nobackup/lott/g5input/hires/GMI/EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
+  GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4:
+    template: ExtData/CMIP6/sfc/biomass_burning/CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
+  GMI_CMIP6_CEDS.airNOemis.x720_y360_z72_t12.%y4.nc4:
+    template: ExtData/CMIP6/L72/aircraft/CMIP6_CEDS.airNOemis.x720_y360_z72_t12.%y4.nc4
+  GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4:
+    template: ExtData/CMIP6/sfc/fossil_fuels/CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
   GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc:
-    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
-  GMI_OCS_vmr.x360_y181.t12.2016.nc4:
-    template: /discover/nobackup/mmanyin/CCM/bc/OCS/OCS_vmr.x360_y181.t12.2016.nc4
-  GMI_TRANSCOM_EDGAR_GMI.emis_ch4.x1152_y721.t12.2005.nc:
-    template: /discover/nobackup/lott/g5input/hires/GMI/TRANSCOM_EDGAR_GMI.emis_ch4.x1152_y721.t12.2005.nc
+    template: ExtData/g5chem/sfc/MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
+  GMI_OCS_vmr.x360_y181_z72.t12.2016.nc4:
+    template: ExtData/g5chem/L72/OCS_vmr.x360_y181_z72.t12.2016.nc4
   GMI_acetone_fixed_GMI.x288_y181_z72_t12.2001.nc:
-    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
-  GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc:
-    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-  GMI_dust_GMI.x288_y181_z72_t12.2006.nc:
-    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/L72/dust_GMI.x288_y181_z72_t12.2006.nc
+    template: ExtData/g5chem/L72/acetone_fixed_GMI.x288_y181_z72_t12.2001.nc
   GMI_fertilizer_GMI.x288_y181_t12.2006.nc:
-    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/fertilizer_GMI.x288_y181_t12.2006.nc
+    template: ExtData/g5chem/sfc/fertilizer_GMI.x288_y181_t12.2006.nc
   GMI_lai_x720_y360_v72_t12_2008.nc:
     template: ExtData/g5chem/sfc/LAI/lai_x720_y360_v72_t12_2008.nc
   GMI_precipitation_GMI.x288_y181_t12.2006.nc:
-    template: /discover/nobackup/projects/gmao/share/dasilva/fvInput/g5chem/sfc/precipitation_GMI.x288_y181_t12.2006.nc
-  GMI_qfed2.emis_ald2.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_ald2.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_alk4.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_alk4.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_c2h6.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_c2h6.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_c3h6.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_c3h6.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_c3h8.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_c3h8.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_ch2o.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_ch2o.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_ch4.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_ch4.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_co.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_co.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_mek.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_mek.006.%y4%m2%d2.nc4
-  GMI_qfed2.emis_no.006.%y4%m2%d2.nc4:
-    template: ExtData/PIESA/../g5chem/sfc/QFED/v2.5r1/0.25/Y%y4/M%m2/qfed2.emis_no.006.%y4%m2%d2.nc4
-  GMI_sad_wt_CMIP6_x288_y181_z72_%y4.nc:
-    template: /discover/nobackup/mmanyin/CCM/emissions/CMIP6/SAD/L72/sad_wt_CMIP6_x288_y181_z72_%y4.nc
+    template: ExtData/g5chem/sfc/precipitation_GMI.x288_y181_t12.2006.nc
+  GMI_sad_wt_CMIP6_288x181x72_%y4.nc:
+    template: ExtData/CMIP6/L72/SAD/sad_wt_CMIP6_288x181x72_%y4.nc
   GMI_veg_fraction_x720_y360_t12_2008.nc:
     template: ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc
 
@@ -68,149 +42,92 @@ Exports:
     variable: ACET
   ALD2_biof:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: biofuel
   ALD2_biom:
-    collection: GMI_qfed2.emis_ald2.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: ALD2_bb
   ALK4_biof:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: biofuel
   ALK4_biom:
-    collection: GMI_qfed2.emis_alk4.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: ALK4_bb
   ALK4_fosf:
-    collection: /dev/null
+    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: fossil_fuel
+    variable: ALK4_ff
   BC1:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: BC1
+    collection: /dev/null
   BC2:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: BC2
+    collection: /dev/null
   C2H6_biof:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: biofuel
   C2H6_biom:
-    collection: GMI_qfed2.emis_c2h6.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: C2H6_bb
   C2H6_fosf:
-    collection: /dev/null
+    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: fossil_fuel
+    variable: C2H6_ff
   C3H8_biof:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: biofuel
   C3H8_biom:
-    collection: GMI_qfed2.emis_c3h8.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: C3H8_bb
   C3H8_fosf:
-    collection: /dev/null
+    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: fossil_fuel
+    variable: C3H8_ff
   CH2O_biof:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: biofuel
   CH2O_biom:
-    collection: GMI_qfed2.emis_ch2o.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: CH2O_bb
   CH4_aggr:
-    collection: GMI_TRANSCOM_EDGAR_GMI.emis_ch4.x1152_y721.t12.2005.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: CH4_TOT
+    collection: /dev/null
   CH4_biom:
-    collection: GMI_qfed2.emis_ch4.006.%y4%m2%d2.nc4
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: biomass
+    collection: /dev/null
   CO_biof:
-    collection: GMI_EDGAR_GMI.emis_co.fossil_biofuel.x1152_y721.t12.2008.nc
-    linear_transformation:
-      - 0.0
-      - 1.2
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: CO_bf
+    collection: /dev/null
   CO_biom:
-    collection: GMI_qfed2.emis_co.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: CO_bb
   CO_fosf:
-    collection: GMI_EDGAR_GMI.emis_co.fossil_biofuel.x1152_y721.t12.2008.nc
-    linear_transformation:
-      - 0.0
-      - 1.2
+    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
     regrid: CONSERVE
-    sample: GMI_sample_0
+    sample: GMI_sample_1
     variable: CO_ff
   LAI_FRAC:
     collection: GMI_lai_x720_y360_v72_t12_2008.nc
     sample: GMI_sample_0
     variable: LAI_FRAC
   MDUST1:
-    collection: GMI_dust_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: MDUST1
+    collection: /dev/null
   MDUST2:
-    collection: GMI_dust_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: MDUST2
+    collection: /dev/null
   MDUST3:
-    collection: GMI_dust_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: MDUST3
+    collection: /dev/null
   MDUST4:
-    collection: GMI_dust_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: MDUST4
+    collection: /dev/null
   MDUST5:
-    collection: GMI_dust_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: MDUST5
+    collection: /dev/null
   MDUST6:
-    collection: GMI_dust_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: MDUST6
+    collection: /dev/null
   MDUST7:
-    collection: GMI_dust_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: MDUST7
+    collection: /dev/null
   MEGAN_ISOP:
     collection: GMI_MEGAN_AEF_LAI_Heracles.x288_y181_t12.2008.nc
     regrid: CONSERVE
@@ -281,102 +198,72 @@ Exports:
     variable: BIOGSRCE_AEF_OVC
   MEK_biof:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: biofuel
   MEK_biom:
-    collection: GMI_qfed2.emis_mek.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: MEK_bb
   MEK_fosf:
-    collection: /dev/null
+    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: fossil_fuel
+    variable: MEK_ff
   NO_air:
-    collection: GMI_CCMI_emisb_m-2_2008_t12.nc
+    collection: GMI_CMIP6_CEDS.airNOemis.x720_y360_z72_t12.%y4.nc4
     regrid: CONSERVE
-    sample: GMI_sample_0
+    sample: GMI_sample_1
     variable: NO_air
   NO_biof:
-    collection: GMI_EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: NO_bf
+    collection: /dev/null
   NO_biom:
-    collection: GMI_qfed2.emis_no.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: NO_bb
   NO_fosf:
-    collection: GMI_EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
+    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
     regrid: CONSERVE
-    sample: GMI_sample_0
+    sample: GMI_sample_1
     variable: NO_ff
   NO_lgt:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: NO_lgt
   NO_pwrp:
-    collection: GMI_EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: NO_pp
+    collection: /dev/null
   NO_ship:
-    collection: GMI_EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: NO_ship
+    collection: /dev/null
   OC1:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: OC1
+    collection: /dev/null
   OC2:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: OC2
+    collection: /dev/null
   OCS_CLIMO:
-    collection: GMI_OCS_vmr.x360_y181.t12.2016.nc4
+    collection: GMI_OCS_vmr.x360_y181_z72.t12.2016.nc4
     sample: GMI_sample_0
     variable: ocs
   PRPE_biof:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_1
-    variable: biofuel
   PRPE_biom:
-    collection: GMI_qfed2.emis_c3h6.006.%y4%m2%d2.nc4
+    collection: GMI_CMIP6_BB.emis.x1440_y720_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: biomass
+    variable: PRPE_bb
   PRPE_fosf:
-    collection: /dev/null
+    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
     regrid: CONSERVE
     sample: GMI_sample_1
-    variable: fossil_fuel
+    variable: PRPE_ff
   SAD:
-    collection: GMI_sad_wt_CMIP6_x288_y181_z72_%y4.nc
+    collection: GMI_sad_wt_CMIP6_288x181x72_%y4.nc
     sample: GMI_sample_1
     variable: lbssad
   SHIP_NO:
-    collection: GMI_EDGAR_GMI.emis_no.fossil_biofuel.x1152_y721.t12.2008.nc
+    collection: GMI_CMIP6_CEDS.emis.x720_y360_t12.%y4.nc4
     regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: NO_ship
+    sample: GMI_sample_1
+    variable: NO_shp
   SO4:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: SO4
+    collection: /dev/null
   SO4v:
     collection: /dev/null
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: SO4v
   SOILFERT:
     collection: GMI_fertilizer_GMI.x288_y181_t12.2006.nc
     regrid: CONSERVE
@@ -387,27 +274,16 @@ Exports:
     sample: GMI_sample_0
     variable: soilPrecip
   SS1:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: SS1
+    collection: /dev/null
   SS2:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: SS2
+    collection: /dev/null
   SS3:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: SS3
+    collection: /dev/null
   SS4:
-    collection: GMI_aerosols_corrected_GMI.x288_y181_z72_t12.2006.nc
-    regrid: CONSERVE
-    sample: GMI_sample_0
-    variable: SS4
+    collection: /dev/null
   VEG_FRAC:
     collection: GMI_veg_fraction_x720_y360_t12_2008.nc
     sample: GMI_sample_0
     variable: VEG_FRAC
+
 

--- a/GMIchem_GridComp/GMI_GridComp/GMI_GridComp.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_GridComp.rc
@@ -119,6 +119,10 @@ do_simpledep: F
 do_emission: T
 do_dust_emiss: F
 Diurnal_Emission_Species: 9
+
+        ##################################################################################
+        # Are emissions provided per m^2 (by area) or per gridbox?  Default: by area = T
+        ##################################################################################
 clim_emiss_by_area: T
 
         #############################################################################
@@ -136,15 +140,17 @@ C2H6_biom
 PRPE_biom
 C3H8_biom
 CH2O_biom
-CO_biom
 MEK_biom
+CO_biom
 NO_biom
 NO_air
+ALK4_fosf
+C2H6_fosf
+PRPE_fosf
+C3H8_fosf
+MEK_fosf
 CO_fosf
-CO_biof
 NO_fosf
-NO_biof
-NO_pwrp
 ::
 
 emissionSpeciesLayers::
@@ -158,6 +164,8 @@ emissionSpeciesLayers::
 1
 1
 72
+1
+1
 1
 1
 1
@@ -191,7 +199,7 @@ monotconv_infile_name: ExtData/g5chem/x/GMI_MONOT_convTable.asc
 
 do_gcr: F
 do_solar_cycle: T
-sc_infile_name: /discover/nobackup/ldoman/fvInput/solar_cycle_NRL_1882_present_fill2100.asc
+sc_infile_name: ExtData/g5chem/x/solar_cycle/solar_cycle_NRL_1882_present_fill2100.asc
 
         ######################################
         #     Lightning related variables
@@ -230,17 +238,19 @@ AerDust_Effect_opt: 0
         ###########################################################
 
 forc_bc_opt: 2
-forc_bc_years: 151
+forc_bc_years: 69
 forc_bc_start_num: 1950
 forc_bc_kmin: 1
 forc_bc_kmax: 2
-# prev_bc_infile_name: EXTDATA/g5chem/sfc/wmo2002_GHGODS.y19_t1200.1970-2069.asc
-#
+# Previous entry (151 years):
 # Be aware that this forc_bc_infile is for RCP 6.0; other options include RCP 4.5, 8.5 and 3PD.
 # CO2 is not included in this file; it is specified in getco2.F90 which has different RCP versions too.
 # Be sure to use the same RCP versions of forc_bc_infile and getco2.F90 .
 #
-forc_bc_infile_name: /discover/nobackup/ldoman/fvInput/RCP6.0_5BrWMO2018_ch4latvar_1950_2100.asc
+#forc_bc_infile_name: /discover/nobackup/ldoman/fvInput/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
+#forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2014_ch4latvar_1950_2100.asc
+#forc_bc_infile_name:              ExtData/g5chem/x/GMI/RCP6.0_5BrWMO2018_ch4latvar_1950_2100.asc
+forc_bc_infile_name:               ExtData/g5chem/x/GMI/ccmiRefD1_GMIbc_1950_2018.asc
 
 forcedBcSpeciesNames:: 
 CFCl3
@@ -359,17 +369,17 @@ do_ozone_inFastJX: F
 #     (as listed in GmiPhotolysis_GridCompClassMod.F90)
 
 ## For FastJX & JPL02
-# cross section file: ExtData/g5chem/x/xsec_jx_06a.dat
+# cross section file: ExtData/g5chem/x/photolysis/FastJX/xsec_jx_06a.dat
 
 ## For FastJX & JPL10
-# cross section file: /discover/nobackup/ldoman/fvInput/xsec_jx_jpl10update2_JNOx1_0.dat
+# cross section file: ExtData/g5chem/x/photolysis/FastJX/xsec_jx_jpl10update2_JNOx1_0.dat
 
 ## For FastJX 6.5 & JPL10
  fastj_opt: 4
- cross_section_file: /discover/nobackup/mmanyin/fvInput/fastjx/65/xsec_jx65_jpl10update2_JNOx1_0.dat
+ cross_section_file: ExtData/g5chem/x/photolysis/FastJX_6.5/xsec_jx65_jpl10update2_JNOx1_0.dat
 # rate_file not needed for FastJX6.5; new approach only differs by roundoff
-# rate_file: ExtData/g5chem/x/ratec_124spc_jx_gmiv2.dat
-# rate_file: /discover/nobackup/mmanyin/CCM/fvInput/fastjx/ratec_119spc_jx_gmiv3.dat
+# rate_file: ExtData/g5chem/x/photolysis/FastJX/ratec_124spc_jx_gmiv2.dat
+# rate_file: ExtData/g5chem/x/photolysis/FastJX/ratec_119spc_jx_gmiv3.dat
  T_O3_climatology_file: ExtData/g5chem/x/atms_jx_o3andtemp.dat
 
 ##
@@ -385,14 +395,14 @@ do_ozone_inFastJX: F
 ###   7: RECOMMENDED - Use all (up to 4) QCAs (average clouds within each Q-bin)
 ###   8: Calculate Js for ALL ICAs (up to 20,000 per cell!)
 # CloudJ_cldflag:  7
-# cross_section_file:       /home/ssteenro/gmi/gmi_gsfc/Components/GmiChemistry/photolysis/CloudJ/reference/data/FJX_spec_JNOx1_0.dat
-# cloud_scat_file:          /home/ssteenro/gmi/gmi_gsfc/Components/GmiChemistry/photolysis/CloudJ/reference/data/FJX_scat-cld.dat
-# ssa_scat_file:            /home/ssteenro/gmi/gmi_gsfc/Components/GmiChemistry/photolysis/CloudJ/reference/data/FJX_scat-ssa.dat
-# aer_scat_file:            /home/ssteenro/gmi/gmi_gsfc/Components/GmiChemistry/photolysis/CloudJ/reference/data/FJX_scat-aer.dat
-# UMaer_scat_file:          /home/ssteenro/gmi/gmi_gsfc/Components/GmiChemistry/photolysis/CloudJ/reference/data/FJX_scat-UMa.dat
-# GMI_scat_file:            /home/ssteenro/gmi/gmi_gsfc/Components/GmiChemistry/photolysis/CloudJ/reference/data/GMI_scat-aer.dat
-# T_O3_climatology_file:    /home/ssteenro/gmi/gmi_gsfc/Components/GmiChemistry/photolysis/CloudJ/reference/data/atmos_std.dat
-# H2O_CH4_climatology_file: /home/ssteenro/gmi/gmi_gsfc/Components/GmiChemistry/photolysis/CloudJ/reference/data/atmos_h2och4.dat
+# cross_section_file:       ExtData/g5chem/x/photolysis/CloudJ/FJX_spec_JNOx1_0.dat
+# cloud_scat_file:          ExtData/g5chem/x/photolysis/CloudJ/FJX_scat-cld.dat
+# ssa_scat_file:            ExtData/g5chem/x/photolysis/CloudJ/FJX_scat-ssa.dat
+# aer_scat_file:            ExtData/g5chem/x/photolysis/CloudJ/FJX_scat-aer.dat
+# UMaer_scat_file:          ExtData/g5chem/x/photolysis/CloudJ/FJX_scat-UMa.dat
+# GMI_scat_file:            ExtData/g5chem/x/photolysis/CloudJ/GMI_scat-aer.dat
+# T_O3_climatology_file:    ExtData/g5chem/x/photolysis/CloudJ/atmos_std.dat
+# H2O_CH4_climatology_file: ExtData/g5chem/x/photolysis/CloudJ/atmos_h2och4.dat
 ##
 
  #####################################################

--- a/HEMCO_GridComp/HEMCOgmi_ExtData.rc
+++ b/HEMCO_GridComp/HEMCOgmi_ExtData.rc
@@ -16,30 +16,30 @@ PrimaryExports%%
 #
 
 # --- MEGAN ---
-MEGAN_AEF_ISOP_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_ISOPRENE      /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
-MEGAN_AEF_MBOX_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_MBO           /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
-MEGAN_AEF_BPIN_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_BETA_PINENE   /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
-MEGAN_AEF_CARE_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_CARENE        /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
-MEGAN_AEF_LIMO_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_LIMONENE      /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
-MEGAN_AEF_OCIM_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_OCIMENE       /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
-MEGAN_AEF_SABI_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_SABINENE      /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
-CLM4_PFT_BARE_GMI      '1'          N    N -                    none     none    PFT_BARE          /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_NDLF_EVGN_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_EVGN_TMPT_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_NDLF_EVGN_BORL_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_EVGN_BORL_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_NDLF_DECD_BORL_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_DECD_BORL_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_BDLF_EVGN_TROP_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_EVGN_TROP_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_BDLF_EVGN_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_EVGN_TMPT_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_BDLF_DECD_TROP_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TROP_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_BDLF_DECD_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TMPT_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_BDLF_DECD_BORL_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_BORL_TREE /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_BDLF_EVGN_SHRB_GMI      '1' N    N -                    none     none    PFT_BDLF_EVGN_SHRB      /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_BDLF_DECD_TMPT_SHRB_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TMPT_SHRB /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_BDLF_DECD_BORL_SHRB_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_BORL_SHRB /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_C3_ARCT_GRSS_GMI        '1' N    N -                    none     none    PFT_C3_ARCT_GRSS        /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_C3_NARC_GRSS_GMI        '1' N    N -                    none     none    PFT_C3_NARC_GRSS        /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_C4_GRSS_GMI             '1' N    N -                    none     none    PFT_C4_GRSS             /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-CLM4_PFT_CROP_GMI                '1' N    N -                    none     none    PFT_CROP                /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
-MEGAN_ORVC_GMI       'kgC/m2/s'      Y    Y 1999-%m2-01T00:00:00 none     none    OCPI                    /discover/nobackup/cakelle2/data/NVOC.geos.1x1.esmf.nc
+MEGAN_AEF_ISOP_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_ISOPRENE      ExtData/g5chem/sfc/HEMCO/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_MBOX_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_MBO           ExtData/g5chem/sfc/HEMCO/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_BPIN_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_BETA_PINENE   ExtData/g5chem/sfc/HEMCO/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_CARE_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_CARENE        ExtData/g5chem/sfc/HEMCO/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_LIMO_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_LIMONENE      ExtData/g5chem/sfc/HEMCO/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_OCIM_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_OCIMENE       ExtData/g5chem/sfc/HEMCO/MEGAN2.1_EF.geos.025x03125.esmf.nc
+MEGAN_AEF_SABI_GMI  'kgC/m2/s'      N    Y -                    none     none    AEF_SABINENE      ExtData/g5chem/sfc/HEMCO/MEGAN2.1_EF.geos.025x03125.esmf.nc
+CLM4_PFT_BARE_GMI      '1'          N    N -                    none     none    PFT_BARE          ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_NDLF_EVGN_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_EVGN_TMPT_TREE ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_NDLF_EVGN_BORL_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_EVGN_BORL_TREE ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_NDLF_DECD_BORL_TREE_GMI '1' N    N -                    none     none    PFT_NDLF_DECD_BORL_TREE ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_EVGN_TROP_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_EVGN_TROP_TREE ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_EVGN_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_EVGN_TMPT_TREE ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_TROP_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TROP_TREE ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_TMPT_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TMPT_TREE ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_BORL_TREE_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_BORL_TREE ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_EVGN_SHRB_GMI      '1' N    N -                    none     none    PFT_BDLF_EVGN_SHRB      ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_TMPT_SHRB_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_TMPT_SHRB ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_BDLF_DECD_BORL_SHRB_GMI '1' N    N -                    none     none    PFT_BDLF_DECD_BORL_SHRB ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_C3_ARCT_GRSS_GMI        '1' N    N -                    none     none    PFT_C3_ARCT_GRSS        ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_C3_NARC_GRSS_GMI        '1' N    N -                    none     none    PFT_C3_NARC_GRSS        ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_C4_GRSS_GMI             '1' N    N -                    none     none    PFT_C4_GRSS             ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+CLM4_PFT_CROP_GMI                '1' N    N -                    none     none    PFT_CROP                ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
+MEGAN_ORVC_GMI       'kgC/m2/s'      Y    Y 1999-%m2-01T00:00:00 none     none    OCPI                    ExtData/g5chem/sfc/HEMCO/NVOC.geos.1x1.esmf.nc
 
 # --- Mask ---
 #TIMEZONES NA  N V - none none  UTC_OFFSET /discover/nobackup/cakelle2/data/timezones_esmf.2x25.nc

--- a/HEMCO_GridComp/HEMCOgmi_ExtData.yaml
+++ b/HEMCO_GridComp/HEMCOgmi_ExtData.yaml
@@ -1,10 +1,10 @@
 Collections:
   HEMCOgmi_CLM4_PFT.geos.025x03125.esmf.nc:
-    template: /discover/nobackup/cakelle2/data/MEGAN_20180519/CLM4_PFT.geos.025x03125.esmf.nc
+    template: ExtData/g5chem/sfc/HEMCO/CLM4_PFT.geos.025x03125.esmf.nc
   HEMCOgmi_MEGAN2.1_EF.geos.025x03125.esmf.nc:
-    template: /discover/nobackup/cakelle2/data/MEGAN_20180519/MEGAN2.1_EF.geos.025x03125.esmf.nc
+    template: ExtData/g5chem/sfc/HEMCO/MEGAN2.1_EF.geos.025x03125.esmf.nc
   HEMCOgmi_NVOC.geos.1x1.esmf.nc:
-    template: /discover/nobackup/cakelle2/data/NVOC.geos.1x1.esmf.nc
+    template: ExtData/g5chem/sfc/HEMCO/NVOC.geos.1x1.esmf.nc
 
 Samplings:
   HEMCOgmi_sample_0:


### PR DESCRIPTION
GMI now uses boundary conditions and emissions (CMIP6) matching CCMI  REF-D1.
Relocated ExtData files into GMAO shared space (e.g. CMIP6 files).
This is zero-diff for all runs except GMI.