### PR TITLE
new Runtime_Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Added new Runtime_Registry module in Shared/Chem_Base, for Chem children to use instead of Chem_Registry.
+
 ### Removed
 
 - Removed diagnostic messages for GMI isoprene emissions
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GMI photolysis now uses "random cloud overlap" instead of "maximal overlap"
 - GMI now enforces a floor value for transported species
+- TR now uses Runtime_Registry instead of Chem_Registry
 
 ### Fixed
 

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -515,7 +515,9 @@ contains
      ! First test - add O3 and the species needed to compute O3 loss
      ! Later, parse the TR .rc files to determine the fields we need
      CALL MAPL_AddConnectivity ( GC, &
-          SHORT_NAME  = (/'OX    ', 'QQK007', 'QQK027', 'QQK028', 'DD_OX ', 'QQK005', &
+            SRC_NAME  = (/'OX    ', 'QQK007', 'QQK027', 'QQK028', 'DD_OX ', 'QQK005', &
+                          'QQK235', 'QQK170', 'QQK216', 'QQK179', 'QQK150'/), &
+            DST_NAME  = (/'OX_TR ', 'QQK007', 'QQK027', 'QQK028', 'DD_OX ', 'QQK005', &
                           'QQK235', 'QQK170', 'QQK216', 'QQK179', 'QQK150'/), &
           DST_ID = TR, SRC_ID = GMICHEM, __RC__  )
   ENDIF

--- a/Shared/Chem_Base/CMakeLists.txt
+++ b/Shared/Chem_Base/CMakeLists.txt
@@ -2,6 +2,7 @@ esma_set_this ()
 
 set (srcs
   Chem_RegistryMod.F90
+  Runtime_RegistryMod.F90
   Chem_ArrayMod.F90
   Chem_BundleMod.F90
   Chem_Mod.F90

--- a/Shared/Chem_Base/Runtime_RegistryMod.F90
+++ b/Shared/Chem_Base/Runtime_RegistryMod.F90
@@ -1,0 +1,342 @@
+#include "MAPL_Generic.h"
+
+!-------------------------------------------------------------------------
+!      NASA/GSFC, Atmospheric Chemistry and Dynamics Lab, Code 614       !
+!-------------------------------------------------------------------------
+!BOP
+!
+! !MODULE:  Runtime_RegistryMod --- Chemistry Registry Class
+!
+! !INTERFACE:
+!
+
+   module  Runtime_RegistryMod
+
+! !USES:
+
+   USE ESMF
+   USE MAPL
+
+   implicit none
+
+! !PUBLIC TYPES:
+!
+   PRIVATE
+   PUBLIC  Runtime_Registry  ! A listing of species, units and long names
+                           
+!
+! !PUBLIIC MEMBER FUNCTIONS:
+!
+   PUBLIC  Runtime_RegistryCreate   ! Constructor from RC file
+   PUBLIC  Runtime_RegistryDestroy  ! Destructor
+   PUBLIC  Runtime_RegistryPrint    ! Prints a summary of the registry
+
+!
+! !DESCRIPTION:
+!
+!  This module implements a simple registry.
+!
+!
+! !REVISION HISTORY:
+!
+!  2022.08.26  Manyin  First crack
+!
+!EOP
+!-------------------------------------------------------------------------
+
+  integer, parameter :: REGISTER_NAME_LENGTH     = 32
+  integer, parameter :: REGISTER_UNITS_LENGTH    = 32
+  integer, parameter :: REGISTER_LONGNAME_LENGTH = 64
+
+! integer, parameter :: RC_DATA_LINE    = 0
+! integer, parameter :: RC_END_OF_TABLE = 1
+! integer, parameter :: RC_END_OF_FILE  = 2
+
+! Registry
+! --------
+  type Runtime_Registry
+
+     integer :: nq    ! Total number of tracers 
+
+     character(len=REGISTER_NAME_LENGTH),     pointer :: vname(:)   ! (nq), variable short name
+     character(len=REGISTER_UNITS_LENGTH),    pointer :: vunits(:)  ! (nq), variable units
+     character(len=REGISTER_LONGNAME_LENGTH), pointer :: vtitle(:)  ! (nq), variable long  name
+
+  end type Runtime_Registry
+
+CONTAINS
+
+!------------------------------------------------------------------------
+!     NASA/GSFC, Atmospheric Chemistry and Dynamics Lab, Code 614       !
+!------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE:  Runtime_RegistryCreate --- Construct Chemistry Registry
+!
+! !INTERFACE:
+!
+
+  Function Runtime_RegistryCreate ( rcfile, table_name, rc )
+
+  implicit none
+  type(Runtime_Registry) Runtime_RegistryCreate 
+
+! !USES:
+
+! !INPUT PARAMETERS:
+
+   character(len=*), intent(in) :: rcfile      ! Resource file name
+   character(len=*), intent(in) :: table_name  ! includes '::'
+
+! !OUTPUT PARAMETERS:
+
+   integer, intent(out) ::  rc            ! Error return code:
+                                          !  0 - all is well
+
+! !DESCRIPTION:
+!
+!
+! !REVISION HISTORY:
+!
+!  2022.08.26  Manyin  First crack
+!
+!EOP
+!-------------------------------------------------------------------------
+
+  ! Possible return codes from get_line:
+  integer, parameter :: RC_DATA_LINE    = 1
+  integer, parameter :: RC_END_OF_TABLE = 2
+  integer, parameter :: RC_END_OF_FILE  = 3
+
+  integer, parameter :: TOKEN_LENGTH  = 256
+
+    __Iam__('Runtime_RegistryCreate')   ! NOTE: this macro declares STATUS
+                                        ! ALSO: Never set Iam = TRIM(Iam) // suffix
+                                        !       because Iam is a SAVED varaible
+
+   character(len=*), parameter ::  myname = 'Runtime_RegistryCreate'
+
+   character(len=TOKEN_LENGTH) ::  str_arr(3)
+
+   type(ESMF_Config)  ::  cf
+
+   type(Runtime_Registry) :: this
+   integer :: nq, item_count, retcode
+   integer :: i
+
+   rc = 0
+   str_arr(:) = ""
+                
+   cf = ESMF_ConfigCreate(__RC__)
+
+   call ESMF_ConfigLoadFile(cf, rcfile, rc=rc)
+   _ASSERT(rc==0, TRIM(Iam)//': Cannot load RC file '//TRIM(rcfile))
+
+   call ESMF_ConfigGetAttribute(cf, nq, label='tracer_count:', rc=rc)
+   _ASSERT(rc==0, TRIM(Iam)//': Cannot find tracer_count in file '//TRIM(rcfile))
+
+!  Allocate memory in registry
+!  ---------------------------
+   this%nq = nq
+   allocate ( this%vname(nq), this%vunits(nq), this%vtitle(nq), __STAT__ )
+
+   call ESMF_ConfigFindLabel(cf, table_name, rc=rc)
+   _ASSERT(rc==0, TRIM(Iam)//': Cannot find '//TRIM(table_name)//' in file '//TRIM(rcfile))
+
+   do i=1,nq
+      call get_line ( cf, 3, str_arr, item_count, retcode )
+      select case( retcode )
+        case( RC_END_OF_FILE  )
+          _ASSERT(.FALSE., TRIM(Iam)//': early EOF in file '//TRIM(rcfile))
+        case( RC_END_OF_TABLE )
+          _ASSERT(.FALSE., TRIM(Iam)//': table too short '//TRIM(table_name)//' in file '//TRIM(rcfile))
+        case( RC_DATA_LINE    )
+          _ASSERT(item_count==3, TRIM(Iam)//': fewer than 3 entries in '//TRIM(table_name)//' in file '//TRIM(rcfile))
+          this%vname(i)  = str_arr(1)
+          this%vunits(i) = str_arr(2)
+          this%vtitle(i) = str_arr(3)
+      end select
+   end do
+
+   call ESMF_ConfigDestroy(cf, __RC__)
+
+!  All done
+!  --------
+   Runtime_RegistryCreate = this
+   
+   return 
+
+!                 -----------------
+!                 Internal Routines
+!                 -----------------
+
+   CONTAINS
+
+!     -------------------
+!     GET_LINE
+!     Advance one line and then try to read <expected_entries> items
+!     Retcode will be set to one of these values:
+!       RC_END_OF_FILE    - cannot advance a line
+!       RC_END_OF_TABLE   - first item is '::'
+!       RC_DATA_LINE      - at least one entry has been put into str_arr
+!     Note that ESMF automatically skips over blank lines and comment lines
+!     -------------------
+      subroutine get_line ( cf, expected_entries, str_arr, item_count, retcode )
+!     -------------------
+      type(ESMF_Config),           intent(inout)  :: cf
+      integer,                     intent(in)     :: expected_entries  ! read this many items
+      character(len=TOKEN_LENGTH), intent(out)    :: str_arr(*)   ! space for one or more items
+      integer,                     intent(out)    :: item_count   ! how many were successfully read
+      integer,                     intent(out)    :: retcode      ! see possible values above
+
+      integer :: i
+
+      call ESMF_ConfigNextLine(cf, rc=rc)
+      if ( rc/=0 ) then
+        retcode = RC_END_OF_FILE
+        return
+      end if
+
+      ! Because ESMF skips over blank lines, rc should always be 0:
+      call ESMF_ConfigGetAttribute(cf, str_arr(1), rc=rc)
+      if ( rc/=0 ) then
+        retcode = RC_END_OF_FILE
+        return
+      end if
+      if ( INDEX(str_arr(1), '::' ) == 1 ) then
+        retcode = RC_END_OF_TABLE
+        return
+      end if
+
+      retcode = RC_DATA_LINE
+      item_count = 1
+      do i=2,expected_entries
+        call ESMF_ConfigGetAttribute(cf, str_arr(i), rc=rc)
+        if (rc==0) item_count = item_count + 1
+      end do
+
+      return
+      
+      end subroutine get_line
+
+ end Function Runtime_RegistryCreate
+
+!------------------------------------------------------------------------
+!     NASA/GSFC, Atmospheric Chemistry and Dynamics Lab, Code 614       !
+!------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE:  Runtime_RegistryDestroy --- Destruct Chemisty Registry
+!
+! !INTERFACE:
+!
+  subroutine Runtime_RegistryDestroy ( this, rc )
+
+! !USES:
+
+  implicit none
+
+! !INPUT/OUTPUT PARAMETERS:
+
+   type(Runtime_Registry), intent(inout) :: this
+
+! !OUTPUT PARAMETERS:
+
+  integer, intent(out)          ::  rc     ! Error return code:
+                                           !  0 - all is well
+                                           !  1 - 
+
+! !DESCRIPTION: Destructor for Registry object.
+!
+! !REVISION HISTORY:
+!
+!  2022.08.26  Manyin  First crack
+!
+!EOP
+!-------------------------------------------------------------------------
+
+   __Iam__('Runtime_RegistryDestroy')   ! NOTE: this macro declares STATUS
+
+   rc = 0
+   this%nq = -1 
+   deallocate ( this%vname, this%vunits, this%vtitle, __STAT__ )
+
+end subroutine Runtime_RegistryDestroy 
+
+
+!-------------------------------------------------------------------------
+!     NASA/GSFC, Global Modeling and Assimilation Office, Code 900.3     !
+!-------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE:  Runtime_RegistryPrint --- Print summary of Chemistry Registry
+!
+! !INTERFACE:
+!
+   SUBROUTINE Runtime_RegistryPrint( reg, mod_name )
+
+! !USES:
+
+! !INPUT PARAMETERS:
+
+   IMPLICIT none
+   TYPE(Runtime_Registry) :: reg
+   character(len=*)       :: mod_name  ! name of the calling module
+
+! !OUTPUT PARAMETERS:
+
+
+! !DESCRIPTION:
+!
+!   Prints summary of Chemistry Registry
+!
+! !REVISION HISTORY:
+!
+!  2022.08.26  Manyin  First crack
+!
+!EOP
+!-------------------------------------------------------------------------
+
+   PRINT *
+   PRINT *,'****'
+   PRINT *,'****       Summary of the '//mod_name//' Registry'
+   PRINT *,'****            from Runtime_RegistryPrint'
+   PRINT *,'****'
+   WRITE(*,FMT="(' ','       Number of species: ',I3)") reg%nq
+
+   CALL reg_prt_( mod_name, reg%nq )
+
+   PRINT *
+
+  101 FORMAT(/,'       Number of species: ',I3)
+
+   RETURN
+   
+   CONTAINS
+   
+      SUBROUTINE reg_prt_ ( compName, n )
+      
+      IMPLICIT none
+      CHARACTER(LEN=*), INTENT(IN) :: compName
+      INTEGER, INTENT(IN) :: n
+      INTEGER :: i
+      CHARACTER(LEN=7) :: string
+      
+      string = 'species'
+      
+      WRITE(*,101) TRIM(compName),n,string
+      DO i = 1, n
+       WRITE(*,201) i,TRIM(reg%vname(i)),TRIM(reg%vunits(i)),TRIM(reg%vtitle(i))
+      END DO
+
+  101 FORMAT(/,' Component ',A,' has ',I3,' ',A7,/, &
+	     ' No ',2X,'  Name  ',2X,'   Units  ',2X,'Description',/, &
+	     ' ---',2X,'--------',2X,'----------',2X,'-----------')
+  201 FORMAT(' ',I3,2X,A8,2X,A10,2X,A)
+          
+  END SUBROUTINE reg_prt_
+  
+END SUBROUTINE Runtime_RegistryPrint
+
+ end module Runtime_RegistryMod
+

--- a/TR_GridComp/TR_ExtData.rc
+++ b/TR_GridComp/TR_ExtData.rc
@@ -38,6 +38,19 @@ TR_regionMask               NA        N    V          -                none     
 TR_regionMask2              NA        N    V          -                none      none      REGION_MASK       ExtData/AeroCom/sfc/ARCTAS.region_mask.x540_y361.2008.nc
 #HTAP2_REGION_MASK          NA        N    V          -                none      none      region_map        ExtData/g5chem/sfc/HTAP2.region_map.x720_y360.nc4
 HTAP2_REGION_MASK_COASTAL_MOD  NA     N    V          -                none      none      region_map        ExtData/g5chem/sfc/HTAP2.region_map_modified_coastlines.x720_y360.nc4
+# In case GMI is not running; this is a temporary fix:
+OX_TR                    'none'       N    N          -                none      none      NA                /dev/null
+QQK007                   'none'       N    N          -                none      none      NA                /dev/null
+QQK027                   'none'       N    N          -                none      none      NA                /dev/null
+QQK028                   'none'       N    N          -                none      none      NA                /dev/null
+DD_OX                    'none'       N    N          -                none      none      NA                /dev/null
+QQK005                   'none'       N    N          -                none      none      NA                /dev/null
+QQK235                   'none'       N    N          -                none      none      NA                /dev/null
+QQK170                   'none'       N    N          -                none      none      NA                /dev/null
+QQK216                   'none'       N    N          -                none      none      NA                /dev/null
+QQK179                   'none'       N    N          -                none      none      NA                /dev/null
+QQK150                   'none'       N    N          -                none      none      NA                /dev/null
+#
 # -------------|--------------|-----|----|----|---|----------------------|--------|-----------|------------------|----------------------   
 %%
 

--- a/TR_GridComp/TR_ExtData.yaml
+++ b/TR_GridComp/TR_ExtData.yaml
@@ -38,6 +38,10 @@ Samplings:
     update_reference_time: '0'
   TR_sample_1:
     extrapolation: persist_closest
+  TR_sample_2:
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
 
 Exports:
   CO_CMIP6_ANTHRO:
@@ -65,11 +69,33 @@ Exports:
     regrid: CONSERVE
     sample: TR_sample_0
     variable: co_bionmvoc
+  DD_OX:
+    collection: /dev/null
   HTAP2_REGION_MASK_COASTAL_MOD:
     collection: TR_HTAP2.region_map_modified_coastlines.x720_y360.nc4
     regrid: VOTE
     sample: TR_sample_1
     variable: region_map
+  OX_TR:
+    collection: /dev/null
+  QQK005:
+    collection: /dev/null
+  QQK007:
+    collection: /dev/null
+  QQK027:
+    collection: /dev/null
+  QQK028:
+    collection: /dev/null
+  QQK150:
+    collection: /dev/null
+  QQK170:
+    collection: /dev/null
+  QQK179:
+    collection: /dev/null
+  QQK216:
+    collection: /dev/null
+  QQK235:
+    collection: /dev/null
   SRC_2D_CH3I:
     collection: TR_unity.x144_y91.nc
     linear_transformation:
@@ -154,4 +180,52 @@ Exports:
     regrid: VOTE
     sample: TR_sample_1
     variable: REGION_MASK
+
+Derived:
+  SRC_2D_CO_ANZ:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_ARC:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_CAM:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_CAS:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_EAS:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_EUR:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_GLB:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_MDE:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_NAF:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_NAM:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_RAF:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_RBU:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_SAM:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_SAS:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+  SRC_2D_CO_SEA:
+    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
+    sample: TR_sample_2
+
 

--- a/TR_GridComp/TR_Registry.rc
+++ b/TR_GridComp/TR_Registry.rc
@@ -1,0 +1,71 @@
+#------------------------------------------------------------------------
+#BOP
+#
+# !RESOURCE: TR_Registry --- Passive Tracer Run-time Registry
+# 
+# !HELP:
+#
+#  This Registry lists the TR species to be run.
+#  It includes Name, Units and Long_name for each.
+#  This is sufficient information for calling MAPL_AddInternalSpec.
+#  It is read by routines in Runtime_RegistryMod.F90.
+#  
+#  Only the first 'tracer_count' species from the table will be run.
+#  
+#  Each species has an additional list of parameters in its
+#  own specific resource file TR_GridComp---<species_name>.rc
+#
+# !REVISION HISTORY:
+#
+#  2022.08.26  Manyin   First crack
+#
+#-----------------------------------------------------------------------
+#EOP
+
+tracer_count: 4
+
+TR_table::
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+aoa          days       'Age of air (uniform source) tracer'
+e90       'mol mol-1'   'Constant burden 90 day tracer'
+Rn222     'kg kg-1'     'Radon-222'
+CH3I      'mol mol-1'   'Methyl iodide'
+Pb210     'kg kg-1'     'Lead-210'
+nh_5      'mol mol-1'   'Northern Hemisphere 5 day tracer'
+nh_50     'mol mol-1'   'Northern Hemisphere 50 day tracer'
+aoa_nh       days       'Age of air northern hemisphere tracer'
+st80_25   'mol mol-1'   'Stratospheric source 25 day tracer'
+CO_25     'mol mol-1'   'Anthro CO 25 day tracer'
+CO_50     'mol mol-1'   'Anthro CO 50 day tracer'
+CO_50_ea  'mol mol-1'   'Anthro CO 50 day tracer East Asia'
+CO_50_na  'mol mol-1'   'Anthro CO 50 day tracer North America'
+CO_50_eu  'mol mol-1'   'Anthro CO 50 day tracer Europe'
+CO_50_sa  'mol mol-1'   'Anthro CO 50 day tracer South Asia'
+SF6       'mol mol-1'   'Sulfur Hexafluoride tracer'
+e90_n     'mol mol-1'   'Constant burden 90 day tracer 40N-pole emiss'
+e90_s     'mol mol-1'   'Constant burden 90 day tracer 40S-pole emiss'
+Be7       'kg kg-1'     'Beryllium radionuclide 7(Be)'
+Be10      'kg kg-1'     'Beryllium radionuclide 10(Be)'
+Be7s      'kg kg-1'     'Beryllium radionuclide 7(Be) strat-source'
+Be10s     'kg kg-1'     'Beryllium radionuclide 10(Be) strat-source'
+Pb210s    'kg kg-1'     'Lead-210 strat-source'
+CO_GLB    'mol mol-1'   'CO 50 day tracer Global CMIP6+M2G'
+CO_NAM    'mol mol-1'   'CO 50 day tracer North America CMIP6+M2G'
+CO_EUR    'mol mol-1'   'CO 50 day tracer Europe CMIP6+M2G'
+CO_SAS    'mol mol-1'   'CO 50 day tracer South Asia CMIP6+M2G'
+CO_EAS    'mol mol-1'   'CO 50 day tracer East Asia CMIP6+M2G'
+CO_SEA    'mol mol-1'   'CO 50 day tracer Southeast Asia CMIP6+M2G'
+CO_ANZ    'mol mol-1'   'CO 50 day tracer Australia & New Zealand CMIP6+M2G'
+CO_NAF    'mol mol-1'   'CO 50 day tracer North Africa CMIP6+M2G'
+CO_RAF    'mol mol-1'   'CO 50 day tracer Rest of Africa CMIP6+M2G'
+CO_MDE    'mol mol-1'   'CO 50 day tracer Middle East CMIP6+M2G'
+CO_CAM    'mol mol-1'   'CO 50 day tracer Central America CMIP6+M2G'
+CO_SAM    'mol mol-1'   'CO 50 day tracer South America CMIP6+M2G'
+CO_RBU    'mol mol-1'   'CO 50 day tracer Russia & Belarus & Ukraine CMIP6+M2G'
+CO_CAS    'mol mol-1'   'CO 50 day tracer Central Asia CMIP6+M2G'
+CO_ARC    'mol mol-1'   'CO 50 day tracer Arctic CMIP6+M2G'
+CO_from_CH4 'mol mol-1' 'CO from global average CH4 oxidation'
+stOX      'mol mol-1'   'Strat Ozone with chemical loss'
+aoa_bl       days       'Age of air above boundary layer'
+::


### PR DESCRIPTION
Introduced a new Runtime Registry module, which is a simplified version of Chem_Registry, usable by any child of the Chemistry GridComp. The Runtime Registry is entirely ESMF- and MAPL-based.  TR has been refactored to use this new registry, with zero-diff.