### PR TITLE
Take GMI out of Chem_Registry.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+
+- Species_Bundle and Species_Array modules are simpler versions of the Chemistry counterparts
+
 ### Removed
 ### Changed
 
-- Updates to emissions from galactic cosmic rays
+- Updates to emissions from galactic cosmic rays in GMI
 - Minor improvement to Runtime_Registry module.
+- Broke away the GMI contents from Chem_Registry.rc, into a separate file 
 
 ### Fixed
 

--- a/GMIchem_GridComp/CMakeLists.txt
+++ b/GMIchem_GridComp/CMakeLists.txt
@@ -151,6 +151,7 @@ set ( rc_files
    GMI_GridComp/GMI_ExtData.yaml
    GMI_GridComp/GMI_GridComp.rc
    GMI_GridComp/GMI_Registry.rc
+   GMI_GridComp/GMI_Mech_Registry.rc
 )
 install (
    FILES ${rc_files}

--- a/GMIchem_GridComp/GMI_GridComp/GMI_GridCompMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_GridCompMod.F90
@@ -20,6 +20,8 @@
       USE Chem_Mod 	     ! Chemistry Base Class
       USE Chem_UtilMod
 
+      USE Species_BundleMod
+
       USE GmiSAD_GCCMod
       USE GmiChem_GCCMod
       USE GmiDepos_GCCMod
@@ -93,13 +95,14 @@
 !
 ! !INTERFACE:
 !
-   SUBROUTINE GMI_GridCompInitialize(gcGMI, w_c, impChem, expChem, nymd, nhms, cdt, gc, clock, rc)
+   SUBROUTINE GMI_GridCompInitialize(gcGMI, bgg, bxx, impChem, expChem, nymd, nhms, cdt, gc, clock, rc)
 !
    IMPLICIT none
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), INTENT(in) :: w_c         ! Chemical tracer fields, delp, +
+   TYPE(Species_Bundle), INTENT(in) :: bgg         ! Chemical tracer fields, delp, +
+   TYPE(Species_Bundle), INTENT(in) :: bxx         ! Chemical tracer fields, delp, +
    INTEGER,	      INTENT(in) :: nymd, nhms  ! Time from AGCM
    REAL, 	      INTENT(in) :: cdt         ! Chemistry time step (secs)
 
@@ -137,21 +140,21 @@
 !BOC
       rc = 0
 
-      CALL GmiEmiss_GridCompInitialize     (gcGMI%gcEmiss,     w_c, impChem, expChem, nymd, nhms, cdt, gc, clock, __RC__)
+      CALL GmiEmiss_GridCompInitialize     (gcGMI%gcEmiss,     bgg, bxx, impChem, expChem, nymd, nhms, cdt, gc, clock, __RC__)
 
-      CALL GmiDepos_GridCompInitialize     (gcGMI%gcDepos,     w_c, impChem, expChem, nymd, nhms, cdt,            __RC__)
+      CALL GmiDepos_GridCompInitialize     (gcGMI%gcDepos,     bgg, bxx, impChem, expChem, nymd, nhms, cdt,            __RC__)
 
-      CALL GmiSAD_GridCompInitialize       (gcGMI%gcSAD,       w_c, impChem, expChem, nymd, nhms, cdt,            __RC__)
+      CALL GmiSAD_GridCompInitialize       (gcGMI%gcSAD,       bgg, bxx, impChem, expChem, nymd, nhms, cdt,            __RC__)
 
-      CALL GmiPhotolysis_GridCompInitialize(gcGMI%gcPhot,      w_c, impChem, expChem, nymd, nhms, cdt,            __RC__)
+      CALL GmiPhotolysis_GridCompInitialize(gcGMI%gcPhot,      bgg, bxx, impChem, expChem, nymd, nhms, cdt,            __RC__)
 
-      CALL GmiForcingBC_GridCompInitialize (gcGMI%gcFBC,       w_c, impChem, expChem, nymd, nhms, cdt,            __RC__)
+      CALL GmiForcingBC_GridCompInitialize (gcGMI%gcFBC,       bgg, bxx, impChem, expChem, nymd, nhms, cdt,            __RC__)
 
-      CALL GmiThermalRC_GridCompInitialize (gcGMI%gcThermalRC, w_c, impChem, expChem, nymd, nhms, cdt,            __RC__)
+      CALL GmiThermalRC_GridCompInitialize (gcGMI%gcThermalRC, bgg, bxx, impChem, expChem, nymd, nhms, cdt,            __RC__)
 
-      CALL GmiChemistry_GridCompInitialize (gcGMI%gcChem,      w_c, impChem, expChem, nymd, nhms, cdt,            __RC__)
+      CALL GmiChemistry_GridCompInitialize (gcGMI%gcChem,      bgg, bxx, impChem, expChem, nymd, nhms, cdt,            __RC__)
 
-      CALL GmiEmiss_initSurfEmissBundle    (gcGMI%gcEmiss,     w_c,          expChem,                             __RC__)
+      CALL GmiEmiss_initSurfEmissBundle    (gcGMI%gcEmiss,     bgg,               expChem,                             __RC__)
 
       RETURN
 
@@ -166,7 +169,7 @@
 !
 ! !INTERFACE:
 !
-   SUBROUTINE GMI_GridCompRun1(gcGMI, w_c, impChem, expChem, nymd, nhms, tdt, clock, rc)
+   SUBROUTINE GMI_GridCompRun1(gcGMI, bgg, bxx, impChem, expChem, nymd, nhms, tdt, clock, rc)
 
 ! !USES:
 
@@ -175,7 +178,8 @@
 ! !INPUT/OUTPUT PARAMETERS:
 
    TYPE(GMI_GridComp), INTENT(inOut) :: gcGMI   ! Grid Component
-   TYPE(Chem_Bundle),  INTENT(inOut) :: w_c     ! Chemical tracer fields   
+   TYPE(Species_Bundle),  INTENT(inOut) :: bgg     ! Chemical tracer fields   
+   TYPE(Species_Bundle),  INTENT(inOut) :: bxx     ! Chemical tracer fields   
    TYPE(ESMF_State),   INTENT(inOut) :: impChem ! Import State
    TYPE(ESMF_State),   INTENT(inOut) :: expChem ! Export State
    TYPE(ESMF_Clock),   INTENT(inOut) :: clock   ! The clock
@@ -219,9 +223,9 @@
 
       mixPBL = .FALSE.
 
-      CALL GmiEmiss_GridCompRun     (gcGMI%gcEmiss, w_c, impChem, expChem, nymd, nhms, tdt, clock, mixPBL, __RC__)
+      CALL GmiEmiss_GridCompRun     (gcGMI%gcEmiss, bgg, bxx, impChem, expChem, nymd, nhms, tdt, clock, mixPBL, __RC__)
 
-      CALL GmiForcingBC_GridCompRun (gcGMI%gcFBC,   w_c, impChem, expChem, nymd, nhms, tdt,                __RC__)
+      CALL GmiForcingBC_GridCompRun (gcGMI%gcFBC,   bgg, bxx, impChem, expChem, nymd, nhms, tdt,                __RC__)
 
       RETURN
 
@@ -237,7 +241,7 @@
 !
 ! !INTERFACE:
 !
-   SUBROUTINE GMI_GridCompRun2(gcGMI, w_c, impChem, expChem, nymd, nhms, tdt, cdt, doChem, rc)
+   SUBROUTINE GMI_GridCompRun2(gcGMI, bgg, bxx, impChem, expChem, nymd, nhms, tdt, cdt, doChem, rc)
 ! !USES:
 
    IMPLICIT none
@@ -245,7 +249,8 @@
 ! !INPUT/OUTPUT PARAMETERS:
 
    TYPE(GMI_GridComp), INTENT(inOut) :: gcGMI   ! Grid Component
-   TYPE(Chem_Bundle),  INTENT(inOut) :: w_c     ! Chemical tracer fields   
+   TYPE(Species_Bundle),  INTENT(inOut) :: bgg     ! Chemical tracer fields   
+   TYPE(Species_Bundle),  INTENT(inOut) :: bxx     ! Chemical tracer fields   
    TYPE(ESMF_State),   INTENT(inOut) :: impChem ! Import State
    TYPE(ESMF_State),   INTENT(inOut) :: expChem ! Export State
 
@@ -287,17 +292,17 @@
 !BOC
       rc = 0
 
-      CALL GmiDepos_GridCompRun       (gcGMI%gcDepos,     w_c, impChem, expChem, nymd, nhms, tdt, __RC__)  ! tdt
+      CALL GmiDepos_GridCompRun       (gcGMI%gcDepos,     bgg, bxx, impChem, expChem, nymd, nhms, tdt, __RC__)  ! tdt
 
       IF ( doChem ) THEN
 
-        CALL GmiSAD_GridCompRun       (gcGMI%gcSAD,       w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+        CALL GmiSAD_GridCompRun       (gcGMI%gcSAD,       bgg, bxx, impChem, expChem, nymd, nhms, cdt, __RC__)
 
-        CALL GmiPhotolysis_GridCompRun(gcGMI%gcPhot,      w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+        CALL GmiPhotolysis_GridCompRun(gcGMI%gcPhot,      bgg, bxx, impChem, expChem, nymd, nhms, cdt, __RC__)
 
-        CALL GmiThermalRC_GridCompRun (gcGMI%gcThermalRC, w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+        CALL GmiThermalRC_GridCompRun (gcGMI%gcThermalRC, bgg, bxx, impChem, expChem, nymd, nhms, cdt, __RC__)
 
-        CALL GmiChemistry_GridCompRun (gcGMI%gcChem,      w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+        CALL GmiChemistry_GridCompRun (gcGMI%gcChem,      bgg, bxx, impChem, expChem, nymd, nhms, cdt, __RC__)
 
       ENDIF
 
@@ -314,7 +319,7 @@
 !
 ! !INTERFACE:
 !
-   SUBROUTINE GMI_GridCompRunOrig(gcGMI, w_c, impChem, expChem, nymd, nhms, cdt, clock, rc)
+   SUBROUTINE GMI_GridCompRunOrig(gcGMI, bgg, bxx, impChem, expChem, nymd, nhms, cdt, clock, rc)
 
 ! !USES:
 
@@ -323,7 +328,8 @@
 ! !INPUT/OUTPUT PARAMETERS:
 
    TYPE(GMI_GridComp), INTENT(inOut) :: gcGMI   ! Grid Component
-   TYPE(Chem_Bundle),  INTENT(inOut) :: w_c     ! Chemical tracer fields   
+   TYPE(Species_Bundle),  INTENT(inOut) :: bgg     ! Chemical tracer fields   
+   TYPE(Species_Bundle),  INTENT(inOut) :: bxx     ! Chemical tracer fields   
    TYPE(ESMF_State),   INTENT(inOut) :: impChem ! Import State
    TYPE(ESMF_State),   INTENT(inOut) :: expChem ! Export State
    TYPE(ESMF_Clock),   INTENT(inOut) :: clock   ! The clock
@@ -369,19 +375,19 @@
 
       mixPBL = .TRUE.
 
-      CALL GmiDepos_GridCompRun     (gcGMI%gcDepos,     w_c, impChem, expChem, nymd, nhms, cdt,               __RC__)
+      CALL GmiDepos_GridCompRun     (gcGMI%gcDepos,     bgg, bxx, impChem, expChem, nymd, nhms, cdt,               __RC__)
 
-      CALL GmiEmiss_GridCompRun     (gcGMI%gcEmiss,     w_c, impChem, expChem, nymd, nhms, cdt, clock, mixPBL, __RC__)
+      CALL GmiEmiss_GridCompRun     (gcGMI%gcEmiss,     bgg, bxx, impChem, expChem, nymd, nhms, cdt, clock, mixPBL, __RC__)
 
-      CALL GmiSAD_GridCompRun       (gcGMI%gcSAD,       w_c, impChem, expChem, nymd, nhms, cdt,               __RC__)
+      CALL GmiSAD_GridCompRun       (gcGMI%gcSAD,       bgg, bxx, impChem, expChem, nymd, nhms, cdt,               __RC__)
 
-      CALL GmiPhotolysis_GridCompRun(gcGMI%gcPhot,      w_c, impChem, expChem, nymd, nhms, cdt,               __RC__)
+      CALL GmiPhotolysis_GridCompRun(gcGMI%gcPhot,      bgg, bxx, impChem, expChem, nymd, nhms, cdt,               __RC__)
 
-      CALL GmiForcingBC_GridCompRun (gcGMI%gcFBC,       w_c, impChem, expChem, nymd, nhms, cdt,               __RC__)
+      CALL GmiForcingBC_GridCompRun (gcGMI%gcFBC,       bgg, bxx, impChem, expChem, nymd, nhms, cdt,               __RC__)
 
-      CALL GmiThermalRC_GridCompRun (gcGMI%gcThermalRC, w_c, impChem, expChem, nymd, nhms, cdt,               __RC__)
+      CALL GmiThermalRC_GridCompRun (gcGMI%gcThermalRC, bgg, bxx, impChem, expChem, nymd, nhms, cdt,               __RC__)
 
-      CALL GmiChemistry_GridCompRun (gcGMI%gcChem,      w_c, impChem, expChem, nymd, nhms, cdt,               __RC__)
+      CALL GmiChemistry_GridCompRun (gcGMI%gcChem,      bgg, bxx, impChem, expChem, nymd, nhms, cdt,               __RC__)
 
       RETURN
 
@@ -397,7 +403,7 @@
 ! !INTERFACE:
 !
 
-   SUBROUTINE GMI_GridCompFinalize(gcGMI, w_c, impChem, expChem, nymd, nhms, cdt, rc)
+   SUBROUTINE GMI_GridCompFinalize(gcGMI, impChem, expChem, nymd, nhms, cdt, rc)
 
    IMPLICIT none
 
@@ -409,7 +415,6 @@
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), INTENT(in)  :: w_c      ! Chemical tracer fields   
    INTEGER, INTENT(in) :: nymd, nhms	      ! time
    REAL,    INTENT(in) :: cdt  	              ! chemical timestep (secs)
 
@@ -440,19 +445,19 @@
 !BOC
       rc = 0
 
-      CALL GmiDepos_GridCompFinalize     (gcGMI%gcDepos,     w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+      CALL GmiDepos_GridCompFinalize     (gcGMI%gcDepos,     impChem, expChem, nymd, nhms, cdt, __RC__)
 
-      CALL GmiEmiss_GridCompFinalize     (gcGMI%gcEmiss,     w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+      CALL GmiEmiss_GridCompFinalize     (gcGMI%gcEmiss,     impChem, expChem, nymd, nhms, cdt, __RC__)
 
-      CALL GmiSAD_GridCompFinalize       (gcGMI%gcSAD,       w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+      CALL GmiSAD_GridCompFinalize       (gcGMI%gcSAD,       impChem, expChem, nymd, nhms, cdt, __RC__)
 
-      CALL GmiPhotolysis_GridCompFinalize(gcGMI%gcPhot,      w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+      CALL GmiPhotolysis_GridCompFinalize(gcGMI%gcPhot,      impChem, expChem, nymd, nhms, cdt, __RC__)
 
-      CALL GmiForcingBC_GridCompFinalize (gcGMI%gcFBC,       w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+      CALL GmiForcingBC_GridCompFinalize (gcGMI%gcFBC,       impChem, expChem, nymd, nhms, cdt, __RC__)
 
-      CALL GmiThermalRC_GridCompFinalize (gcGMI%gcThermalRC, w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+      CALL GmiThermalRC_GridCompFinalize (gcGMI%gcThermalRC, impChem, expChem, nymd, nhms, cdt, __RC__)
 
-      CALL GmiChemistry_GridCompFinalize (gcGMI%gcChem,      w_c, impChem, expChem, nymd, nhms, cdt, __RC__)
+      CALL GmiChemistry_GridCompFinalize (gcGMI%gcChem,      impChem, expChem, nymd, nhms, cdt, __RC__)
 
       RETURN
 

--- a/GMIchem_GridComp/GMI_GridComp/GMI_GridCompMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_GridCompMod.F90
@@ -101,10 +101,10 @@
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Species_Bundle), INTENT(in) :: bgg         ! Chemical tracer fields, delp, +
-   TYPE(Species_Bundle), INTENT(in) :: bxx         ! Chemical tracer fields, delp, +
-   INTEGER,	      INTENT(in) :: nymd, nhms  ! Time from AGCM
-   REAL, 	      INTENT(in) :: cdt         ! Chemistry time step (secs)
+   TYPE(Species_Bundle), INTENT(in) :: bgg         ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(in) :: bxx         ! GMI Species - not transported
+   INTEGER,	         INTENT(in) :: nymd, nhms  ! Time from AGCM
+   REAL, 	         INTENT(in) :: cdt         ! Chemistry time step (secs)
 
 ! !INPUT/OUTPUT PARAMETERS:
 
@@ -177,12 +177,12 @@
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GMI_GridComp), INTENT(inOut) :: gcGMI   ! Grid Component
-   TYPE(Species_Bundle),  INTENT(inOut) :: bgg     ! Chemical tracer fields   
-   TYPE(Species_Bundle),  INTENT(inOut) :: bxx     ! Chemical tracer fields   
-   TYPE(ESMF_State),   INTENT(inOut) :: impChem ! Import State
-   TYPE(ESMF_State),   INTENT(inOut) :: expChem ! Export State
-   TYPE(ESMF_Clock),   INTENT(inOut) :: clock   ! The clock
+   TYPE(GMI_GridComp),   INTENT(inOut) :: gcGMI   ! Grid Component
+   TYPE(Species_Bundle), INTENT(inOut) :: bgg     ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(inOut) :: bxx     ! GMI Species - not transported
+   TYPE(ESMF_State),     INTENT(inOut) :: impChem ! Import State
+   TYPE(ESMF_State),     INTENT(inOut) :: expChem ! Export State
+   TYPE(ESMF_Clock),     INTENT(inOut) :: clock   ! The clock
 
 ! !INPUT PARAMETERS:
 
@@ -248,11 +248,11 @@
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GMI_GridComp), INTENT(inOut) :: gcGMI   ! Grid Component
-   TYPE(Species_Bundle),  INTENT(inOut) :: bgg     ! Chemical tracer fields   
-   TYPE(Species_Bundle),  INTENT(inOut) :: bxx     ! Chemical tracer fields   
-   TYPE(ESMF_State),   INTENT(inOut) :: impChem ! Import State
-   TYPE(ESMF_State),   INTENT(inOut) :: expChem ! Export State
+   TYPE(GMI_GridComp),   INTENT(inOut) :: gcGMI   ! Grid Component
+   TYPE(Species_Bundle), INTENT(inOut) :: bgg     ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(inOut) :: bxx     ! GMI Species - not transported
+   TYPE(ESMF_State),     INTENT(inOut) :: impChem ! Import State
+   TYPE(ESMF_State),     INTENT(inOut) :: expChem ! Export State
 
 ! !INPUT PARAMETERS:
 
@@ -327,12 +327,12 @@
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GMI_GridComp), INTENT(inOut) :: gcGMI   ! Grid Component
-   TYPE(Species_Bundle),  INTENT(inOut) :: bgg     ! Chemical tracer fields   
-   TYPE(Species_Bundle),  INTENT(inOut) :: bxx     ! Chemical tracer fields   
-   TYPE(ESMF_State),   INTENT(inOut) :: impChem ! Import State
-   TYPE(ESMF_State),   INTENT(inOut) :: expChem ! Export State
-   TYPE(ESMF_Clock),   INTENT(inOut) :: clock   ! The clock
+   TYPE(GMI_GridComp),   INTENT(inOut) :: gcGMI   ! Grid Component
+   TYPE(Species_Bundle), INTENT(inOut) :: bgg     ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(inOut) :: bxx     ! GMI Species - not transported
+   TYPE(ESMF_State),     INTENT(inOut) :: impChem ! Import State
+   TYPE(ESMF_State),     INTENT(inOut) :: expChem ! Export State
+   TYPE(ESMF_Clock),     INTENT(inOut) :: clock   ! The clock
 
 ! !INPUT PARAMETERS:
 

--- a/GMIchem_GridComp/GMI_GridComp/GMI_Mech_Registry.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GMI_Mech_Registry.rc
@@ -1,0 +1,168 @@
+#------------------------------------------------------------------------
+#BOP
+#
+# !RESOURCE: GMI_Mech_Registry
+# 
+# !HELP:
+#
+#  The GMI Mechanism Registry resource file provides names and units
+#  for the species in the GMI chemical mechanism. There is a different
+#  file for each different mechanism, and the choice of mechanism
+#  occurs at compile time.
+#
+#  This file is read at run-time.  It provides the list of GMI species
+#  that GEOS will use for the INTERNAL state.  There is a separate,
+#  largely identical list of species that the SMV chemical solver will use,
+#  i.e. the GMI internal list.
+#
+#  The differences between the GEOS list (this file) and the
+#  GMI internal list are as follows:
+#    - AOADAYS is only in the GEOS list
+#    - T2M15d  is only in the GEOS list
+#    - H2O     is only in the GMI internal list
+#
+#  This file has 2 tables:  the GMI table holds the chemical species
+#  that are transported; the XX table holds the non-transported species.
+#
+#  The following assumptions exist in the code:
+#    - AOADAYS is the first entry in the GMI_table
+#    - T2M15d  is the last entry in the XX_table
+#
+# !REVISION HISTORY:
+#
+#  2022-09-15  manyin   Derived this file from Chem_Registry.rc
+#
+#-----------------------------------------------------------------------
+#EOP
+
+GMI_table::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+AOADAYS    days         Age-of-air
+CH2O       'mol mol-1'  Formaldehyde
+CH4        'mol mol-1'  Methane
+CO         'mol mol-1'  Carbon monoxide
+H2         'mol mol-1'  Molecular hydrogen
+HCOOH      'mol mol-1'  Formic acid (CH2O2)
+HNO2       'mol mol-1'  Nitrous acid
+HNO3       'mol mol-1'  Nitric acid
+HNO4       'mol mol-1'  Pernitric acid
+HO2        'mol mol-1'  Perhydroxyl radical
+H2O2       'mol mol-1'  Hydrogen peroxide
+MOH        'mol mol-1'  Methanol
+MP         'mol mol-1'  Methyl hydroperoxide  
+N2O        'mol mol-1'  Nitrous oxide
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+OX         'mol mol-1'  Ozone
+OH         'mol mol-1'  Hydroxyl radical
+Br         'mol mol-1'  Ground state atomic bromine (2P3/2)
+BrCl       'mol mol-1'  Bromine chloride
+BrO        'mol mol-1'  Bromine monoxide radical
+BrONO2     'mol mol-1'  Bromine nitrate
+HBr        'mol mol-1'  Hydrogen bromide
+HOBr       'mol mol-1'  Hydrobromous acid
+Cl         'mol mol-1'  Ground state atomic chlorine (2P3/2)
+Cl2        'mol mol-1'  Molecular chlorine
+ClO        'mol mol-1'  Chlorine monoxide radical
+Cl2O2      'mol mol-1'  Chlorine peroxide
+ClONO2     'mol mol-1'  Chlorine nitrate
+HCl        'mol mol-1'  Hydrochloric acid
+HOCl       'mol mol-1'  Hydrochlorous acid
+OClO       'mol mol-1'  Symmetrical chlorine dioxide
+CH3Br      'mol mol-1'  Methyl bromide
+CH3Cl      'mol mol-1'  Methyl chloride
+CH3CCl3    'mol mol-1'  Methyl chloroform
+CCl4       'mol mol-1'  Carbon tetrachloride
+CFC11      'mol mol-1'  CFC11 (CFCl3)
+CFC12      'mol mol-1'  CFC12 (CF2Cl2)
+CFC113     'mol mol-1'  CFC113 (C2Cl3F3)
+CFC114     'mol mol-1'  CFC114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC115 (C2ClF5)
+HCFC22     'mol mol-1'  HCFC22 (CClF2H)
+HCFC141b   'mol mol-1'  HCFC141b (C2Cl2FH3)
+HCFC142b   'mol mol-1'  HCFC142b (C2ClF2H3)
+CF2Br2     'mol mol-1'  Halon 1202
+CF2ClBr    'mol mol-1'  Halon 1211
+CF3Br      'mol mol-1'  Halon 1301
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+ACTA       'mol mol-1'  Acetic acid (C2H4O2)
+ALD2       'mol mol-1'  Acetaldehyde (C2H4O)
+ALK4       'mol mol-1'  C4-5 alkanes (C4H10 C5H12)
+C2H6       'mol mol-1'  Ethane
+C3H8       'mol mol-1'  Propane
+ETP        'mol mol-1'  Ethylhydroperoxide (C2H6O2) from ETO2
+HAC        'mol mol-1'  Hydroxyacetone (C3H6O2)
+IALD       'mol mol-1'  Hydroxy carbonyl alkenes (C5H8O2) from isoprene
+IAP        'mol mol-1'  Peroxide (C5H10O5) from IAO2
+ISOP       'mol mol-1'  Isoprene (C5H8)
+MACR       'mol mol-1'  Methacrolein (C4H6O)
+MEK        'mol mol-1'  Methyl ethyl ketone (C4H8O)
+MVK        'mol mol-1'  Methyl vinyl ketone (C4H6O)
+PAN        'mol mol-1'  Peroxyacetyl nitrate (C2H3NO5)
+PMN        'mol mol-1'  Peroxymethacryloyl nitrate (C4H5O5N)
+PPN        'mol mol-1'  Peroxypropionyl nitrate (C3H5NO5)
+PRPE       'mol mol-1'  Propene (C3H6)
+R4N2       'mol mol-1'  C4-C5 alkylnitrates (C4H9O3N)
+RCHO       'mol mol-1'  C2 aldehydes (C3H6O)
+RCOOH      'mol mol-1'  C2 organic acids
+N2          cm-3        Molecular nitrogen
+HNO3COND   'mol mol-1'  Condensed nitric acid
+::
+
+XX_table::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+H          'mol mol-1'  Ground state atomic hydrogen (2S)
+MO2        'mol mol-1'  Methylperoxy radical (CH3O2)
+N          'mol mol-1'  Ground state atomic nitrogen
+O          'mol mol-1'  Ground state atomic oxygen (3P)
+O1D        'mol mol-1'  First excited singlet state of atomic oxygen (1D)
+A3O2       'mol mol-1'  Primary RO2 (C3H7O2) from propane
+ATO2       'mol mol-1'  RO2 from acetone (C3H6O3)
+B3O2       'mol mol-1'  Secondary RO2 (C3H7O2) from propane
+EOH        'mol mol-1'  Ethanol
+ETO2       'mol mol-1'  Ethylperoxy radical (C2H5O2)
+GLYC       'mol mol-1'  Glycolaldehyde (Hydroxyacetaldehyde C2H4O2)
+GLYX       'mol mol-1'  Glyoxal (2CHO)
+IAO2       'mol mol-1'  RO2 (C5H9O5) from isoprene oxidation products
+INO2       'mol mol-1'  RO2 (C5H8O3N) from ISOP+NO3
+INPN       'mol mol-1'  Peroxide (C5H8O6N2) from INO2
+ISN1       'mol mol-1'  RO2 (C4H7O4N) from ISN2
+ISNP       'mol mol-1'  Peroxide (C4H7O4N) from ISN1
+KO2        'mol mol-1'  RO2 (C4H7O3) from C3 ketones
+MAN2       'mol mol-1'  RO2 (C4H6O6N) from MACR+NO3
+MAO3       'mol mol-1'  Peroxyacyl (C4H5O3) from MACR and MVK
+MAOP       'mol mol-1'  Peroxide (C4H6O3) from MAO3
+MAP        'mol mol-1'  Peroxyacetic acid (C2H4O3)
+MCO3       'mol mol-1'  Peroxyacetyl radical (C2H3O3)
+MGLY       'mol mol-1'  Methylglyoxal (C3H4O2)
+MRO2       'mol mol-1'  RO2 (C4H7O4) from MACR+OH
+MRP        'mol mol-1'  Peroxide (C4H8O4) from MRO2
+PO2        'mol mol-1'  RO2 (C3H7O3) from propene
+PP         'mol mol-1'  Peroxide (C3H8O3) from PO2
+PRN1       'mol mol-1'  RO2 (C3H6O3N) from propene+NO3
+PRPN       'mol mol-1'  Peroxide (C3H6O3N) from PRN1
+R4N1       'mol mol-1'  RO2 (C4H9O3N) from R4N2
+R4O2       'mol mol-1'  RO2 (C4H9O2) from ALK4
+R4P        'mol mol-1'  Peroxide (C4H10O2) from R4O2
+RA3P       'mol mol-1'  Peroxy propyl alcohol (C3H8O2) from A3O2
+RB3P       'mol mol-1'  Peroxide (C3H8O2) from B3O2
+RCO3       'mol mol-1'  Peroxypropionyl radical (C3H5O3)
+RIO1       'mol mol-1'  RO2 (C5H9O3) from isoprene oxydation products
+RIO2       'mol mol-1'  RO2 (C5H9O3) from isoprene
+RIP        'mol mol-1'  Peroxide (C5H10O3) from RIO2
+ROH        'mol mol-1'  C2 alcohols
+RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
+VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
+VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
+OCSg       'mol mol-1'  Carbonyl sulfide in GMI
+ACET       'mol mol-1'  Acetone
+O2          cm-3        Molecular oxygen
+NUMDENS     cm-3        Total number density
+T2M15d      K           Daily T2M time average
+::

--- a/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -161,10 +161,10 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Species_Bundle), INTENT(in) :: bgg                ! Chemical tracer fields, delp, +
-   TYPE(Species_Bundle), INTENT(in) :: bxx                ! Chemical tracer fields, delp, +
-   INTEGER, INTENT(IN) :: nymd, nhms		       ! Time from AGCM
-   REAL,    INTENT(IN) :: tdt			       ! Chemistry time step (secs)
+   TYPE(Species_Bundle), INTENT(in) :: bgg                ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(in) :: bxx                ! GMI Species - not transported
+   INTEGER,              INTENT(IN) :: nymd, nhms         ! Time from AGCM
+   REAL,                 INTENT(IN) :: tdt                ! Chemistry time step (secs)
 
 ! !OUTPUT PARAMETERS:
 
@@ -578,15 +578,15 @@ CONTAINS
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GmiChemistry_GridComp), INTENT(INOUT) :: self ! Grid Component
-   TYPE(Species_Bundle), INTENT(INOUT) :: bgg    ! Chemical tracer fields   
-   TYPE(Species_Bundle), INTENT(INOUT) :: bxx    ! Chemical tracer fields   
+   TYPE(GmiChemistry_GridComp), INTENT(INOUT) :: self   ! Grid Component
+   TYPE(Species_Bundle),        INTENT(INOUT) :: bgg    ! GMI Species - transported
+   TYPE(Species_Bundle),        INTENT(INOUT) :: bxx    ! GMI Species - not transported
 
 ! !INPUT PARAMETERS:
 
    TYPE(ESMF_State), INTENT(INOUT) :: impChem ! Import State
-   INTEGER, INTENT(IN) :: nymd, nhms	      ! time
-   REAL,    INTENT(IN) :: tdt		      ! chemical timestep (secs)
+   INTEGER, INTENT(IN) :: nymd, nhms          ! time
+   REAL,    INTENT(IN) :: tdt                 ! chemical timestep (secs)
 
 ! !OUTPUT PARAMETERS:
 
@@ -984,7 +984,7 @@ CONTAINS
     O3ppmv(i1:i2,j1:j2,1:km) = bgg%qa(ic)%data3d(i1:i2,j1:j2,1:km)*1.00E+06
 
    IF(ASSOCIATED(O3)) &
-    O3(i1:i2,j1:j2,1:km) = bgg%qa(ic)%data3d(i1:i2,j1:j2,1:km)*(MAPL_O3MW/MAPL_AIRMW)
+        O3(i1:i2,j1:j2,1:km) = bgg%qa(ic)%data3d(i1:i2,j1:j2,1:km)*(MAPL_O3MW/MAPL_AIRMW)
 
 ! --------------------------------------------------------------------
 ! Reaction rate constants (q) and rates (qq)

--- a/GMIchem_GridComp/GMI_GridComp/GmiDepos_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiDepos_GridCompClassMod.F90
@@ -19,6 +19,8 @@
    USE Chem_Mod 	     ! Chemistry Base Class
    USE Chem_UtilMod
 
+   USE Species_BundleMod
+
    USE GmiEmissionMethod_mod,         ONLY : t_Emission
    USE GmiDepositionMethod_mod,       ONLY : t_Deposition
    USE GmiSpcConcentrationMethod_mod, ONLY : t_SpeciesConcentration
@@ -141,7 +143,7 @@ CONTAINS
 ! !INTERFACE:
 !
 
-   SUBROUTINE GmiDepos_GridCompInitialize( self, w_c, impChem, expChem, nymd, nhms, &
+   SUBROUTINE GmiDepos_GridCompInitialize( self, bgg, bxx, impChem, expChem, nymd, nhms, &
                                       tdt, rc )
 
    USE GmiSpcConcentrationMethod_mod, ONLY : InitializeSpcConcentration
@@ -157,7 +159,8 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), INTENT(in) :: w_c                ! Chemical tracer fields, delp, +
+   TYPE(Species_Bundle), INTENT(in) :: bgg             ! Transported GMI species
+   TYPE(Species_Bundle), INTENT(in) :: bxx             ! Non-transported GMI species
    INTEGER, INTENT(IN) :: nymd, nhms		       ! Time from AGCM
    REAL,    INTENT(IN) :: tdt			       ! Chemistry time step (secs)
 
@@ -200,7 +203,7 @@ CONTAINS
    INTEGER :: ilo, ihi, julo, jvlo, jhi
    INTEGER :: ilo_gl, ihi_gl, julo_gl, jvlo_gl, jhi_gl
    INTEGER :: gmi_nborder
-   INTEGER :: numSpecies
+   INTEGER :: NMR      ! number of species from the GMI_Mech_Registry.rc
 
    INTEGER :: loc_proc
    LOGICAL :: one_proc, rootProc
@@ -387,20 +390,23 @@ CONTAINS
                           ilo_gl, ihi_gl, julo_gl, jvlo_gl, jhi_gl, &
                           ilong, ilat, ivert, itloop, j1p, j2p)  
 
-! Number of species and perform a consistency check with setkin_par.h.
-! NOTES:
-!  1. H2O is specie number 10 in the strat-trop mechanism, but will not be
-!     found in w_c%reg%vname. H2O will be initialized from specific humidity, Q.
-!  2. The GEOS-5 bundle has an Age-Of-Air tracer, which is not carried by GMI.
-!  3. At the end of the XX (non-transported) species is a place holder for T2M15d.
-! So w_c%reg%j_XX-w_c%reg%i_GMI must equal the parameter NSP = NCONST + NDYN.
+! Perform a consistency check with setkin_par.h.
+!   NSP is the number of species in setkins
+!   NMR is the number of species in the Mech Registry
+!
+!   H2O   is in setkins,           but not in GMI_Mech_Registry
+!   AOA   is in GMI_Mech_Registry, but not in setkins
+!   T2M15 is in GMI_Mech_Registry, but not in setkins
+!
+!   The number of species common to both is therefore
+!     NMR - 2     ! number in GMI_Mech_Registry - 2
+!     NSP - 1     ! number in setkins - 1
 ! --------------------------------------------------------------------------------
-   numSpecies = w_c%reg%j_XX-w_c%reg%i_GMI
-   IF(numSpecies /= NSP) THEN
-    PRINT *,TRIM(IAm),': Number of species from Chem_Registry.rc does not match number in setkin_par.h'
+   NMR = bgg%nq + bxx%nq
+   IF( NMR-2 /= NSP-1 ) THEN
+    PRINT *,TRIM(IAm),': Number of species from GMI_Mech_Registry.rc does not match number in setkin_par.h'
     STATUS = 1
     VERIFY_(STATUS)
-    RETURN
    END IF
 
 ! Allocate space, etc., but the initialization of the
@@ -408,12 +414,12 @@ CONTAINS
 ! ----------------------------------------------------------
 
       CALL InitializeSpcConcentration(self%SpeciesConcentration,              &
-     &               self%gmiGrid, gmiConfigFile, numSpecies, NMF, NCHEM,     &
-     &               loc_proc)
+                     self%gmiGrid, gmiConfigFile, NSP, NMF, NCHEM,            &
+                     loc_proc)
 
       CALL InitializeDeposition(self%Deposition, self%gmiGrid,               &
-     &               gmiConfigFile, numSpecies, loc_proc, self%pr_diag,      &
-     &               self%pr_dry_depos, self%pr_wet_depos, self%pr_scav)
+                     gmiConfigFile, NSP, loc_proc, self%pr_diag,      &
+                     self%pr_dry_depos, self%pr_wet_depos, self%pr_scav)
 
       !#################################################################
       ! This section of the code was included to be able to read some 
@@ -444,7 +450,7 @@ CONTAINS
     !---------------------------------------------------------------
 
     allocate(self%mapSpecies(NSP))
-    self%mapSpecies(:) = speciesReg_for_CCM(lchemvar, w_c%reg%vname, NSP, w_c%reg%i_GMI, w_c%reg%j_XX)
+    self%mapSpecies(:) = speciesReg_for_CCM(lchemvar, NSP, bgg%reg%vname, bxx%reg%vname )
 
 
     self%veg_fraction_done = .FALSE.
@@ -463,7 +469,7 @@ CONTAINS
 ! !INTERFACE:
 !
 
-   SUBROUTINE GmiDepos_GridCompRun ( self, w_c, impChem, expChem, nymd, nhms, &
+   SUBROUTINE GmiDepos_GridCompRun ( self, bgg, bxx, impChem, expChem, nymd, nhms, &
                                 tdt, rc )
 
 ! !USES:
@@ -483,7 +489,8 @@ CONTAINS
 ! !INPUT/OUTPUT PARAMETERS:
 
    TYPE(GmiDepos_GridComp), INTENT(INOUT) :: self ! Grid Component
-   TYPE(Chem_Bundle), INTENT(INOUT) :: w_c    ! Chemical tracer fields   
+   TYPE(Species_Bundle), INTENT(INOUT) :: bgg             ! Transported GMI species
+   TYPE(Species_Bundle), INTENT(INOUT) :: bxx             ! Non-transported GMI species
 
 ! !INPUT PARAMETERS:
 
@@ -720,10 +727,10 @@ CONTAINS
 
 ! Hand the species concentrations to GMI's bundle
 ! -----------------------------------------------
-   IF (self%gotImportRst) then
+   IF (self%gotImportRst) THEN
       CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration, &
-               w_c%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
-               STATUS)   
+               bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
+               STATUS)
       VERIFY_(STATUS)
    END IF
 
@@ -805,7 +812,7 @@ CONTAINS
 ! -----------------------------------------------------
    IF (self%gotImportRst) then
       CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration, &
-               w_c%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
+               bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
                STATUS)
       VERIFY_(STATUS)
    END IF
@@ -1224,7 +1231,7 @@ CONTAINS
 ! !INTERFACE:
 !
 
-   SUBROUTINE GmiDepos_GridCompFinalize ( self, w_c, impChem, expChem, &
+   SUBROUTINE GmiDepos_GridCompFinalize ( self, impChem, expChem, &
                                      nymd, nhms, cdt, rc )
 
   IMPLICIT none
@@ -1235,7 +1242,6 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), INTENT(in)  :: w_c      ! Chemical tracer fields   
    INTEGER, INTENT(in) :: nymd, nhms	      ! time
    REAL,    INTENT(in) :: cdt  	              ! chemical timestep (secs)
 

--- a/GMIchem_GridComp/GMI_GridComp/GmiDepos_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiDepos_GridCompClassMod.F90
@@ -159,8 +159,8 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Species_Bundle), INTENT(in) :: bgg             ! Transported GMI species
-   TYPE(Species_Bundle), INTENT(in) :: bxx             ! Non-transported GMI species
+   TYPE(Species_Bundle), INTENT(in) :: bgg             ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(in) :: bxx             ! GMI Species - not transported
    INTEGER, INTENT(IN) :: nymd, nhms		       ! Time from AGCM
    REAL,    INTENT(IN) :: tdt			       ! Chemistry time step (secs)
 
@@ -417,8 +417,8 @@ CONTAINS
                      self%gmiGrid, gmiConfigFile, NSP, NMF, NCHEM,            &
                      loc_proc)
 
-      CALL InitializeDeposition(self%Deposition, self%gmiGrid,               &
-                     gmiConfigFile, NSP, loc_proc, self%pr_diag,      &
+      CALL InitializeDeposition(self%Deposition, self%gmiGrid,                &
+                     gmiConfigFile, NSP, loc_proc, self%pr_diag,              &
                      self%pr_dry_depos, self%pr_wet_depos, self%pr_scav)
 
       !#################################################################
@@ -488,9 +488,9 @@ CONTAINS
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GmiDepos_GridComp), INTENT(INOUT) :: self ! Grid Component
-   TYPE(Species_Bundle), INTENT(INOUT) :: bgg             ! Transported GMI species
-   TYPE(Species_Bundle), INTENT(INOUT) :: bxx             ! Non-transported GMI species
+   TYPE(GmiDepos_GridComp), INTENT(INOUT) :: self   ! Grid Component
+   TYPE(Species_Bundle),    INTENT(INOUT) :: bgg    ! GMI Species - transported
+   TYPE(Species_Bundle),    INTENT(INOUT) :: bxx    ! GMI Species - not transported
 
 ! !INPUT PARAMETERS:
 

--- a/GMIchem_GridComp/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiEmiss_GridCompClassMod.F90
@@ -218,10 +218,10 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Species_Bundle), INTENT(in) :: bgg                ! Chemical tracer fields, delp, +
-   TYPE(Species_Bundle), INTENT(in) :: bxx                ! Chemical tracer fields, delp, +
-   INTEGER, INTENT(IN) :: nymd, nhms                   ! Time from AGCM
-   REAL,    INTENT(IN) :: tdt                          ! Chemistry time step (secs)
+   TYPE(Species_Bundle), INTENT(IN) :: bgg             ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(IN) :: bxx             ! GMI Species - not transported
+   INTEGER,              INTENT(IN) :: nymd, nhms      ! Time from AGCM
+   REAL,                 INTENT(IN) :: tdt             ! Chemistry time step (secs)
 
 ! !OUTPUT PARAMETERS:
 
@@ -539,10 +539,10 @@ CONTAINS
                      self%gmiGrid, gmiConfigFile, NSP, NMF, NCHEM,            &
                      loc_proc)
 
-      CALL InitializeEmission(self%Emission, self%SpeciesConcentration,      &
-                     self%gmiGrid, gmiConfigFile, self%cellArea, IHNO3, IO3, &
-                     NSP, loc_proc, rootProc, self%chem_opt, self%trans_opt, &
-                     self%pr_diag,   &
+      CALL InitializeEmission(self%Emission, self%SpeciesConcentration,       &
+                     self%gmiGrid, gmiConfigFile, self%cellArea, IHNO3, IO3,  &
+                     NSP, loc_proc, rootProc, self%chem_opt, self%trans_opt,  &
+                     self%pr_diag,                                            &
                      self%pr_const, self%pr_surf_emiss, self%pr_emiss_3d, tdt)
 
       IF (BTEST(self%Emission%emiss_opt,1)) THEN
@@ -700,10 +700,10 @@ CONTAINS
             SUBROUTINE GmiEmiss_initSurfEmissBundle (self, bgg, expChem, rc)
 !
 ! !INPUT PARAMETERS:
-   TYPE(Species_Bundle), INTENT(in) :: bgg                ! Chemical tracer fields, delp
+   TYPE(Species_Bundle), INTENT(in) :: bgg      ! GMI Species - transported
 
 ! !OUTPUT PARAMETERS:
-      INTEGER, INTENT(out) ::  rc                  ! Error return code:
+      INTEGER, INTENT(out) ::  rc               ! Error return code:
                                                 !  0 - all is well
                                                 !  1 - 
 !
@@ -785,8 +785,8 @@ CONTAINS
 ! !INPUT/OUTPUT PARAMETERS:
 
    TYPE(GmiEmiss_GridComp), INTENT(INOUT) :: self        ! Grid Component
-   TYPE(Species_Bundle),       INTENT(INOUT) :: bgg         ! Chemical tracer fields   
-   TYPE(Species_Bundle),       INTENT(INOUT) :: bxx         ! Chemical tracer fields   
+   TYPE(Species_Bundle),    INTENT(INOUT) :: bgg         ! GMI Species - transported
+   TYPE(Species_Bundle),    INTENT(INOUT) :: bxx         ! GMI Species - not transported
    TYPE(ESMF_State),        INTENT(INOUT) :: impChem     ! Import State
    TYPE(ESMF_State),        INTENT(INOUT) :: expChem     ! Export State
    TYPE(ESMF_Clock),        INTENT(INOUT) :: clock       ! The clock
@@ -1074,9 +1074,8 @@ CONTAINS
 ! Hand the species concentrations to GMI's bundle
 ! -----------------------------------------------
    IF (self%gotImportRst) THEN
-      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration, &
-               bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
-               STATUS)
+      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration,          &
+               bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, STATUS)
       VERIFY_(STATUS)
    END IF
 
@@ -1176,7 +1175,7 @@ CONTAINS
 ! Return species concentrations to the chemistry bundle
 ! -----------------------------------------------------
    IF (self%gotImportRst) THEN
-      CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration, &
+      CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration,   &
                bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
                STATUS)
       VERIFY_(STATUS)

--- a/GMIchem_GridComp/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiForcingBC_GridCompClassMod.F90
@@ -126,7 +126,7 @@
 
 ! Component derived type declarations
 ! -----------------------------------
-   TYPE(t_gmiGrid   )		:: gmiGrid
+   TYPE(t_gmiGrid   )           :: gmiGrid
    TYPE(t_GmiClock  )           :: gmiClock
    TYPE(t_SpeciesConcentration) :: SpeciesConcentration
  
@@ -148,10 +148,10 @@ CONTAINS
                                       tdt, rc )
 
    USE GmiSpcConcentrationMethod_mod, ONLY : InitializeSpcConcentration
-   USE GmiGrid_mod,		      ONLY : InitializeGmiGrid
+   USE GmiGrid_mod,                   ONLY : InitializeGmiGrid
    USE GmiTimeControl_mod
-   use GmiStringManipulation_mod, only : constructListNames
-   use ReadForcedBC_mod, only : readForcedBcData
+   USE GmiStringManipulation_mod,     ONLY : constructListNames
+   USE ReadForcedBC_mod,              ONLY : readForcedBcData
 
    IMPLICIT none
 
@@ -161,10 +161,10 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Species_Bundle), INTENT(in) :: bgg                ! Chemical tracer fields, delp, +
-   TYPE(Species_Bundle), INTENT(in) :: bxx                ! Chemical tracer fields, delp, +
-   INTEGER, INTENT(IN) :: nymd, nhms		       ! Time from AGCM
-   REAL,    INTENT(IN) :: tdt			       ! Chemistry time step (secs)
+   TYPE(Species_Bundle), INTENT(in) :: bgg            ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(in) :: bxx            ! GMI Species - not transported
+   INTEGER,              INTENT(IN) :: nymd, nhms     ! Time from AGCM
+   REAL,                 INTENT(IN) :: tdt            ! Chemistry time step (secs)
 
 ! !OUTPUT PARAMETERS:
 
@@ -579,9 +579,9 @@ CONTAINS
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GmiForcingBC_GridComp), INTENT(INOUT) :: self ! Grid Component
-   TYPE(Species_Bundle), INTENT(INOUT) :: bgg    ! Chemical tracer fields   
-   TYPE(Species_Bundle), INTENT(INOUT) :: bxx    ! Chemical tracer fields   
+   TYPE(GmiForcingBC_GridComp), INTENT(INOUT) :: self   ! Grid Component
+   TYPE(Species_Bundle),        INTENT(INOUT) :: bgg    ! GMI Species - transported
+   TYPE(Species_Bundle),        INTENT(INOUT) :: bxx    ! GMI Species - not transported
 
 ! !INPUT PARAMETERS:
 
@@ -723,7 +723,7 @@ CONTAINS
 ! Hand the species concentrations to GMI's bundle
 ! -----------------------------------------------
    IF (self%gotImportRst) then
-      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration, &
+      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration,    &
                bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
                STATUS)
       VERIFY_(STATUS)
@@ -759,7 +759,7 @@ CONTAINS
 ! Return species concentrations to the chemistry bundle
 ! -----------------------------------------------------
    IF (self%gotImportRst) then
-      CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration, &
+      CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration,   &
                bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
                STATUS)
       VERIFY_(STATUS)

--- a/GMIchem_GridComp/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiPhotolysis_GridCompClassMod.F90
@@ -262,10 +262,10 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-   TYPE(Species_Bundle), INTENT(in) :: bgg                ! Chemical tracer fields, delp, +
-   TYPE(Species_Bundle), INTENT(in) :: bxx                ! Chemical tracer fields, delp, +
-   INTEGER, INTENT(IN) :: nymd, nhms                   ! Time from AGCM
-   REAL,    INTENT(IN) :: tdt                          ! Chemistry time step (secs)
+   TYPE(Species_Bundle), INTENT(IN) :: bgg                ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(IN) :: bxx                ! GMI Species - not transported
+   INTEGER,              INTENT(IN) :: nymd, nhms         ! Time from AGCM
+   REAL,                 INTENT(IN) :: tdt                ! Chemistry time step (secs)
 !
 ! !OUTPUT PARAMETERS:
 !
@@ -1177,9 +1177,9 @@ CONTAINS
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GmiPhotolysis_GridComp), INTENT(INOUT) :: self ! Grid Component
-   TYPE(Species_Bundle), INTENT(INOUT) :: bgg    ! Chemical tracer fields   
-   TYPE(Species_Bundle), INTENT(INOUT) :: bxx    ! Chemical tracer fields   
+   TYPE(GmiPhotolysis_GridComp), INTENT(INOUT) :: self   ! Grid Component
+   TYPE(Species_Bundle),         INTENT(INOUT) :: bgg    ! GMI Species - transported
+   TYPE(Species_Bundle),         INTENT(INOUT) :: bxx    ! GMI Species - not transported
 
 ! !INPUT PARAMETERS:
 
@@ -1463,7 +1463,7 @@ CONTAINS
 ! Hand the species concentrations to GMI's bundle
 ! -----------------------------------------------
    IF (self%gotImportRst) then
-      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration, &
+      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration,    &
                bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
                STATUS)
       VERIFY_(STATUS)
@@ -1590,7 +1590,7 @@ CONTAINS
 ! Return species concentrations to the chemistry bundle
 ! -----------------------------------------------------
    IF (self%gotImportRst) then
-      CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration, &
+      CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration,   &
                bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
                STATUS)
       VERIFY_(STATUS)

--- a/GMIchem_GridComp/GMI_GridComp/GmiSAD_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiSAD_GridCompClassMod.F90
@@ -167,7 +167,7 @@
 
 ! Component derived type declarations
 ! -----------------------------------
-   TYPE(t_gmiGrid   )		:: gmiGrid
+   TYPE(t_gmiGrid   )           :: gmiGrid
    TYPE(t_GmiClock  )           :: gmiClock
    TYPE(t_SpeciesConcentration) :: SpeciesConcentration
  
@@ -189,7 +189,7 @@ CONTAINS
                                       tdt, rc )
 
    USE GmiSpcConcentrationMethod_mod, ONLY : InitializeSpcConcentration
-   USE GmiGrid_mod,		      ONLY : InitializeGmiGrid
+   USE GmiGrid_mod,                   ONLY : InitializeGmiGrid
    USE GmiTimeControl_mod,            ONLY : Set_curGmiDate, Set_curGmiTime
    USE GmiTimeControl_mod,            ONLY : Set_begGmiDate, Set_begGmiTime
    USE GmiTimeControl_mod,            ONLY : Set_numTimeSteps
@@ -199,16 +199,16 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Species_Bundle), INTENT(in) :: bgg                ! Chemical tracer fields, delp, +
-   TYPE(Species_Bundle), INTENT(in) :: bxx                ! Chemical tracer fields, delp, +
-   INTEGER, INTENT(IN) :: nymd, nhms		       ! Time from AGCM
-   REAL,    INTENT(IN) :: tdt			       ! time step (secs)
+   TYPE(Species_Bundle), INTENT(IN) :: bgg                ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(IN) :: bxx                ! GMI Species - not transported
+   INTEGER,              INTENT(IN) :: nymd, nhms         ! Time from AGCM
+   REAL,                 INTENT(IN) :: tdt                ! time step (secs)
 
 ! !OUTPUT PARAMETERS:
 
-   TYPE(GmiSAD_GridComp), INTENT(INOUT)  :: self      ! Grid Component
-   TYPE(ESMF_State),   INTENT(INOUT)  :: impChem    ! Import State
-   TYPE(ESMF_State),   INTENT(INOUT)  :: expChem    ! Export State
+   TYPE(GmiSAD_GridComp), INTENT(INOUT)  :: self       ! Grid Component
+   TYPE(ESMF_State),      INTENT(INOUT)  :: impChem    ! Import State
+   TYPE(ESMF_State),      INTENT(INOUT)  :: expChem    ! Export State
 
    INTEGER, INTENT(out) ::  rc                  ! Error return code:
                                                 !  0 - all is well
@@ -725,15 +725,15 @@ CONTAINS
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GmiSAD_GridComp), INTENT(INOUT) :: self ! Grid Component
-   TYPE(Species_Bundle), INTENT(INOUT) :: bgg    ! Chemical tracer fields   
-   TYPE(Species_Bundle), INTENT(INOUT) :: bxx    ! Chemical tracer fields   
+   TYPE(GmiSAD_GridComp), INTENT(INOUT) :: self   ! Grid Component
+   TYPE(Species_Bundle),  INTENT(INOUT) :: bgg    ! GMI Species - transported
+   TYPE(Species_Bundle),  INTENT(INOUT) :: bxx    ! GMI Species - not transported
 
 ! !INPUT PARAMETERS:
 
    TYPE(ESMF_State), INTENT(INOUT) :: impChem ! Import State
-   INTEGER, INTENT(IN) :: nymd, nhms	      ! time
-   REAL,    INTENT(IN) :: tdt		      ! chemical timestep (secs)
+   INTEGER, INTENT(IN) :: nymd, nhms          ! time
+   REAL,    INTENT(IN) :: tdt                 ! chemical timestep (secs)
 
 ! !OUTPUT PARAMETERS:
 
@@ -928,7 +928,7 @@ CONTAINS
 ! Hand the species concentrations to GMI's bundle
 ! -----------------------------------------------
    IF (self%gotImportRst) then
-      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration, &
+      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration,    &
                bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
                STATUS)
       VERIFY_(STATUS)
@@ -950,22 +950,22 @@ CONTAINS
     self%dehydmin = 0.00
 
     CALL updateSurfaceAreaDensities (tdt8, tropopausePress, press3c,      &
-    	       press3e, kel, self%SpeciesConcentration%concentration,	  &
-    	       self%ch4clim, self%h2oclim, self%hno3cond, self%hno3gas,   &
-    	       self%lbssad, self%sadgmi, self%h2oback, self%h2ocond,	  &
-    	       self%reffice, self%reffsts, self%vfall, self%dehydmin,	  &
-    	       self%dehyd_opt, self%h2oclim_opt, self%lbssad_opt,	  &
-    	       self%sad_opt, IHNO3COND, self%idehyd_num, ICH4,  	  &
-    	       IHNO3, IH2O, nymd, self%pr_diag, loc_proc, NSP,  	  &
-    	       NSAD, self%lbssad_timpyr, self%h2oclim_timpyr,		  &
-    	       ilo, ihi, julo, jhi, i1, i2, ju1, j2, k1, k2, londeg,	  &
-    	       latdeg, self%NoPSCZone, self%PSCMaxP, self%chem_mecha)
+               press3e, kel, self%SpeciesConcentration%concentration,     &
+               self%ch4clim, self%h2oclim, self%hno3cond, self%hno3gas,   &
+               self%lbssad, self%sadgmi, self%h2oback, self%h2ocond,      &
+               self%reffice, self%reffsts, self%vfall, self%dehydmin,     &
+               self%dehyd_opt, self%h2oclim_opt, self%lbssad_opt,         &
+               self%sad_opt, IHNO3COND, self%idehyd_num, ICH4,            &
+               IHNO3, IH2O, nymd, self%pr_diag, loc_proc, NSP,            &
+               NSAD, self%lbssad_timpyr, self%h2oclim_timpyr,             &
+               ilo, ihi, julo, jhi, i1, i2, ju1, j2, k1, k2, londeg,      &
+               latdeg, self%NoPSCZone, self%PSCMaxP, self%chem_mecha)
 
 ! Return species concentrations to the chemistry bundle
 ! -----------------------------------------------------
-    CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration, &
-    	     bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
-    	     STATUS)
+    CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration,   &
+             bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
+             STATUS)
     VERIFY_(STATUS)
 
 ! Check for HNO3COND above chosen limit

--- a/GMIchem_GridComp/GMI_GridComp/GmiSwapSpeciesBundlesMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiSwapSpeciesBundlesMod.F90
@@ -13,7 +13,6 @@ module GmiSwapSpeciesBundlesMod
 
       USE GmiStringManipulation_mod, ONLY : stringLowerCase
       USE GmiArrayBundlePointer_mod, ONLY : t_GmiArrayBundle
-!     USE Chem_ArrayMod
       USE Species_ArrayMod
 !
       implicit none
@@ -62,8 +61,8 @@ module GmiSwapSpeciesBundlesMod
 ! !INPUT/OUTPUT PARAMETERS:
       REAL                    :: specHum(:,:,:)
       type (t_GmiArrayBundle) :: gmiBundle(:)
-      type(species_array)        :: geos5BundleGG(:)
-      type(species_array)        :: geos5BundleXX(:)
+      type(Species_Array)     :: geos5BundleGG(:)
+      type(Species_Array)     :: geos5BundleXX(:)
 !
 ! !DESCRIPTION:
 !  Copy chemistry bundle to GMI's species concentration bundle and 

--- a/GMIchem_GridComp/GMI_GridComp/GmiSwapSpeciesBundlesMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiSwapSpeciesBundlesMod.F90
@@ -13,7 +13,8 @@ module GmiSwapSpeciesBundlesMod
 
       USE GmiStringManipulation_mod, ONLY : stringLowerCase
       USE GmiArrayBundlePointer_mod, ONLY : t_GmiArrayBundle
-      USE Chem_ArrayMod
+!     USE Chem_ArrayMod
+      USE Species_ArrayMod
 !
       implicit none
 !
@@ -41,7 +42,7 @@ module GmiSwapSpeciesBundlesMod
 !
 ! !INTERFACE:
 
-      SUBROUTINE SwapSpeciesBundles(direction, gmiBundle, geos5Bundle, &
+      SUBROUTINE SwapSpeciesBundles(direction, gmiBundle, geos5BundleGG, geos5BundleXX, &
                      specHum, mapSpecies, lchemvar, do_synoz, numSpecies, rc)
 
       IMPLICIT NONE
@@ -49,6 +50,8 @@ module GmiSwapSpeciesBundlesMod
 ! !INPUT PARAMETERS:
       INTEGER, INTENT(IN) :: numSpecies
       INTEGER, INTENT(IN) :: direction       ! 1=To GMI  -1=FromGMI
+#define GEOS_TO_GMI 1
+#define GMI_TO_GEOS -1
       INTEGER, INTENT(IN) :: mapSpecies(numSpecies) ! map GMI species indices to CCM indices
       LOGICAL, INTENT(IN) :: do_synoz
       character (len=*), intent(in) :: lchemvar(numSpecies) ! GMI list of species
@@ -59,7 +62,8 @@ module GmiSwapSpeciesBundlesMod
 ! !INPUT/OUTPUT PARAMETERS:
       REAL                    :: specHum(:,:,:)
       type (t_GmiArrayBundle) :: gmiBundle(:)
-      type(chem_array)        :: geos5Bundle(:)
+      type(species_array)        :: geos5BundleGG(:)
+      type(species_array)        :: geos5BundleXX(:)
 !
 ! !DESCRIPTION:
 !  Copy chemistry bundle to GMI's species concentration bundle and 
@@ -75,6 +79,7 @@ module GmiSwapSpeciesBundlesMod
       INTEGER :: STATUS
       INTEGER :: i, ic
       INTEGER :: k, km
+      INTEGER :: nqGG, nqXX
       LOGICAL :: found
       LOGICAL :: FeedBack_QV    ! TRUE for CCM, FALSE for CTM
       CHARACTER(LEN=255) :: speciesName
@@ -90,13 +95,16 @@ module GmiSwapSpeciesBundlesMod
 
       CALL CheckConfig(FeedBack_QV, __RC__)
 
-      IF (ABS(direction) /= 1) THEN
+      IF ( direction /= GEOS_TO_GMI .AND. direction /= GMI_TO_GEOS ) THEN
          rc=1
          PRINT *,TRIM(MyName),": Invalid direction specified for swapping bundles."
          RETURN
       END IF
 
       km = size(specHum, 3)
+
+      nqGG = size(geos5BundleGG)
+      nqXX = size(geos5BundleXX)
 
       DO ic=1,numSpecies
          found=.FALSE.
@@ -105,9 +113,9 @@ module GmiSwapSpeciesBundlesMod
          IF (TRIM(speciesName) == "H2O") THEN
     
             SELECT CASE (direction)
-            CASE ( 1)
+            CASE ( GEOS_TO_GMI )
                gmiBundle(ic)%pArray3D(:,:,km:1:-1) = specHum(:,:,1:km)*(MWTAIR/MWTH2O)
-            CASE (-1)
+            CASE ( GMI_TO_GEOS )
               IF ( FeedBack_QV ) THEN
                specHum(:,:,1:km) = gmiBundle(ic)%pArray3D(:,:,km:1:-1)*(MWTH2O/MWTAIR)
               END IF
@@ -123,16 +131,24 @@ module GmiSwapSpeciesBundlesMod
             i = mapSpecies(ic)
     
             SELECT CASE (direction)
-            CASE ( 1)
-               gmiBundle(ic)%pArray3D(:,:,km:1:-1) = geos5Bundle(i)%data3d(:,:,1:km)
+            CASE ( GEOS_TO_GMI )
+               IF ( i .LE. nqGG ) THEN
+                 gmiBundle(ic)%pArray3D(:,:,km:1:-1) = geos5BundleGG(i     )%data3d(:,:,1:km)
+               ELSE
+                 gmiBundle(ic)%pArray3D(:,:,km:1:-1) = geos5BundleXX(i-nqGG)%data3d(:,:,1:km)
+               END IF
 ! ########
 !                IF( MAPL_AM_I_ROOT() ) THEN
 !                  print*,'+++SPEC,iGMI,iGEOS '//TRIM(speciesName), ic, i
 !                END IF
 ! ########
 
-            CASE (-1)
-               geos5Bundle(i)%data3d(:,:,1:km) = gmiBundle(ic)%pArray3D(:,:,km:1:-1)
+            CASE ( GMI_TO_GEOS )
+               IF ( i .LE. nqGG ) THEN
+                 geos5BundleGG(i     )%data3d(:,:,1:km) = gmiBundle(ic)%pArray3D(:,:,km:1:-1)
+               ELSE
+                 geos5BundleXX(i-nqGG)%data3d(:,:,1:km) = gmiBundle(ic)%pArray3D(:,:,km:1:-1)
+               END IF
             END SELECT
     
             found=.TRUE.
@@ -149,14 +165,15 @@ module GmiSwapSpeciesBundlesMod
 ! !ROUTINE: speciesReg_for_CCM
 !
 ! !INTERFACE:
-      FUNCTION speciesReg_for_CCM(nameSpecies, vname, numSpecies, iStart, iEnd) RESULT(regCCM)
+      FUNCTION speciesReg_for_CCM(nameSpecies, numSpecies, vnameGG, vnameXX ) RESULT(regCCM)
 !
 ! !INPUT PARAMETERS:
-    INTEGER, INTENT(IN) :: numSpecies ! number of GMI species
-    INTEGER, INTENT(IN) :: iStart     ! Starting index for GMI transported species in w_c%qa
-    INTEGER, INTENT(IN) :: iEnd       ! Last index for GMI non-transported species in w_c%qa
-    CHARACTER (LEN=*), INTENT(IN) :: nameSpecies(numSpecies) ! GMI mechanism list of species
-    CHARACTER (LEN=*), INTENT(IN) :: vname(*)		     ! GMIChem internal list of species
+
+    CHARACTER (LEN=*), INTENT(IN) :: nameSpecies(numSpecies) ! GMI mechanism list of species  - setkins names
+    INTEGER,           INTENT(IN) :: numSpecies              ! number of setkins species
+
+    CHARACTER (LEN=*), INTENT(IN) :: vnameGG(:)		     ! GEOS list of species - part A (transported)
+    CHARACTER (LEN=*), INTENT(IN) :: vnameXX(:)		     ! GEOS list of species - part B (non-transported)
 !
 ! !RETURNED VALUE:
     INTEGER :: regCCM(numSpecies)
@@ -170,11 +187,15 @@ module GmiSwapSpeciesBundlesMod
     LOGICAL :: found
     CHARACTER(LEN=255) :: speciesName
     INTEGER, PARAMETER :: wrongIndex = -999
+    INTEGER  nqGG, nqXX
 !
 !EOP
 !------------------------------------------------------------------------------
 !BOC
       regCCM(:) = wrongIndex
+
+      nqGG = size(vnameGG)
+      nqXX = size(vnameXX)
 
 ! Scan the GMI mechanism's species list, with numSpecies = NSP
 ! ------------------------------------------------------------
@@ -190,17 +211,27 @@ module GmiSwapSpeciesBundlesMod
 
          found = .FALSE.
 
-! Look for a match in the Chem_Registry.rc
-! ----------------------------------------
-         GEOS5List: DO ii = iStart, iEnd
+! Look for a match in the GEOS set
+! --------------------------------
+         GEOS5ListGG: DO ii = 1, nqGG
 
-            IF(TRIM(stringLowerCase(speciesName)) == TRIM(stringLowerCase(vname(ii)))) THEN
+            IF(TRIM(stringLowerCase(speciesName)) == TRIM(stringLowerCase(vnameGG(ii)))) THEN
                regCCM(ic) = ii
                found = .TRUE.
-               EXIT GEOS5List
+               EXIT GEOS5ListGG
             END IF
 
-         END DO GEOS5List
+         END DO GEOS5ListGG
+
+         GEOS5ListXX: DO ii = 1, nqXX
+
+            IF(TRIM(stringLowerCase(speciesName)) == TRIM(stringLowerCase(vnameXX(ii)))) THEN
+               regCCM(ic) = ii + nqGG
+               found = .TRUE.
+               EXIT GEOS5ListXX
+            END IF
+
+         END DO GEOS5ListXX
 
          IF (.NOT. found .AND. TRIM(nameSpecies(ic)) /= "H2O" ) THEN
             PRINT *,"speciesReg_for_CCM: "//TRIM(nameSpecies(ic))//" not found in GMIChem internal state"

--- a/GMIchem_GridComp/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
@@ -20,6 +20,8 @@
    USE Chem_Mod 	     ! Chemistry Base Class
    USE Chem_UtilMod
 
+   USE Species_BundleMod
+
    USE GmiChemistryMethod_mod,        ONLY : t_Chemistry
    USE GmiEmissionMethod_mod,         ONLY : t_Emission
    USE GmiDepositionMethod_mod,       ONLY : t_Deposition
@@ -137,7 +139,7 @@ CONTAINS
 ! !INTERFACE:
 !
 
-   SUBROUTINE GmiThermalRC_GridCompInitialize( self, w_c, impChem, expChem, nymd, nhms, &
+   SUBROUTINE GmiThermalRC_GridCompInitialize( self, bgg, bxx, impChem, expChem, nymd, nhms, &
                                       tdt, rc )
 
    USE GmiSpcConcentrationMethod_mod, ONLY : InitializeSpcConcentration
@@ -151,7 +153,8 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), INTENT(in) :: w_c                ! Chemical tracer fields, delp, +
+   TYPE(Species_Bundle), INTENT(in) :: bgg                ! Chemical tracer fields, delp, +
+   TYPE(Species_Bundle), INTENT(in) :: bxx                ! Chemical tracer fields, delp, +
    INTEGER, INTENT(IN) :: nymd, nhms		       ! Time from AGCM
    REAL,    INTENT(IN) :: tdt			       ! Chemistry time step (secs)
 
@@ -194,7 +197,7 @@ CONTAINS
    INTEGER :: ilo, ihi, julo, jvlo, jhi
    INTEGER :: ilo_gl, ihi_gl, julo_gl, jvlo_gl, jhi_gl
    INTEGER :: gmi_nborder
-   INTEGER :: numSpecies
+   INTEGER :: NMR      ! number of species from the GMI_Mech_Registry.rc
    INTEGER :: LogicalUnitNum
 
    INTEGER :: loc_proc, locGlobProc, commu_slaves
@@ -404,20 +407,23 @@ CONTAINS
                           ilo_gl, ihi_gl, julo_gl, jvlo_gl, jhi_gl, &
                           ilong, ilat, ivert, itloop, j1p, j2p)  
 
-! Number of species and perform a consistency check with setkin_par.h.
-! NOTES:
-!  1. H2O is specie number 10 in the strat-trop mechanism, but will not be
-!     found in w_c%reg%vname. H2O will be initialized from specific humidity, Q.
-!  2. The GEOS-5 bundle has an Age-Of-Air tracer, which is not carried by GMI.
-!  3. At the end of the XX (non-transported) species is a place holder for T2M15d.
-! So w_c%reg%j_XX-w_c%reg%i_GMI must equal the parameter NSP = NCONST + NDYN.
+! Perform a consistency check with setkin_par.h.
+!   NSP is the number of species in setkins
+!   NMR is the number of species in the Mech Registry
+!
+!   H2O   is in setkins,           but not in GMI_Mech_Registry
+!   AOA   is in GMI_Mech_Registry, but not in setkins
+!   T2M15 is in GMI_Mech_Registry, but not in setkins
+!
+!   The number of species common to both is therefore
+!     NMR - 2     ! number in GMI_Mech_Registry - 2
+!     NSP - 1     ! number in setkins - 1
 ! --------------------------------------------------------------------------------
-   numSpecies = w_c%reg%j_XX-w_c%reg%i_GMI
-   IF(numSpecies /= NSP) THEN
-    PRINT *,TRIM(IAm),': Number of species from Chem_Registry.rc does not match number in setkin_par.h'
+   NMR = bgg%nq + bxx%nq
+   IF( NMR-2 /= NSP-1 ) THEN
+    PRINT *,TRIM(IAm),': Number of species from GMI_Mech_Registry.rc does not match number in setkin_par.h'
     STATUS = 1
     VERIFY_(STATUS)
-    RETURN
    END IF
 
 ! Photolysis reaction list.  Read from kinetics
@@ -439,8 +445,8 @@ CONTAINS
 ! ----------------------------------------------------------
 
       CALL InitializeSpcConcentration(self%SpeciesConcentration,              &
-     &               self%gmiGrid, gmiConfigFile, numSpecies, NMF, NCHEM,     &
-     &               loc_proc)
+                     self%gmiGrid, gmiConfigFile, NSP, NMF, NCHEM,            &
+                     loc_proc)
 
       Allocate(self%qkgmi(NUM_K))
       do ic = 1, NUM_K
@@ -464,7 +470,7 @@ CONTAINS
       write (binName ,'(i4.4)') ib
       varName = 'qk'//binName
 
-      call addTracerToBundle (qkBundle, var, w_c%grid_esmf, varName)
+      call addTracerToBundle (qkBundle, var, bgg%grid_esmf, varName)
    end do
 
    ! Sanity check
@@ -479,7 +485,7 @@ CONTAINS
     !---------------------------------------------------------------
 
     allocate(self%mapSpecies(NSP))
-    self%mapSpecies(:) = speciesReg_for_CCM(lchemvar, w_c%reg%vname, NSP, w_c%reg%i_GMI, w_c%reg%j_XX)
+    self%mapSpecies(:) = speciesReg_for_CCM(lchemvar, NSP, bgg%reg%vname, bxx%reg%vname )
 
   RETURN
 
@@ -495,7 +501,7 @@ CONTAINS
 ! !INTERFACE:
 !
 
-   SUBROUTINE GmiThermalRC_GridCompRun ( self, w_c, impChem, expChem, nymd, nhms, &
+   SUBROUTINE GmiThermalRC_GridCompRun ( self, bgg, bxx, impChem, expChem, nymd, nhms, &
                                 tdt, rc )
 
 ! !USES:
@@ -512,7 +518,8 @@ CONTAINS
 ! !INPUT/OUTPUT PARAMETERS:
 
    TYPE(GmiThermalRC_GridComp), INTENT(INOUT) :: self ! Grid Component
-   TYPE(Chem_Bundle), INTENT(INOUT) :: w_c    ! Chemical tracer fields   
+   TYPE(Species_Bundle), INTENT(INOUT) :: bgg    ! Chemical tracer fields   
+   TYPE(Species_Bundle), INTENT(INOUT) :: bxx    ! Chemical tracer fields   
 
 ! !INPUT PARAMETERS:
 
@@ -731,7 +738,7 @@ CONTAINS
 ! -----------------------------------------------
    IF (self%gotImportRst) then
       CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration, &
-               w_c%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
+               bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
                STATUS)
       VERIFY_(STATUS)
    END IF
@@ -794,7 +801,7 @@ CONTAINS
 ! -----------------------------------------------------
    IF (self%gotImportRst) then
       CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration, &
-               w_c%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
+               bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
                STATUS)
       VERIFY_(STATUS)
    END IF
@@ -1141,8 +1148,8 @@ CONTAINS
     CALL pmaxmin('CNV_MFC:', cnv_mfc, qmin, qmax, iXj, km+1, 1. )
     CALL pmaxmin('RH2:', rh2, qmin, qmax, iXj, km, 1. )
 
-    i = w_c%reg%j_XX
-    CALL pmaxmin('TROPP:', w_c%qa(i)%data3d(:,:,km), qmin, qmax, iXj, 1, 0.01 )
+    i = bxx%reg%nq
+    CALL pmaxmin('TROPP:', bxx%qa(i)%data3d(:,:,km), qmin, qmax, iXj, 1, 0.01 )
 
     CALL pmaxmin('FRLAND:', frland, qmin, qmax, iXj, 1, 1. )
     CALL pmaxmin('FRLANDICE:', frlandice, qmin, qmax, iXj, 1, 1. )
@@ -1190,8 +1197,8 @@ CONTAINS
 ! Singly-layered                                                            GEOS-5 Units       GMI Units
 ! The most recent valid tropopause pressures are stored in T2M15D(:,:,km)
 ! -----------------------------------------------------------------------   ------------       -------------
-  i = w_c%reg%j_XX
-  tropopausePress(i1:i2,j1:j2) = w_c%qa(i)%data3d(i1:i2,j1:j2,km)*Pa2hPa    ! Pa               hPa
+  i = bxx%reg%nq
+  tropopausePress(i1:i2,j1:j2) = bxx%qa(i)%data3d(i1:i2,j1:j2,km)*Pa2hPa    ! Pa               hPa
 
 ! Layer means                                                               GEOS-5 Units       GMI Units
 ! -----------                                                               ------------       -------------
@@ -1259,7 +1266,7 @@ CONTAINS
 ! !INTERFACE:
 !
 
-   SUBROUTINE GmiThermalRC_GridCompFinalize ( self, w_c, impChem, expChem, &
+   SUBROUTINE GmiThermalRC_GridCompFinalize ( self, impChem, expChem, &
                                      nymd, nhms, cdt, rc )
 
   IMPLICIT none
@@ -1270,7 +1277,6 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Chem_Bundle), INTENT(in)  :: w_c      ! Chemical tracer fields   
    INTEGER, INTENT(in) :: nymd, nhms	      ! time
    REAL,    INTENT(in) :: cdt  	              ! chemical timestep (secs)
 

--- a/GMIchem_GridComp/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiThermalRC_GridCompClassMod.F90
@@ -121,7 +121,7 @@
 
 ! Component derived type declarations
 ! -----------------------------------
-   TYPE(t_gmiGrid   )		:: gmiGrid
+   TYPE(t_gmiGrid   )           :: gmiGrid
    TYPE(t_GmiClock  )           :: gmiClock
    TYPE(t_SpeciesConcentration) :: SpeciesConcentration
  
@@ -143,7 +143,7 @@ CONTAINS
                                       tdt, rc )
 
    USE GmiSpcConcentrationMethod_mod, ONLY : InitializeSpcConcentration
-   USE GmiGrid_mod,		      ONLY : InitializeGmiGrid
+   USE GmiGrid_mod,                   ONLY : InitializeGmiGrid
    USE GmiTimeControl_mod,            ONLY : Set_curGmiDate, Set_curGmiTime
    USE GmiTimeControl_mod,            ONLY : Set_begGmiDate, Set_begGmiTime
    USE GmiTimeControl_mod,            ONLY : Set_numTimeSteps
@@ -153,10 +153,10 @@ CONTAINS
 
 ! !INPUT PARAMETERS:
 
-   TYPE(Species_Bundle), INTENT(in) :: bgg                ! Chemical tracer fields, delp, +
-   TYPE(Species_Bundle), INTENT(in) :: bxx                ! Chemical tracer fields, delp, +
-   INTEGER, INTENT(IN) :: nymd, nhms		       ! Time from AGCM
-   REAL,    INTENT(IN) :: tdt			       ! Chemistry time step (secs)
+   TYPE(Species_Bundle), INTENT(IN) :: bgg                ! GMI Species - transported
+   TYPE(Species_Bundle), INTENT(IN) :: bxx                ! GMI Species - not transported
+   INTEGER,              INTENT(IN) :: nymd, nhms         ! Time from AGCM
+   REAL,                 INTENT(IN) :: tdt                ! Chemistry time step (secs)
 
 ! !OUTPUT PARAMETERS:
 
@@ -517,15 +517,15 @@ CONTAINS
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   TYPE(GmiThermalRC_GridComp), INTENT(INOUT) :: self ! Grid Component
-   TYPE(Species_Bundle), INTENT(INOUT) :: bgg    ! Chemical tracer fields   
-   TYPE(Species_Bundle), INTENT(INOUT) :: bxx    ! Chemical tracer fields   
+   TYPE(GmiThermalRC_GridComp), INTENT(INOUT) :: self   ! Grid Component
+   TYPE(Species_Bundle),        INTENT(INOUT) :: bgg    ! GMI Species - transported
+   TYPE(Species_Bundle),        INTENT(INOUT) :: bxx    ! GMI Species - not transported
 
 ! !INPUT PARAMETERS:
 
    TYPE(ESMF_State), INTENT(INOUT) :: impChem ! Import State
-   INTEGER, INTENT(IN) :: nymd, nhms	      ! time
-   REAL,    INTENT(IN) :: tdt		      ! chemical timestep (secs)
+   INTEGER, INTENT(IN) :: nymd, nhms          ! time
+   REAL,    INTENT(IN) :: tdt                 ! chemical timestep (secs)
 
 ! !OUTPUT PARAMETERS:
 
@@ -737,7 +737,7 @@ CONTAINS
 ! Hand the species concentrations to GMI's bundle
 ! -----------------------------------------------
    IF (self%gotImportRst) then
-      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration, &
+      CALL SwapSpeciesBundles(ToGMI, self%SpeciesConcentration%concentration,    &
                bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP, &
                STATUS)
       VERIFY_(STATUS)
@@ -800,7 +800,7 @@ CONTAINS
 ! Return species concentrations to the chemistry bundle
 ! -----------------------------------------------------
    IF (self%gotImportRst) then
-      CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration, &
+      CALL SwapSpeciesBundles(FromGMI, self%SpeciesConcentration%concentration,   &
                bgg%qa, bxx%qa, Q, self%mapSpecies, lchemvar, self%do_synoz, NSP,  &
                STATUS)
       VERIFY_(STATUS)

--- a/Shared/Chem_Base/AMIP/Chem_Registry.rc
+++ b/Shared/Chem_Base/AMIP/Chem_Registry.rc
@@ -55,7 +55,6 @@ doing_NI:  no   # &YesNo Include nitrate?
 doing_Rn:  no   # &YesNo include Radon?
 doing_CH4: no   # &YesNo include Methane?
 doing_SC:  no   # &YesNo Include stratospheric chemistry?
-doing_GMI: no   # &YesNo GMI chemistry (GEOS-5)
 doing_XX:  no   # &YesNo generic tracer
 doing_PC:  yes  # parameterized chemistry (GEOS-5)
 doing_OCS: no   # ACHEM chemistry (OCS)
@@ -83,8 +82,6 @@ nbins_XX_SC_f: 18   # stratchem (full) non-transported species
 nbins_SC_r:    33   # stratospheric chemistry (reduced)
 nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
 nbins_PC:       1   # parameterized chemistry (GEOS-5)
-nbins_GMI:     72   # GMI chemistry (GEOS-5)
-nbins_XX_GMI:  48   # generic tracer
 nbins_OCS:      1   # ACHEM chemistry (OCS)
 
 # Units for each constituent
@@ -106,7 +103,6 @@ units_CH4: 'mol mol-1'   # methane
 units_SC:  'mol mol-1'   # stratospheric chemistry
 units_XX:  'mol mol-1'   # generic tracer
 units_PC:  'kg kg-1'     # parameterized chemistry (GEOS-5)
-units_GMI: 'mol mol-1'   # GMI chemistry (GEOS-5)
 units_OCS: 'kg kg-1'     # ACHEM chemistry (OCS)
 
 # Variable names to override defaults.  Optional.  Name and Units must 
@@ -396,138 +392,6 @@ SF6        'mol mol-1'  Sulfur hexafluoride
 RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
-variable_table_GMI::
-
-# Name     Units        Long Name
-# -----    ------       --------------------------------
-AOADAYS    days         Age-of-air
-CH2O       'mol mol-1'  Formaldehyde
-CH4        'mol mol-1'  Methane
-CO         'mol mol-1'  Carbon monoxide
-H2         'mol mol-1'  Molecular hydrogen
-HCOOH      'mol mol-1'  Formic acid (CH2O2)
-HNO2       'mol mol-1'  Nitrous acid
-HNO3       'mol mol-1'  Nitric acid
-HNO4       'mol mol-1'  Pernitric acid
-HO2        'mol mol-1'  Perhydroxyl radical
-H2O2       'mol mol-1'  Hydrogen peroxide
-MOH        'mol mol-1'  Methanol
-MP         'mol mol-1'  Methyl hydroperoxide  
-N2O        'mol mol-1'  Nitrous oxide
-NO         'mol mol-1'  Nitric oxide
-NO2        'mol mol-1'  Nitrogen dioxide
-NO3        'mol mol-1'  Nitrogen trioxide
-N2O5       'mol mol-1'  Dinitrogen pentoxide
-OX         'mol mol-1'  Ozone
-OH         'mol mol-1'  Hydroxyl radical
-Br         'mol mol-1'  Ground state atomic bromine (2P3/2)
-BrCl       'mol mol-1'  Bromine chloride
-BrO        'mol mol-1'  Bromine monoxide radical
-BrONO2     'mol mol-1'  Bromine nitrate
-HBr        'mol mol-1'  Hydrogen bromide
-HOBr       'mol mol-1'  Hydrobromous acid
-Cl         'mol mol-1'  Ground state atomic chlorine (2P3/2)
-Cl2        'mol mol-1'  Molecular chlorine
-ClO        'mol mol-1'  Chlorine monoxide radical
-Cl2O2      'mol mol-1'  Chlorine peroxide
-ClONO2     'mol mol-1'  Chlorine nitrate
-HCl        'mol mol-1'  Hydrochloric acid
-HOCl       'mol mol-1'  Hydrochlorous acid
-OClO       'mol mol-1'  Symmetrical chlorine dioxide
-CH3Br      'mol mol-1'  Methyl bromide
-CH3Cl      'mol mol-1'  Methyl chloride
-CH3CCl3    'mol mol-1'  Methyl chloroform
-CCl4       'mol mol-1'  Carbon tetrachloride
-CFC11      'mol mol-1'  CFC11 (CFCl3)
-CFC12      'mol mol-1'  CFC12 (CF2Cl2)
-CFC113     'mol mol-1'  CFC113 (C2Cl3F3)
-CFC114     'mol mol-1'  CFC114 (C2Cl2F4)
-CFC115     'mol mol-1'  CFC115 (C2ClF5)
-HCFC22     'mol mol-1'  HCFC22 (CClF2H)
-HCFC141b   'mol mol-1'  HCFC141b (C2Cl2FH3)
-HCFC142b   'mol mol-1'  HCFC142b (C2ClF2H3)
-CF2Br2     'mol mol-1'  Halon 1202
-CF2ClBr    'mol mol-1'  Halon 1211
-CF3Br      'mol mol-1'  Halon 1301
-H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
-ACTA       'mol mol-1'  Acetic acid (C2H4O2)
-ALD2       'mol mol-1'  Acetaldehyde (C2H4O)
-ALK4       'mol mol-1'  C4-5 alkanes (C4H10 C5H12)
-C2H6       'mol mol-1'  Ethane
-C3H8       'mol mol-1'  Propane
-ETP        'mol mol-1'  Ethylhydroperoxide (C2H6O2) from ETO2
-HAC        'mol mol-1'  Hydroxyacetone (C3H6O2)
-IALD       'mol mol-1'  Hydroxy carbonyl alkenes (C5H8O2) from isoprene
-IAP        'mol mol-1'  Peroxide (C5H10O5) from IAO2
-ISOP       'mol mol-1'  Isoprene (C5H8)
-MACR       'mol mol-1'  Methacrolein (C4H6O)
-MEK        'mol mol-1'  Methyl ethyl ketone (C4H8O)
-MVK        'mol mol-1'  Methyl vinyl ketone (C4H6O)
-PAN        'mol mol-1'  Peroxyacetyl nitrate (C2H3NO5)
-PMN        'mol mol-1'  Peroxymethacryloyl nitrate (C4H5O5N)
-PPN        'mol mol-1'  Peroxypropionyl nitrate (C3H5NO5)
-PRPE       'mol mol-1'  Propene (C3H6)
-R4N2       'mol mol-1'  C4-C5 alkylnitrates (C4H9O3N)
-RCHO       'mol mol-1'  C2 aldehydes (C3H6O)
-RCOOH      'mol mol-1'  C2 organic acids
-N2          cm-3        Molecular nitrogen
-HNO3COND   'mol mol-1'  Condensed nitric acid
-::
-
-variable_table_XX_GMI::
-
-# Name     Units        Long Name
-# -----    ------       --------------------------------
-H          'mol mol-1'  Ground state atomic hydrogen (2S)
-MO2        'mol mol-1'  Methylperoxy radical (CH3O2)
-N          'mol mol-1'  Ground state atomic nitrogen
-O          'mol mol-1'  Ground state atomic oxygen (3P)
-O1D        'mol mol-1'  First excited singlet state of atomic oxygen (1D)
-A3O2       'mol mol-1'  Primary RO2 (C3H7O2) from propane
-ATO2       'mol mol-1'  RO2 from acetone (C3H6O3)
-B3O2       'mol mol-1'  Secondary RO2 (C3H7O2) from propane
-EOH        'mol mol-1'  Ethanol
-ETO2       'mol mol-1'  Ethylperoxy radical (C2H5O2)
-GLYC       'mol mol-1'  Glycolaldehyde (Hydroxyacetaldehyde C2H4O2)
-GLYX       'mol mol-1'  Glyoxal (2CHO)
-IAO2       'mol mol-1'  RO2 (C5H9O5) from isoprene oxidation products
-INO2       'mol mol-1'  RO2 (C5H8O3N) from ISOP+NO3
-INPN       'mol mol-1'  Peroxide (C5H8O6N2) from INO2
-ISN1       'mol mol-1'  RO2 (C4H7O4N) from ISN2
-ISNP       'mol mol-1'  Peroxide (C4H7O4N) from ISN1
-KO2        'mol mol-1'  RO2 (C4H7O3) from C3 ketones
-MAN2       'mol mol-1'  RO2 (C4H6O6N) from MACR+NO3
-MAO3       'mol mol-1'  Peroxyacyl (C4H5O3) from MACR and MVK
-MAOP       'mol mol-1'  Peroxide (C4H6O3) from MAO3
-MAP        'mol mol-1'  Peroxyacetic acid (C2H4O3)
-MCO3       'mol mol-1'  Peroxyacetyl radical (C2H3O3)
-MGLY       'mol mol-1'  Methylglyoxal (C3H4O2)
-MRO2       'mol mol-1'  RO2 (C4H7O4) from MACR+OH
-MRP        'mol mol-1'  Peroxide (C4H8O4) from MRO2
-PO2        'mol mol-1'  RO2 (C3H7O3) from propene
-PP         'mol mol-1'  Peroxide (C3H8O3) from PO2
-PRN1       'mol mol-1'  RO2 (C3H6O3N) from propene+NO3
-PRPN       'mol mol-1'  Peroxide (C3H6O3N) from PRN1
-R4N1       'mol mol-1'  RO2 (C4H9O3N) from R4N2
-R4O2       'mol mol-1'  RO2 (C4H9O2) from ALK4
-R4P        'mol mol-1'  Peroxide (C4H10O2) from R4O2
-RA3P       'mol mol-1'  Peroxy propyl alcohol (C3H8O2) from A3O2
-RB3P       'mol mol-1'  Peroxide (C3H8O2) from B3O2
-RCO3       'mol mol-1'  Peroxypropionyl radical (C3H5O3)
-RIO1       'mol mol-1'  RO2 (C5H9O3) from isoprene oxydation products
-RIO2       'mol mol-1'  RO2 (C5H9O3) from isoprene
-RIP        'mol mol-1'  Peroxide (C5H10O3) from RIO2
-ROH        'mol mol-1'  C2 alcohols
-RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
-VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
-VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl sulfide in GMI
-ACET       'mol mol-1'  Acetone
-O2          cm-3        Molecular oxygen
-NUMDENS     cm-3        Total number density
-T2M15d      K           Daily T2M time average
-::
-
 #........................................................................
 
 #               -------------------
@@ -553,14 +417,12 @@ advect_CH4: yes  # methane
 advect_SC:  yes  # stratospheric chemistry
 advect_XX:  no   # generic tracer
 advect_PC:  yes  # parameterized chemistry (GEOS-5)
-advect_GMI: yes  # GMI chemistry (GEOS-5)
 advect_OCS: yes  # ACHEM chemistry (OCS)
 
 # Whether to diffuse the constituent
 # ----------------------------------
 diffuse_H2O: yes  # water vapor 
 diffuse_O3:  yes  # ozone 
-diffuse_XX:  yes  # generic tracer
 diffuse_CO:  yes  # carbon monoxide
 diffuse_CO2: yes  # carbon dioxide
 diffuse_DU:  yes  # mineral dust
@@ -576,6 +438,5 @@ diffuse_CH4: yes  # methane
 diffuse_SC:  yes  # stratospheric chemistry
 diffuse_XX:  yes  # generic tracer
 diffuse_PC:  yes  # parameterized chemistry (GEOS-5)
-diffuse_GMI: yes  # GMI chemistry (GEOS-5)
 diffuse_OCS: yes  # ACHEM chemistry (OCS)
 

--- a/Shared/Chem_Base/CMakeLists.txt
+++ b/Shared/Chem_Base/CMakeLists.txt
@@ -4,7 +4,9 @@ set (srcs
   Chem_RegistryMod.F90
   Runtime_RegistryMod.F90
   Chem_ArrayMod.F90
+  Species_ArrayMod.F90
   Chem_BundleMod.F90
+  Species_BundleMod.F90
   Chem_Mod.F90
   Chem_InitMod.F90
   Chem_MieTableMod.F90

--- a/Shared/Chem_Base/Chem_BundleMod.F90
+++ b/Shared/Chem_Base/Chem_BundleMod.F90
@@ -229,7 +229,11 @@
 !    ------------
      rc = 0
      nq = reg%nq
-     if ( im<1 .or. jm<1 .or. km<1 .or. nq<1) then
+
+!    9.15.22 manyin: As we move away from Chem_Registry, there may be
+!                    cases where NO tracers are active
+!    if ( im<1 .or. jm<1 .or. km<1 .or. nq<1) then
+     if ( im<1 .or. jm<1 .or. km<1          ) then
           rc = -3
           return
      endif
@@ -362,14 +366,12 @@
            if ( ios4 == 0 ) w_c%airdens = 0.0
         endif
 
-         
      end if
 
 !    Set array of pointers: may be null() if no allocation took place
 !    ----------------------------------------------------------------
      call Chem_BundleSetPtr ( w_c, rc ) 
 
-  
    end subroutine Chem_BundleCreate_
 
 !-------------------------------------------------------------------------

--- a/Shared/Chem_Base/Chem_Registry.rc
+++ b/Shared/Chem_Base/Chem_Registry.rc
@@ -55,7 +55,6 @@ doing_NI:  no   # &YesNo Include nitrate?
 doing_Rn:  no   # &YesNo include Radon?
 doing_CH4: no   # &YesNo include Methane?
 doing_SC:  no   # &YesNo Include stratospheric chemistry?
-doing_GMI: no   # &YesNo GMI chemistry (GEOS-5)
 doing_XX:  no   # &YesNo generic tracer
 doing_PC:  yes  # parameterized chemistry (GEOS-5)
 doing_OCS: no   # ACHEM chemistry (OCS)
@@ -83,8 +82,6 @@ nbins_XX_SC_f: 18   # stratchem (full) non-transported species
 nbins_SC_r:    33   # stratospheric chemistry (reduced)
 nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
 nbins_PC:       1   # parameterized chemistry (GEOS-5)
-nbins_GMI:     72   # GMI chemistry (GEOS-5)
-nbins_XX_GMI:  48   # generic tracer
 nbins_OCS:      1   # ACHEM chemistry (OCS)
 
 # Units for each constituent
@@ -106,7 +103,6 @@ units_CH4: 'mol mol-1'   # methane
 units_SC:  'mol mol-1'   # stratospheric chemistry
 units_XX:  'mol mol-1'   # generic tracer
 units_PC:  'kg kg-1'     # parameterized chemistry (GEOS-5)
-units_GMI: 'mol mol-1'   # GMI chemistry (GEOS-5)
 units_OCS: 'kg kg-1'     # ACHEM chemistry (OCS)
 
 # Variable names to override defaults.  Optional.  Name and Units must 
@@ -396,138 +392,6 @@ SF6        'mol mol-1'  Sulfur hexafluoride
 RO3OX      "none"       Ozone-to-odd oxygen ratio
 ::
 
-variable_table_GMI::
-
-# Name     Units        Long Name
-# -----    ------       --------------------------------
-AOADAYS    days         Age-of-air
-CH2O       'mol mol-1'  Formaldehyde
-CH4        'mol mol-1'  Methane
-CO         'mol mol-1'  Carbon monoxide
-H2         'mol mol-1'  Molecular hydrogen
-HCOOH      'mol mol-1'  Formic acid (CH2O2)
-HNO2       'mol mol-1'  Nitrous acid
-HNO3       'mol mol-1'  Nitric acid
-HNO4       'mol mol-1'  Pernitric acid
-HO2        'mol mol-1'  Perhydroxyl radical
-H2O2       'mol mol-1'  Hydrogen peroxide
-MOH        'mol mol-1'  Methanol
-MP         'mol mol-1'  Methyl hydroperoxide  
-N2O        'mol mol-1'  Nitrous oxide
-NO         'mol mol-1'  Nitric oxide
-NO2        'mol mol-1'  Nitrogen dioxide
-NO3        'mol mol-1'  Nitrogen trioxide
-N2O5       'mol mol-1'  Dinitrogen pentoxide
-OX         'mol mol-1'  Ozone
-OH         'mol mol-1'  Hydroxyl radical
-Br         'mol mol-1'  Ground state atomic bromine (2P3/2)
-BrCl       'mol mol-1'  Bromine chloride
-BrO        'mol mol-1'  Bromine monoxide radical
-BrONO2     'mol mol-1'  Bromine nitrate
-HBr        'mol mol-1'  Hydrogen bromide
-HOBr       'mol mol-1'  Hydrobromous acid
-Cl         'mol mol-1'  Ground state atomic chlorine (2P3/2)
-Cl2        'mol mol-1'  Molecular chlorine
-ClO        'mol mol-1'  Chlorine monoxide radical
-Cl2O2      'mol mol-1'  Chlorine peroxide
-ClONO2     'mol mol-1'  Chlorine nitrate
-HCl        'mol mol-1'  Hydrochloric acid
-HOCl       'mol mol-1'  Hydrochlorous acid
-OClO       'mol mol-1'  Symmetrical chlorine dioxide
-CH3Br      'mol mol-1'  Methyl bromide
-CH3Cl      'mol mol-1'  Methyl chloride
-CH3CCl3    'mol mol-1'  Methyl chloroform
-CCl4       'mol mol-1'  Carbon tetrachloride
-CFC11      'mol mol-1'  CFC11 (CFCl3)
-CFC12      'mol mol-1'  CFC12 (CF2Cl2)
-CFC113     'mol mol-1'  CFC113 (C2Cl3F3)
-CFC114     'mol mol-1'  CFC114 (C2Cl2F4)
-CFC115     'mol mol-1'  CFC115 (C2ClF5)
-HCFC22     'mol mol-1'  HCFC22 (CClF2H)
-HCFC141b   'mol mol-1'  HCFC141b (C2Cl2FH3)
-HCFC142b   'mol mol-1'  HCFC142b (C2ClF2H3)
-CF2Br2     'mol mol-1'  Halon 1202
-CF2ClBr    'mol mol-1'  Halon 1211
-CF3Br      'mol mol-1'  Halon 1301
-H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
-ACTA       'mol mol-1'  Acetic acid (C2H4O2)
-ALD2       'mol mol-1'  Acetaldehyde (C2H4O)
-ALK4       'mol mol-1'  C4-5 alkanes (C4H10 C5H12)
-C2H6       'mol mol-1'  Ethane
-C3H8       'mol mol-1'  Propane
-ETP        'mol mol-1'  Ethylhydroperoxide (C2H6O2) from ETO2
-HAC        'mol mol-1'  Hydroxyacetone (C3H6O2)
-IALD       'mol mol-1'  Hydroxy carbonyl alkenes (C5H8O2) from isoprene
-IAP        'mol mol-1'  Peroxide (C5H10O5) from IAO2
-ISOP       'mol mol-1'  Isoprene (C5H8)
-MACR       'mol mol-1'  Methacrolein (C4H6O)
-MEK        'mol mol-1'  Methyl ethyl ketone (C4H8O)
-MVK        'mol mol-1'  Methyl vinyl ketone (C4H6O)
-PAN        'mol mol-1'  Peroxyacetyl nitrate (C2H3NO5)
-PMN        'mol mol-1'  Peroxymethacryloyl nitrate (C4H5O5N)
-PPN        'mol mol-1'  Peroxypropionyl nitrate (C3H5NO5)
-PRPE       'mol mol-1'  Propene (C3H6)
-R4N2       'mol mol-1'  C4-C5 alkylnitrates (C4H9O3N)
-RCHO       'mol mol-1'  C2 aldehydes (C3H6O)
-RCOOH      'mol mol-1'  C2 organic acids
-N2          cm-3        Molecular nitrogen
-HNO3COND   'mol mol-1'  Condensed nitric acid
-::
-
-variable_table_XX_GMI::
-
-# Name     Units        Long Name
-# -----    ------       --------------------------------
-H          'mol mol-1'  Ground state atomic hydrogen (2S)
-MO2        'mol mol-1'  Methylperoxy radical (CH3O2)
-N          'mol mol-1'  Ground state atomic nitrogen
-O          'mol mol-1'  Ground state atomic oxygen (3P)
-O1D        'mol mol-1'  First excited singlet state of atomic oxygen (1D)
-A3O2       'mol mol-1'  Primary RO2 (C3H7O2) from propane
-ATO2       'mol mol-1'  RO2 from acetone (C3H6O3)
-B3O2       'mol mol-1'  Secondary RO2 (C3H7O2) from propane
-EOH        'mol mol-1'  Ethanol
-ETO2       'mol mol-1'  Ethylperoxy radical (C2H5O2)
-GLYC       'mol mol-1'  Glycolaldehyde (Hydroxyacetaldehyde C2H4O2)
-GLYX       'mol mol-1'  Glyoxal (2CHO)
-IAO2       'mol mol-1'  RO2 (C5H9O5) from isoprene oxidation products
-INO2       'mol mol-1'  RO2 (C5H8O3N) from ISOP+NO3
-INPN       'mol mol-1'  Peroxide (C5H8O6N2) from INO2
-ISN1       'mol mol-1'  RO2 (C4H7O4N) from ISN2
-ISNP       'mol mol-1'  Peroxide (C4H7O4N) from ISN1
-KO2        'mol mol-1'  RO2 (C4H7O3) from C3 ketones
-MAN2       'mol mol-1'  RO2 (C4H6O6N) from MACR+NO3
-MAO3       'mol mol-1'  Peroxyacyl (C4H5O3) from MACR and MVK
-MAOP       'mol mol-1'  Peroxide (C4H6O3) from MAO3
-MAP        'mol mol-1'  Peroxyacetic acid (C2H4O3)
-MCO3       'mol mol-1'  Peroxyacetyl radical (C2H3O3)
-MGLY       'mol mol-1'  Methylglyoxal (C3H4O2)
-MRO2       'mol mol-1'  RO2 (C4H7O4) from MACR+OH
-MRP        'mol mol-1'  Peroxide (C4H8O4) from MRO2
-PO2        'mol mol-1'  RO2 (C3H7O3) from propene
-PP         'mol mol-1'  Peroxide (C3H8O3) from PO2
-PRN1       'mol mol-1'  RO2 (C3H6O3N) from propene+NO3
-PRPN       'mol mol-1'  Peroxide (C3H6O3N) from PRN1
-R4N1       'mol mol-1'  RO2 (C4H9O3N) from R4N2
-R4O2       'mol mol-1'  RO2 (C4H9O2) from ALK4
-R4P        'mol mol-1'  Peroxide (C4H10O2) from R4O2
-RA3P       'mol mol-1'  Peroxy propyl alcohol (C3H8O2) from A3O2
-RB3P       'mol mol-1'  Peroxide (C3H8O2) from B3O2
-RCO3       'mol mol-1'  Peroxypropionyl radical (C3H5O3)
-RIO1       'mol mol-1'  RO2 (C5H9O3) from isoprene oxydation products
-RIO2       'mol mol-1'  RO2 (C5H9O3) from isoprene
-RIP        'mol mol-1'  Peroxide (C5H10O3) from RIO2
-ROH        'mol mol-1'  C2 alcohols
-RP         'mol mol-1'  Methacrolein peroxy acid (C4H6O3)
-VRO2       'mol mol-1'  RO2 (C4H7O4) from MVK+OH
-VRP        'mol mol-1'  Peroxide (C4H8O4) from VRO2
-OCSg       'mol mol-1'  Carbonyl sulfide in GMI
-ACET       'mol mol-1'  Acetone
-O2          cm-3        Molecular oxygen
-NUMDENS     cm-3        Total number density
-T2M15d      K           Daily T2M time average
-::
-
 #........................................................................
 
 #               -------------------
@@ -553,14 +417,12 @@ advect_CH4: yes  # methane
 advect_SC:  yes  # stratospheric chemistry
 advect_XX:  no   # generic tracer
 advect_PC:  yes  # parameterized chemistry (GEOS-5)
-advect_GMI: yes  # GMI chemistry (GEOS-5)
 advect_OCS: yes  # ACHEM chemistry (OCS)
 
 # Whether to diffuse the constituent
 # ----------------------------------
 diffuse_H2O: yes  # water vapor 
 diffuse_O3:  yes  # ozone 
-diffuse_XX:  yes  # generic tracer
 diffuse_CO:  yes  # carbon monoxide
 diffuse_CO2: yes  # carbon dioxide
 diffuse_DU:  yes  # mineral dust
@@ -576,6 +438,5 @@ diffuse_CH4: yes  # methane
 diffuse_SC:  yes  # stratospheric chemistry
 diffuse_XX:  yes  # generic tracer
 diffuse_PC:  yes  # parameterized chemistry (GEOS-5)
-diffuse_GMI: yes  # GMI chemistry (GEOS-5)
 diffuse_OCS: yes  # ACHEM chemistry (OCS)
 

--- a/Shared/Chem_Base/Runtime_RegistryMod.F90
+++ b/Shared/Chem_Base/Runtime_RegistryMod.F90
@@ -300,7 +300,7 @@ end subroutine Runtime_RegistryDestroy
    PRINT *
    PRINT *,'****'
    PRINT *,'****       Summary of the '//mod_name//' Registry'
-   PRINT *,'****            from Runtime_RegistryPrint'
+   PRINT *,'****       from Runtime_RegistryPrint'
    PRINT *,'****'
    WRITE(*,FMT="(' ','       Number of species: ',I3)") reg%nq
 

--- a/Shared/Chem_Base/Species_ArrayMod.F90
+++ b/Shared/Chem_Base/Species_ArrayMod.F90
@@ -1,0 +1,22 @@
+Module Species_ArrayMod
+
+   private
+   public Species_Array
+
+!  The Species_Array, a light weight ESMF-like array
+!  -------------------------------------------------
+   type Species_Array
+!       integer :: rank
+!       logical :: did_alloc = .false. ! useful to keep track of allocations
+!       real, pointer :: data2d(:,:)   => null()
+        real, pointer :: data3d(:,:,:) => null()
+
+!       A per-tracer scavenging efficiency in convective updrafts [km-1]
+!       real :: fscav = 0.0
+
+!       A per-tracer large-scale wet removal efficiency [fraction]
+!       real :: fwet = 0.0
+
+   end type Species_Array
+
+ end Module Species_ArrayMod

--- a/Shared/Chem_Base/Species_BundleMod.F90
+++ b/Shared/Chem_Base/Species_BundleMod.F90
@@ -1,0 +1,479 @@
+#include "unused_dummy.H"
+!-------------------------------------------------------------------------
+!      NASA/GSFC, Global Modeling & Assimilation Office, Code 900.3      !
+!-------------------------------------------------------------------------
+!BOP
+!
+! !MODULE:  Species_BundleMod.F90 --- Implements Species Bundle Class
+! 
+! !INTERFACE:
+!
+      MODULE  Species_BundleMod
+            
+! !USES:
+
+      Use ESMF
+      Use Runtime_RegistryMod
+      Use Species_ArrayMod
+      Use m_chars, only: uppercase
+      Use MAPL, only: MAPL_UNDEF
+
+      Implicit NONE
+
+! !PUBLIC TYPES:
+!
+      PRIVATE 
+      PUBLIC  Species_Bundle           ! species bundle type
+!
+! !PUBLIC MEMBER FUNCTIONS:
+!
+      PUBLIC  Species_Grid             ! grid definition
+      PUBLIC  Species_BundleCreate     ! initializes chemical bundle
+      PUBLIC  Species_BundleDestroy    ! "cleans" chemical bundle
+      PUBLIC  Species_BundleSetPtr     ! Fix internal pointers
+
+!
+! !DESCRIPTION: This module implements the species bundle class.
+!
+! !REVISION HISTORY: 
+!
+! 2022-09-13 manyin  First crack, based on Chem_Bundle
+!EOP
+!-------------------------------------------------------------------------
+
+   real, parameter ::  missing_val = MAPL_UNDEF ! hardwire this for now
+   integer, parameter :: nch = 256
+
+!   Grid
+!   ----
+    type Species_Grid
+
+!     Zonal grid
+!     ----------
+      integer       :: i1, i2, iml               ! local indices
+      integer       :: ig                        ! ghosting
+      integer       :: im                        ! global dimension
+      integer       :: iLeft                     ! i1's index on global grid
+      real, pointer :: lon(:,:) => null()        ! longitudes (deg)
+
+!     Meridional grid
+!     ---------------
+      integer       :: j1, j2, jml               ! local indices
+      integer       :: jg                        ! ghosting
+      integer       :: jm                        ! global dimension
+      real, pointer :: lat(:,:) => null()        ! latitudes (deg)
+
+!     Vertical grid
+!     -------------
+      integer       :: km
+      real, pointer :: lev(:) => null()
+      character(len=nch) :: levUnits 
+      real          :: ptop          ! Top pressure [Pa]
+
+!     Horizontal gridbox area
+!     -----------------------
+      real, pointer :: cell_area(:,:) => null()
+
+!     Cubed sphere or not
+!     -------------------
+      logical :: Cubed_Sphere = .FALSE.
+
+    end type Species_Grid
+
+!   Species vector
+!   --------------
+    type Species_Bundle
+
+!     Registry
+!     --------
+      type(Runtime_Registry) :: reg
+
+!     Grid
+!     ----
+      type(Species_Grid) :: grid
+
+      real, pointer   :: cosz(:,:) => null()  ! cosine solar zenith angle
+      real, pointer   :: sinz(:,:) => null()  !   sine solar zenith angle
+
+      type(ESMF_Grid) :: grid_esmf
+
+!     Whether this class allocated the memory for q, delp
+!     ---------------------------------------------------
+      logical :: did_allocation = .false.
+      logical :: has_rh = .false.            ! for backward compatibility
+      logical :: diurnal_bb = .false.        ! whether using diurnal biomass burning
+      logical :: do_concentration = .false.  ! using concentration: MR * airdens instead of MR alone
+      real    :: missing_value = MAPL_UNDEF
+
+!     Tracer array
+!     ------------
+      real, pointer :: delp(:,:,:) => null()! Layer thickness [Pa] (not ghosted)
+      real, pointer :: rh(:,:,:) => null()  ! Layer thickness [Pa] (not ghosted)
+      real, pointer :: airdens(:,:,:) => null() ! Air density
+
+      type(Species_array), pointer :: qa(:) => null()
+                                            ! access 4D array in q as a 
+                                            ! collection of 3D arrays; used
+                                            ! for gradually removing the 4D
+                                            ! arrays     
+      integer :: nq
+
+!     Two calendar elements (from ESMF)
+!     ---------------------------------
+      LOGICAL :: isLeapYear
+      REAL :: dayOfYear
+
+    end type Species_Bundle
+
+   CONTAINS
+
+!-------------------------------------------------------------------------
+!      NASA/GSFC Global Modeling & Assimilation Office, Code 900.3       !
+!-------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE:  Species_BundleCreate --- Creates Species Bundle
+! 
+! !INTERFACE:
+!
+  subroutine  Species_BundleCreate  ( reg,                 &
+                                   i1, i2, ig, im,      &
+                                   j1, j2, jg, jm, km,  &
+                                   w_s, rc,             &
+                                   skipAlloc, lat, lon, &
+                                   cell_area,           &
+                                   lev, levUnits, ptop, &
+                                   do_Conc )  ! Optional
+!
+! !USES:
+!
+  implicit NONE
+!
+! !INPUT PARAMETERS: 
+!
+
+  type(Runtime_registry)        :: reg             ! Species Registry
+
+                                                ! Distributed grid info:
+  integer,      intent(in)   :: i1, i2          !   local  zonal indices
+  integer,      intent(in)   :: ig              !   zonal ghosting
+  integer,      intent(in)   :: im              !   global zonal dimension
+  integer,      intent(in)   :: j1, j2          !   local meridional indices
+  integer,      intent(in)   :: jg              !   meridional ghosting
+  integer,      intent(in)   :: jm              !   global zonal dimension
+  integer,      intent(in)   :: km              !   vertical dimension
+
+  logical, OPTIONAL, intent(in) :: skipAlloc    ! Do not allocate arrays
+  real,    OPTIONAL, intent(in) :: lon(i1:i2,j1:j2) ! longitude in degrees
+  real,    OPTIONAL, intent(in) :: lat(i1:i2,j1:j2) ! latitude in degrees
+  real,    OPTIONAL, pointer    :: cell_area(:,:) ! grid box area
+  real,    OPTIONAL, intent(in) :: lev(1:km)    ! levels
+  character(len=*), OPTIONAL, intent(in) :: levUnits ! level units
+  real,    OPTIONAL, intent(in) :: ptop         ! top pressure in Pa
+  logical, OPTIONAL, intent(in) :: do_Conc ! Do_concentration: In case you need MR*airdens instead of MR alone
+!
+! !OUTPUT PARAMETERS:
+!
+  type(Species_Bundle), intent (out) :: w_s   ! Chemical bundle
+
+  integer, intent(out)            :: rc    ! error return code:
+                                           !  0 - all is well
+                                           !  1 - already allocated
+                                           !  2 - could not allocate memory
+                                           !  3 - invalid dimensions
+
+!
+! !DESCRIPTION: Creates a Species Bundle, allocating the necessary memory or
+!               optionally associating internal pointers with model declared 
+!  flat arrays.
+!
+! !REVISION HISTORY: 
+!
+!  2022-09-13  manyin  First crack, based on Chem_Bundle
+!EOP
+!-------------------------------------------------------------------------
+
+     character(len=*), parameter ::  myname = 'Species_BundleCreate'
+
+     integer err, i, j, n, nq, ios, ios1, ios2, ios3, ios4
+     logical :: do_allocation
+     logical :: do_concentration
+     real*8 :: delta
+
+!    Sanity check
+!    ------------
+     rc = 0
+     nq = reg%nq
+     if ( im<1 .or. jm<1 .or. km<1 .or. nq<1) then
+          rc = -3
+          return
+     endif
+              
+     w_s%reg = reg
+     w_s%missing_value = MAPL_UNDEF
+
+!    Whether or not we allocate memory for arrays
+!    --------------------------------------------
+     if ( present(skipAlloc) ) then
+          do_allocation = .not. skipAlloc
+     else
+          do_allocation = .true.
+     end if
+
+!   Whether or not read airdens to be able to work with concentration instead  of MR
+!   -----------------------------------------------
+     if ( present(do_Conc) ) then
+          do_concentration = do_Conc
+     else
+          do_concentration = .false.
+     end if
+
+
+
+!    Initialize dimensional attributes
+!    ---------------------------------
+     w_s%grid%i1 = i1; w_s%grid%i2 = i2; w_s%grid%ig = ig; w_s%grid%im = im
+     w_s%grid%iml = i2 - i1 + 1 
+     w_s%grid%j1 = j1; w_s%grid%j2 = j2; w_s%grid%jg = jg; w_s%grid%jm = jm
+     w_s%grid%jml = j2 - j1 + 1 
+     w_s%grid%km = km
+
+!    Detect cubed sphere for sanity checks latter
+!    --------------------------------------------
+     if ( jm == im * 6 ) then
+          w_s%grid%Cubed_Sphere = .TRUE.
+     else
+          w_s%grid%Cubed_Sphere = .FALSE.
+     end if
+
+!    Horizontal grid (hardwire A-grid for now)
+!    -----------------------------------------
+     if ( present(ptop) ) then
+          w_s%grid%ptop =  ptop
+     else
+          w_s%grid%ptop =  1.0 ! Pa: reasonable default 
+     endif
+
+!    Save lat/lons
+!    -------------
+     allocate ( w_s%grid%lon(i1:i2,j1:j2), w_s%grid%lat(i1:i2,j1:j2), &
+                stat = ios ) ! 
+     if ( ios /= 0 ) then
+        rc = 2
+        return
+     end if
+     if ( present(lon) ) then
+          w_s%grid%lon = lon
+     else
+          !ALT w_s%grid%lon = MAPL_UNDEF
+          delta = 360.0d0/im
+          do i = 1, im
+            w_s%grid%lon(i,:) = -180.0d0 + (i-1)*delta
+          end do
+     end if
+
+     if ( present(lat) ) then
+          w_s%grid%lat = lat
+     else
+          !ALT w_s%grid%lat = MAPL_UNDEF
+          if(jm==1) then
+            delta = 0.0d0
+          else
+            delta = 180.0d0/(jm-1)
+          endif
+          do j = 1, jm
+            w_s%grid%lat(:,j) = -90.0d0 + (j-1)*delta
+          end do
+     end if
+
+     if ( present(cell_area) ) then ! will be left unallocated otherwise
+          w_s%grid%cell_area => cell_area
+     end if
+
+     if ( present(lev) ) then
+        allocate ( w_s%grid%lev(1:km), stat = ios )
+        if ( ios /= 0 ) then
+           rc = 3
+           return
+        end if
+        w_s%grid%lev = lev 
+     end if
+     if ( present(levUnits) ) then
+          w_s%grid%levUnits = levUnits
+     else
+          w_s%grid%levUnits = 'none'
+     end if
+
+     w_s%did_allocation = .false.
+     w_s%has_rh = .false.       ! will be set to TRUE when set
+     w_s%do_concentration = .false.
+
+     w_s%nq = nq
+
+     allocate(w_s%qa(nq),stat=ios2)
+
+     if ( do_allocation ) then
+
+        allocate(w_s%delp(i1:i2,j1:j2,km),stat=ios )
+        do n = 1, nq
+           allocate(w_s%qa(n)%data3d(i1-ig:i2+ig,j1-jg:j2+jg,km),stat=ios1 )
+           ios2 = ios2 + ios1
+        end do
+        allocate(w_s%rh(i1:i2,j1:j2,km),stat=ios3 )
+            
+        if ( ios + ios2 + ios3 == 0 ) then 
+             w_s%did_allocation = .true.
+             w_s%delp = 0.0
+             do n = 1, nq
+                w_s%qa(n)%data3d = 0.0
+             end do
+             w_s%rh = 0.0             
+        else
+             w_s%did_allocation = .false.
+             rc = 4
+        end if
+
+        if (do_concentration ) then
+           w_s%do_concentration = .true.
+           allocate(w_s%airdens(i1:i2,j1:j2,km),stat=ios4 )
+           if ( ios4 == 0 ) w_s%airdens = 0.0
+        endif
+
+         
+     end if
+
+!    Set array of pointers: may be null() if no allocation took place
+!    ----------------------------------------------------------------
+     call Species_BundleSetPtr ( w_s, rc ) 
+
+  
+   end subroutine Species_BundleCreate
+
+!-------------------------------------------------------------------------
+!      NASA/GSFC Global Modeling & Assimilation Office, Code 900.3       !
+!-------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE:  Species_BundleDestroy --- Deallocates memory used by chemical state
+! 
+! !INTERFACE:
+!
+  subroutine  Species_BundleDestroy ( w_s, rc )
+!
+! !USES:
+!
+  implicit NONE
+!
+! !INPUT/OUTPUT PARAMETERS: 
+!
+  type(Species_Bundle), intent (inout) :: w_s   ! chemical bundle
+
+! !OUTPUT PARAMETERS:
+
+  integer, intent(out)          ::  rc     ! Error return code:
+                                           !  0 - all is well
+                                           !  1 - 
+! !DESCRIPTION: 
+!
+!  Deallocates memory used by chemical bundle.
+!
+! !REVISION HISTORY: 
+!
+!  20Jul1999 da Silva  Initial code.
+!  26oct1999 da Silva  Added hs_stdv, ts, lwi, a, b
+!  16Jun2016 Buchard   Added do_concentration option
+!EOP
+!-------------------------------------------------------------------------
+
+   integer n, ier
+
+   rc = 0
+
+   if ( w_s%did_allocation ) then
+
+      if ( associated(w_s%delp) ) deallocate(w_s%delp, stat=ier)
+      if ( associated(w_s%rh)  )  deallocate(w_s%rh, stat=ier)
+
+       
+     
+    
+      do n = 1, w_s%reg%nq 
+         if ( associated(w_s%qa(n)%data3d)  ) &
+              deallocate(w_s%qa(n)%data3d, stat=ier)
+      end do
+      if(associated(w_s%grid%lon)) deallocate( w_s%grid%lon )
+      if(associated(w_s%grid%lat)) deallocate( w_s%grid%lat )
+      if(associated(w_s%grid%lev)) deallocate( w_s%grid%lev )
+      if(associated(w_s%qa))       deallocate( w_s%qa )
+
+
+      if ( w_s%do_concentration ) then
+          if ( associated(w_s%airdens)  )  deallocate(w_s%airdens, stat=ier)
+      endif
+
+      
+   else
+
+      if ( associated(w_s%delp) ) nullify(w_s%delp)
+      if ( associated(w_s%rh) )   nullify(w_s%rh)
+            
+      do n = 1, w_s%reg%nq 
+         if ( associated(w_s%qa(n)%data3d)  ) nullify(w_s%qa(n)%data3d)
+      end do
+      deallocate( w_s%grid%lon, w_s%grid%lat, w_s%grid%lev,w_s%qa, stat=ier)  
+
+      if ( w_s%do_concentration ) then
+          if ( associated(w_s%airdens)  )  nullify(w_s%airdens)
+      endif
+ 
+   end if
+
+
+   w_s%reg%nq = -1
+
+  end subroutine Species_BundleDestroy
+
+!-------------------------------------------------------------------------
+!      NASA/GSFC Global Modeling & Assimilation Office, Code 900.3       !
+!-------------------------------------------------------------------------
+!BOP
+!
+! !IROUTINE:  Species_BundleSetPtr - Make sure internal pointers are set
+! 
+! !INTERFACE:
+!
+  subroutine  Species_BundleSetPtr ( w_s, rc )
+!
+! !USES:
+!
+  implicit NONE
+!
+! !INPUT/OUTPUT PARAMETERS: 
+!
+  type(Species_Bundle), intent (inout) :: w_s   ! chemical bundle
+
+! !OUTPUT PARAMETERS:
+
+  integer, intent(out)          ::  rc     ! Error return code:
+                                           !  0 - all is well
+                                           !  1 - 
+! !DESCRIPTION: 
+!
+!  Make sure the internal array of pointers points to the current
+!  memory location of the 4D q array
+!
+! !REVISION HISTORY: 
+!
+!  22Jul2005 da Silva  Initial code.
+!
+!EOP
+!-------------------------------------------------------------------------
+
+   _UNUSED_DUMMY(w_s)
+   rc = 0
+
+   return
+
+   end subroutine Species_BundleSetPtr
+
+ end MODULE Species_BundleMod


### PR DESCRIPTION
This PR is zero diff.
The GMI-related entries have been removed from Chem_Registry.rc and now live in GMI_Mech_Registry.rc .
This is in preparation for allowing GMI compile-time choice between several chemical mechanisms.