### PR TITLE
Delete the parts of Chem_Registry related to TR, now handled separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+### Removed
+### Changed
+### Fixed
+
+## [1.10.1] - 2022-08-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed diagnostic messages for GMI isoprene emissions
+- Removed code related to TR from Chem_Registry; now handled with Runtime_Registry
 
 ### Changed
 

--- a/Shared/Chem_Base/AMIP/Chem_Registry.rc
+++ b/Shared/Chem_Base/AMIP/Chem_Registry.rc
@@ -16,10 +16,6 @@
 #  NOTES: The water vapor and ozone tracers are not really being used
 #         in GEOS-5. They are still kept for compatibility with GEOS-4.
 #
-#         Beginning with Heracles-1_0, four TR tracers are enabled in the 
-#         default configuration. For the complete list of TR tracers, see 
-#         Chem_MieRegistry.rc.
-#
 #         StratChem can be run with Full or Reduced equation sets.
 #         When running Full,    the string SC_f should be changed to SC.
 #         When running Reduced, the string SC_r should be changed to SC.
@@ -63,7 +59,6 @@ doing_GMI: no   # &YesNo GMI chemistry (GEOS-5)
 doing_XX:  no   # &YesNo generic tracer
 doing_PC:  yes  # parameterized chemistry (GEOS-5)
 doing_OCS: no   # ACHEM chemistry (OCS)
-doing_TR:  yes  # &YesNo run passive tracers?
 
 # You can select the number of bins (e.g., particle size)
 # for each of the constituents. Note nbins>1 may not be
@@ -91,7 +86,6 @@ nbins_PC:       1   # parameterized chemistry (GEOS-5)
 nbins_GMI:     72   # GMI chemistry (GEOS-5)
 nbins_XX_GMI:  48   # generic tracer
 nbins_OCS:      1   # ACHEM chemistry (OCS)
-nbins_TR:       4   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -114,7 +108,6 @@ units_XX:  'mol mol-1'   # generic tracer
 units_PC:  'kg kg-1'     # parameterized chemistry (GEOS-5)
 units_GMI: 'mol mol-1'   # GMI chemistry (GEOS-5)
 units_OCS: 'kg kg-1'     # ACHEM chemistry (OCS)
-units_TR:  'mol mol-1'   # passive tracers
 
 # Variable names to override defaults.  Optional.  Name and Units must 
 # be 1 token. Long names can be more than one token.
@@ -535,54 +528,6 @@ NUMDENS     cm-3        Total number density
 T2M15d      K           Daily T2M time average
 ::
 
-variable_table_TR::
-
-# Name     Units        Long Name
-# -----    ------       --------------------------------
-aoa          days       Age of air (uniform source) tracer
-e90       'mol mol-1'   Constant burden 90 day tracer
-Rn222     'kg kg-1'     Radon-222
-CH3I      'mol mol-1'   Methyl iodide
-Pb210     'kg kg-1'     Lead-210
-nh_5      'mol mol-1'   Northern Hemisphere 5 day tracer
-nh_50     'mol mol-1'   Northern Hemisphere 50 day tracer
-aoa_nh       days       Age of air northern hemisphere tracer
-st80_25   'mol mol-1'   Stratospheric source 25 day tracer
-CO_25     'mol mol-1'   Anthro CO 25 day tracer
-CO_50     'mol mol-1'   Anthro CO 50 day tracer
-CO_50_ea  'mol mol-1'   Anthro CO 50 day tracer East Asia
-CO_50_na  'mol mol-1'   Anthro CO 50 day tracer North America
-CO_50_eu  'mol mol-1'   Anthro CO 50 day tracer Europe
-CO_50_sa  'mol mol-1'   Anthro CO 50 day tracer South Asia
-SF6       'mol mol-1'   Sulfur Hexafluoride tracer
-e90_n     'mol mol-1'   Constant burden 90 day tracer 40N-pole emiss
-e90_s     'mol mol-1'   Constant burden 90 day tracer 40S-pole emiss
-Be7       'kg kg-1'     Beryllium radionuclide 7(Be)
-Be10      'kg kg-1'     Beryllium radionuclide 10(Be)
-Be7s      'kg kg-1'     Beryllium radionuclide 7(Be) strat-source
-Be10s     'kg kg-1'     Beryllium radionuclide 10(Be) strat-source
-Pb210s    'kg kg-1'     Lead-210 strat-source
-CO_GLB    'mol mol-1'   CO 50 day tracer Global CMIP6+M2G
-CO_NAM    'mol mol-1'   CO 50 day tracer North America CMIP6+M2G
-CO_EUR    'mol mol-1'   CO 50 day tracer Europe CMIP6+M2G
-CO_SAS    'mol mol-1'   CO 50 day tracer South Asia CMIP6+M2G
-CO_EAS    'mol mol-1'   CO 50 day tracer East Asia CMIP6+M2G
-CO_SEA    'mol mol-1'   CO 50 day tracer Southeast Asia CMIP6+M2G
-CO_ANZ    'mol mol-1'   CO 50 day tracer Australia & New Zealand CMIP6+M2G
-CO_NAF    'mol mol-1'   CO 50 day tracer North Africa CMIP6+M2G
-CO_RAF    'mol mol-1'   CO 50 day tracer Rest of Africa CMIP6+M2G
-CO_MDE    'mol mol-1'   CO 50 day tracer Middle East CMIP6+M2G
-CO_CAM    'mol mol-1'   CO 50 day tracer Central America CMIP6+M2G
-CO_SAM    'mol mol-1'   CO 50 day tracer South America CMIP6+M2G
-CO_RBU    'mol mol-1'   CO 50 day tracer Russia & Belarus & Ukraine CMIP6+M2G
-CO_CAS    'mol mol-1'   CO 50 day tracer Central Asia CMIP6+M2G
-CO_ARC    'mol mol-1'   CO 50 day tracer Arctic CMIP6+M2G
-CO_from_CH4 'mol mol-1' CO from global average CH4 oxidation
-stOX      'mol mol-1'   Strat Ozone with chemical loss
-aoa_bl       days       Age of air above boundary layer
-::
-
-
 #........................................................................
 
 #               -------------------
@@ -610,7 +555,6 @@ advect_XX:  no   # generic tracer
 advect_PC:  yes  # parameterized chemistry (GEOS-5)
 advect_GMI: yes  # GMI chemistry (GEOS-5)
 advect_OCS: yes  # ACHEM chemistry (OCS)
-advect_TR:  yes  # passive tracers
 
 # Whether to diffuse the constituent
 # ----------------------------------
@@ -634,5 +578,4 @@ diffuse_XX:  yes  # generic tracer
 diffuse_PC:  yes  # parameterized chemistry (GEOS-5)
 diffuse_GMI: yes  # GMI chemistry (GEOS-5)
 diffuse_OCS: yes  # ACHEM chemistry (OCS)
-diffuse_TR:  yes  # passive tracers
 

--- a/Shared/Chem_Base/Chem_Registry.rc
+++ b/Shared/Chem_Base/Chem_Registry.rc
@@ -16,10 +16,6 @@
 #  NOTES: The water vapor and ozone tracers are not really being used
 #         in GEOS-5. They are still kept for compatibility with GEOS-4.
 #
-#         Beginning with Heracles-1_0, four TR tracers are enabled in the 
-#         default configuration. For the complete list of TR tracers, see 
-#         Chem_MieRegistry.rc.
-#
 #         StratChem can be run with Full or Reduced equation sets.
 #         When running Full,    the string SC_f should be changed to SC.
 #         When running Reduced, the string SC_r should be changed to SC.
@@ -63,7 +59,6 @@ doing_GMI: no   # &YesNo GMI chemistry (GEOS-5)
 doing_XX:  no   # &YesNo generic tracer
 doing_PC:  yes  # parameterized chemistry (GEOS-5)
 doing_OCS: no   # ACHEM chemistry (OCS)
-doing_TR:  yes  # &YesNo run passive tracers?
 
 # You can select the number of bins (e.g., particle size)
 # for each of the constituents. Note nbins>1 may not be
@@ -91,7 +86,6 @@ nbins_PC:       1   # parameterized chemistry (GEOS-5)
 nbins_GMI:     72   # GMI chemistry (GEOS-5)
 nbins_XX_GMI:  48   # generic tracer
 nbins_OCS:      1   # ACHEM chemistry (OCS)
-nbins_TR:       4   # passive tracers
 
 # Units for each constituent
 # --------------------------
@@ -114,7 +108,6 @@ units_XX:  'mol mol-1'   # generic tracer
 units_PC:  'kg kg-1'     # parameterized chemistry (GEOS-5)
 units_GMI: 'mol mol-1'   # GMI chemistry (GEOS-5)
 units_OCS: 'kg kg-1'     # ACHEM chemistry (OCS)
-units_TR:  'mol mol-1'   # passive tracers
 
 # Variable names to override defaults.  Optional.  Name and Units must 
 # be 1 token. Long names can be more than one token.
@@ -535,54 +528,6 @@ NUMDENS     cm-3        Total number density
 T2M15d      K           Daily T2M time average
 ::
 
-variable_table_TR::
-
-# Name     Units        Long Name
-# -----    ------       --------------------------------
-aoa          days       Age of air (uniform source) tracer
-e90       'mol mol-1'   Constant burden 90 day tracer
-Rn222     'kg kg-1'     Radon-222
-CH3I      'mol mol-1'   Methyl iodide
-Pb210     'kg kg-1'     Lead-210
-nh_5      'mol mol-1'   Northern Hemisphere 5 day tracer
-nh_50     'mol mol-1'   Northern Hemisphere 50 day tracer
-aoa_nh       days       Age of air northern hemisphere tracer
-st80_25   'mol mol-1'   Stratospheric source 25 day tracer
-CO_25     'mol mol-1'   Anthro CO 25 day tracer
-CO_50     'mol mol-1'   Anthro CO 50 day tracer
-CO_50_ea  'mol mol-1'   Anthro CO 50 day tracer East Asia
-CO_50_na  'mol mol-1'   Anthro CO 50 day tracer North America
-CO_50_eu  'mol mol-1'   Anthro CO 50 day tracer Europe
-CO_50_sa  'mol mol-1'   Anthro CO 50 day tracer South Asia
-SF6       'mol mol-1'   Sulfur Hexafluoride tracer
-e90_n     'mol mol-1'   Constant burden 90 day tracer 40N-pole emiss
-e90_s     'mol mol-1'   Constant burden 90 day tracer 40S-pole emiss
-Be7       'kg kg-1'     Beryllium radionuclide 7(Be)
-Be10      'kg kg-1'     Beryllium radionuclide 10(Be)
-Be7s      'kg kg-1'     Beryllium radionuclide 7(Be) strat-source
-Be10s     'kg kg-1'     Beryllium radionuclide 10(Be) strat-source
-Pb210s    'kg kg-1'     Lead-210 strat-source
-CO_GLB    'mol mol-1'   CO 50 day tracer Global CMIP6+M2G
-CO_NAM    'mol mol-1'   CO 50 day tracer North America CMIP6+M2G
-CO_EUR    'mol mol-1'   CO 50 day tracer Europe CMIP6+M2G
-CO_SAS    'mol mol-1'   CO 50 day tracer South Asia CMIP6+M2G
-CO_EAS    'mol mol-1'   CO 50 day tracer East Asia CMIP6+M2G
-CO_SEA    'mol mol-1'   CO 50 day tracer Southeast Asia CMIP6+M2G
-CO_ANZ    'mol mol-1'   CO 50 day tracer Australia & New Zealand CMIP6+M2G
-CO_NAF    'mol mol-1'   CO 50 day tracer North Africa CMIP6+M2G
-CO_RAF    'mol mol-1'   CO 50 day tracer Rest of Africa CMIP6+M2G
-CO_MDE    'mol mol-1'   CO 50 day tracer Middle East CMIP6+M2G
-CO_CAM    'mol mol-1'   CO 50 day tracer Central America CMIP6+M2G
-CO_SAM    'mol mol-1'   CO 50 day tracer South America CMIP6+M2G
-CO_RBU    'mol mol-1'   CO 50 day tracer Russia & Belarus & Ukraine CMIP6+M2G
-CO_CAS    'mol mol-1'   CO 50 day tracer Central Asia CMIP6+M2G
-CO_ARC    'mol mol-1'   CO 50 day tracer Arctic CMIP6+M2G
-CO_from_CH4 'mol mol-1' CO from global average CH4 oxidation
-stOX      'mol mol-1'   Strat Ozone with chemical loss
-aoa_bl       days       Age of air above boundary layer
-::
-
-
 #........................................................................
 
 #               -------------------
@@ -610,7 +555,6 @@ advect_XX:  no   # generic tracer
 advect_PC:  yes  # parameterized chemistry (GEOS-5)
 advect_GMI: yes  # GMI chemistry (GEOS-5)
 advect_OCS: yes  # ACHEM chemistry (OCS)
-advect_TR:  yes  # passive tracers
 
 # Whether to diffuse the constituent
 # ----------------------------------
@@ -634,5 +578,4 @@ diffuse_XX:  yes  # generic tracer
 diffuse_PC:  yes  # parameterized chemistry (GEOS-5)
 diffuse_GMI: yes  # GMI chemistry (GEOS-5)
 diffuse_OCS: yes  # ACHEM chemistry (OCS)
-diffuse_TR:  yes  # passive tracers
 

--- a/Shared/Chem_Base/Chem_RegistryMod.F90
+++ b/Shared/Chem_Base/Chem_RegistryMod.F90
@@ -93,7 +93,6 @@
      logical :: doing_GMI   ! GMI Chemistry (GEOS-5)
      logical :: doing_OCS   ! ACHEM chemistry (OCS)
      logical :: doing_NI    ! Nitrate
-     logical :: doing_TR    ! passive tracers
 
 !    Number of bins and tracer index ranges for each constituent:
 !        n_TT - number of bins for tracer TT (n_TT = j_TT - i_TT + 1)
@@ -117,7 +116,6 @@
      integer :: n_GMI, i_GMI, j_GMI  ! GMI chemistry (GEOS-5)
      integer :: n_OCS, i_OCS, j_OCS  ! OCS chemistry (ACHEM)
      integer :: n_NI, i_NI, j_NI     ! Nitrate
-     integer :: n_TR, i_TR, j_TR     ! passive tracers
 
 !    GEOS-5 Short-hands: all combined tracers from CO to OC
 !    ------------------------------------------------------
@@ -143,7 +141,6 @@
      character(len=nch) :: units_GMI   ! GMI chemistry (GEOS-5)
      character(len=nch) :: units_OCS   ! OCS chemistry (ACHEM)
      character(len=nch) :: units_NI    ! Nitrate
-     character(len=nch) :: units_TR    ! passive tracers
 
 !    CF Style metadata
 !    -----------------
@@ -257,7 +254,6 @@ CONTAINS
    call parserc_ ( 'XX', this%doing_XX, this%n_XX, this%units_XX )
    call parserc_ ( 'PC', this%doing_PC, this%n_PC, this%units_PC )
    call parserc_ ( 'OCS', this%doing_OCS, this%n_OCS, this%units_OCS )
-   call parserc_ ( 'TR', this%doing_TR, this%n_TR, this%units_TR )
 
 !  Set internal indices
 !  --------------------
@@ -280,7 +276,6 @@ CONTAINS
    call setidx_ ( this%doing_XX, this%n_XX, this%i_XX, this%j_XX )
 !  call setidx_ ( this%doing_PC, this%n_PC, this%i_PC, this%j_PC )
    call setidx_ ( this%doing_OCS, this%n_OCS, this%i_OCS, this%j_OCS )
-   call setidx_ ( this%doing_TR, this%n_TR, this%i_TR, this%j_TR )
 
 !  Allocate memory in registry
 !  ---------------------------
@@ -344,8 +339,6 @@ CONTAINS
 !                  this%units_PC,  this%i_PC, this%j_PC )
    call setmeta_ ( this%doing_OCS,  'ocs', 'Carbonyl Sulfide', &
                    this%units_OCS,  this%i_OCS, this%j_OCS )
-   call setmeta_ ( this%doing_TR,  'TR', 'Passive Tracers', &
-                   this%units_TR,  this%i_TR, this%j_TR )
 		   
    call I90_Release()
 
@@ -608,7 +601,6 @@ RealNames: IF( ier .EQ. 0 ) THEN
    this%doing_OCS = .false.   ! ACHEM chemistry (OCS)
    this%doing_NI = .false.    ! Nitrate
    this%doing_GMI = .false.   ! GMI chemistry (GEOS-5)
-   this%doing_TR = .false.    ! passive tracers
    deallocate ( this%vname, this%vtitle, this%vunits, this%fscav, &
                 this%rhop, this%molwght, this%rlow, this%rup, this%rmed, &
                 this%sigma, this%fNum, this%Hcts, stat=ios )
@@ -682,7 +674,6 @@ end subroutine Chem_RegistryDestroy
    IF ( reg%doing_XX ) ActiveList = TRIM(ActiveList)//'  XX'
    IF ( reg%doing_PC ) ActiveList = TRIM(ActiveList)//'  PC'
    IF ( reg%doing_OCS ) ActiveList = TRIM(ActiveList)//'  OCS'
-   IF ( reg%doing_TR ) ActiveList = TRIM(ActiveList)//'  TR'
    
    PRINT *
    PRINT *, 'Active chemistry components:',TRIM(ActiveList)
@@ -706,7 +697,6 @@ end subroutine Chem_RegistryDestroy
    IF ( reg%doing_XX ) CALL reg_prt_( 'XX', reg%n_XX, reg%i_XX, reg%j_XX )
 !  IF ( reg%doing_PC ) CALL reg_prt_( 'PC', reg%n_PC, reg%i_PC, reg%j_PC )
    IF ( reg%doing_OCS ) CALL reg_prt_( 'OCS', reg%n_OCS, reg%i_OCS, reg%j_OCS )
-   IF ( reg%doing_TR ) CALL reg_prt_( 'TR', reg%n_TR, reg%i_TR, reg%j_TR )
 
    IF ( reg%doing_GOCART ) & 
         CALL reg_prt_( 'GOCART is a COMPOSITE and', &


### PR DESCRIPTION
This PR removes the superfluous code related to TR, in both the Chem_Registry module and resource files.
With the introduction of the Runtime Registry for TR, the old code is no longer needed.
This is zero-diff for all simulations.