### PR TITLE
incremental improvements to GMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,22 +14,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 
-## [Unreleased]
+## [1.10.0] - 2022-08-16
 
 ### Added
 
 - Add YAML validator GitHub Action
   - This action makes sure all YAML files are valid (to a relaxed standard)
+- Added flag to control whether GMI feeds back QV value to rest of model
 
 ### Fixed
 
 - Fixed Dry Deposition in GMI
+- Fixed small memory leak in GMI
 
 ### Changed
 
 - Changed GMI from internal SZA calculation to using MAPL SZA.
 - Changed GMI to use (CMIP6) emissions and boundary conditions from CCMI REF-D1
 - Moved external data files (like emissions) from personal space to GMAO shared space
+- Improved diagnostic print statements
 
 ## [1.9.6] - 2022-08-04
 

--- a/GEOS_ChemEnvGridComp.F90
+++ b/GEOS_ChemEnvGridComp.F90
@@ -711,7 +711,7 @@ contains
     ! SimType is added by ctm_setup
     call ESMF_GridCompGet ( GC, CONFIG=CF, __RC__ )
     call ESMF_ConfigGetAttribute ( CF, rc_string, Label="SimType:", Default="undefined", __RC__ )
-1   IF(MAPL_AM_I_ROOT()) PRINT*,'The SimType resource is '//TRIM(rc_string)
+!   IF(MAPL_AM_I_ROOT()) PRINT*,'The SimType resource is '//TRIM(rc_string)
 
     IF ( TRIM(rc_string) == "CTM" ) THEN
       SimType = "CTM"

--- a/GMIchem_GridComp/GMI_GridComp/GMI_GridComp.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_GridComp.rc
@@ -405,6 +405,12 @@ do_ozone_inFastJX: F
 # H2O_CH4_climatology_file: ExtData/g5chem/x/photolysis/CloudJ/atmos_h2och4.dat
 ##
 
+ #################################
+ # Copy GMI H2O back to GEOS ?
+ #################################
+
+FeedBack_QV: T
+
  #####################################################
  #    PSC related variables controlling HNO3COND
  #####################################################

--- a/GMIchem_GridComp/GMI_GridComp/GmiSAD_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiSAD_GridCompClassMod.F90
@@ -816,11 +816,11 @@ CONTAINS
    rc = 0
    i1 = self%i1
    i2 = self%i2
-   im = self%im
+   im = self%im   ! e.g. 90
    
    j1 = self%j1
    j2 = self%j2
-   jm = self%jm
+   jm = self%jm   ! e.g. 540
    
    km = self%km
    
@@ -963,6 +963,17 @@ CONTAINS
     r = MAXVAL(self%SpeciesConcentration%concentration(ic)%pArray3D(:,:,:))
     IF(r > self%HNO3Ice_MAX*1.00E-09) THEN
      PRINT *,TRIM(Iam)//": Found HNO3COND above limit: ",r*1.00E+09," ppbv"
+     DO i = i1,i2
+     DO j = j1,j2
+     DO k = 1,km
+         IF ( self%SpeciesConcentration%concentration(ic)%pArray3D(i,j,k) > self%HNO3Ice_MAX*1.00E-09 ) THEN
+           PRINT*,'TRAP HNO3COND ', &
+                   self%SpeciesConcentration%concentration(ic)%pArray3D(i,j,k)*1.00E+09, &
+                   latDeg(i,j), lonDeg(i,j), press3c(i,j,k)
+         END IF
+     END DO
+     END DO
+     END DO
      status = 1
      VERIFY_(status)
     END IF
@@ -975,6 +986,17 @@ CONTAINS
     r = MAXVAL(self%SpeciesConcentration%concentration(ic)%pArray3D(:,:,:))
     IF(r > self%HCl_MAX*1.00E-09) THEN
      PRINT *,TRIM(Iam)//": Found HCl above limit: ",r*1.00E+09," ppbv"
+     DO i = i1,i2
+     DO j = j1,j2
+     DO k = 1,km
+         IF ( self%SpeciesConcentration%concentration(ic)%pArray3D(i,j,k) > self%HCl_MAX*1.00E-09 ) THEN
+           PRINT*,'TRAP HCl ', &
+                   self%SpeciesConcentration%concentration(ic)%pArray3D(i,j,k)*1.00E+09, &
+                   latDeg(i,j), lonDeg(i,j), press3c(i,j,k)
+         END IF
+     END DO
+     END DO
+     END DO
      status = 1
      VERIFY_(status)
     END IF
@@ -993,7 +1015,7 @@ CONTAINS
    DEALLOCATE(tropopausePress, STAT=STATUS)
    VERIFY_(STATUS)
 
-   DEALLOCATE(pl, press3c, press3e, kel, STAT=STATUS)
+   DEALLOCATE(pl, press3c, press3e, kel, latDeg, lonDeg, STAT=STATUS)
    VERIFY_(STATUS)
 
 ! IMPORTANT: Reset this switch to .TRUE. after first pass.

--- a/GMIchem_GridComp/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
@@ -755,6 +755,7 @@ CONTAINS
          !--------------------------------------------------------
          ! Calculate the air density at the center of each grid box
          ! (molecules/cm^3).
+         ! NOTE: BOLTZMN_E units = erg/K/molec
          !--------------------------------------------------------
 
           self%SpeciesConcentration%concentration(IMGAS)%pArray3D(:,:,:) =  &


### PR DESCRIPTION
New flag controls whether GMI feeds back QV value to rest of model (default TRUE); improved diagnostic print statements; fixed memory leak in GMI.  This largely brings the code in line with Icarus tag MEM_24.  All changes are zero-diff.