### PR TITLE
new GMI export: stOX loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+
+- GMI now exports stOX_loss (stratospheric OX tracer loss), customized for the specific chemical mechanism being run.
+
 ### Removed
 ### Changed
+
+- Instead of importing a set of QQK diagnostic fields for chemical loss of stOX, TR now imports a single field: stOX_loss
+
 ### Fixed
 
 ## [1.10.4] - 2022-11-08

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -506,26 +506,22 @@ contains
 
   IF(myState%enable_TR) then
      CALL MAPL_AddConnectivity ( GC, &
-          SHORT_NAME  = (/'AIRDENS     ', 'AIRDENS_DRYP', 'DELP        ', &
-                          'CN_PRCP     ', 'NCN_PRCP    '/), &
-          DST_ID = TR, SRC_ID = CHEMENV, __RC__  )
+            SHORT_NAME  = (/'AIRDENS     ', 'AIRDENS_DRYP', 'DELP        ', &
+                            'CN_PRCP     ', 'NCN_PRCP    '/), &
+            DST_ID = TR, SRC_ID = CHEMENV, __RC__  )
   ENDIF
 
   IF(myState%enable_TR .AND. myState%enable_GMICHEM) then
-     ! First test - add O3 and the species needed to compute O3 loss
-     ! Later, parse the TR .rc files to determine the fields we need
      CALL MAPL_AddConnectivity ( GC, &
-            SRC_NAME  = (/'OX    ', 'QQK007', 'QQK027', 'QQK028', 'DD_OX ', 'QQK005', &
-                          'QQK235', 'QQK170', 'QQK216', 'QQK179', 'QQK150'/), &
-            DST_NAME  = (/'OX_TR ', 'QQK007', 'QQK027', 'QQK028', 'DD_OX ', 'QQK005', &
-                          'QQK235', 'QQK170', 'QQK216', 'QQK179', 'QQK150'/), &
-          DST_ID = TR, SRC_ID = GMICHEM, __RC__  )
+            SRC_NAME  = (/'OX       ', 'stOX_loss', 'DD_OX    '/), &
+            DST_NAME  = (/'OX_TR    ', 'stOX_loss', 'DD_OX    '/), &
+            DST_ID = TR, SRC_ID = GMICHEM, __RC__  )
   ENDIF
 
   IF(myState%enable_GEOSCHEM) then
      CALL MAPL_AddConnectivity ( GC, &
-          SHORT_NAME  = (/'AIRDENS', 'DELP   ', 'LFR    ', 'BYNCY  '/), &
-          DST_ID = GEOSCHEM, SRC_ID = CHEMENV, __RC__  )
+            SHORT_NAME  = (/'AIRDENS', 'DELP   ', 'LFR    ', 'BYNCY  '/), &
+            DST_ID = GEOSCHEM, SRC_ID = CHEMENV, __RC__  )
   ENDIF
 
 ! Ozone mole fraction needed by GOCART for

--- a/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -1120,7 +1120,7 @@ CONTAINS
          READ( one_name(4:6),*,IOSTAT=rc) rxn_index
          _ASSERT(rc==0, TRIM(Iam)//': trouble extracting index from '//TRIM(self%rname(i)))
 
-         IF(MAPL_AM_I_ROOT( ))PRINT *,TRIM(IAm),': Add to stOX_loss from '//TRIM(one_name)//' index ',rxn_index
+!        IF(MAPL_AM_I_ROOT( ))PRINT *,TRIM(IAm),': Add to stOX_loss from '//TRIM(one_name)//' index ',rxn_index
 
          SELECT CASE (one_name(1:3))
 

--- a/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -73,6 +73,10 @@
 !EOP
 !-------------------------------------------------------------------------
 
+  INTEGER, PARAMETER :: RXN_NAME_LENGTH     = 16
+  INTEGER, PARAMETER :: RXN_LONGNAME_LENGTH = 256
+  INTEGER, PARAMETER :: TOKEN_LENGTH  = 256
+
   TYPE GmiChemistry_GridComp
    CHARACTER(LEN=255) :: name = "GMI Stratospheric/Tropospheric Chemistry"
 
@@ -109,6 +113,13 @@
 ! Surface area of grid cells
 ! --------------------------
    REAL(KIND=DBL), POINTER :: cellArea(:,:)
+
+! for computing tropospheric OX loss
+! ----------------------------------
+   INTEGER :: stOX_rxn_count
+   CHARACTER(LEN=RXN_NAME_LENGTH),     pointer :: rname(:)  ! vector of reaction short names
+   REAL(KIND=DBL), allocatable                 :: rmult(:)  ! vector of multipliers
+   CHARACTER(LEN=RXN_LONGNAME_LENGTH), pointer :: rdesc(:)  ! vector of reaction long  names
 
 ! Extra diagnostics
 ! -----------------
@@ -183,13 +194,17 @@ CONTAINS
 !EOP
 !-------------------------------------------------------------------------
 
+   INTEGER, PARAMETER :: RC_DATA_LINE    = 1
+   INTEGER, PARAMETER :: RC_END_OF_TABLE = 2
+   INTEGER, PARAMETER :: RC_END_OF_FILE  = 3
+
    CHARACTER(LEN=*), PARAMETER :: IAm    = 'GmiChem_GridCompClassInitialize'
-   CHARACTER(LEN=255) :: rcfilen = 'GMI_GridComp.rc'
+   CHARACTER(LEN=255) :: rcfile = 'GMI_GridComp.rc'
    CHARACTER(LEN=255) :: namelistFile
    CHARACTER(LEN=255) :: importRestartFile
    CHARACTER(LEN=255) :: string
    
-   type (ESMF_Config) :: gmiConfigFile
+   type (ESMF_Config) :: gmiConfig
 
    INTEGER :: ios, m, n, STATUS
    INTEGER :: i, i1, i2, ic, im, j, j1, j2, jm, k, km, kReverse
@@ -217,6 +232,10 @@ CONTAINS
    INTEGER                :: numVars, ib
    CHARACTER(LEN=4)       :: binName
    CHARACTER(LEN=ESMF_MAXSTR) :: varName
+
+   CHARACTER(LEN=TOKEN_LENGTH) ::  str_arr(3)   ! strings for rxn_name, multiplier and rxn_longname
+   INTEGER                     :: nrxn, nx, item_count, retcode
+   CHARACTER(LEN=32)           :: table_name
 
 ! Grid cell area can be set by initialize
 ! ---------------------------------------
@@ -247,14 +266,55 @@ CONTAINS
          PRINT *,"Starting Reading the GMI Resource File for Chemistry"
       ENDIF
 
-      gmiConfigFile = ESMF_ConfigCreate(rc=STATUS )
-      VERIFY_(STATUS)
+      gmiConfig = ESMF_ConfigCreate( __RC__ )
 
-      call ESMF_ConfigLoadFile(gmiConfigFile, TRIM(rcfilen), rc=STATUS )
-      VERIFY_(STATUS)
+      call ESMF_ConfigLoadFile(gmiConfig, TRIM(rcfile), __RC__ )
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, importRestartFile, &
-     &                label   = "importRestartFile:", &
+!     stOX Reactions
+!     --------------
+      table_name = 'stOX_loss_reactions::'
+
+      call ESMF_ConfigGetDim(gmiConfig, nrxn, nx, label=TRIM(table_name), rc=rc)
+      _ASSERT(rc==0, TRIM(Iam)//': Cannot get dims for table '//TRIM(table_name)//' in '//TRIM(rcfile))
+
+      call ESMF_ConfigFindLabel(gmiConfig, TRIM(table_name), rc=rc)
+      _ASSERT(rc==0, TRIM(Iam)//': Cannot find '//TRIM(table_name)//' in file '//TRIM(rcfile))
+
+!     Allocate memory
+!     ---------------
+      self%stOX_rxn_count = nrxn
+      allocate ( self%rname(nrxn), self%rmult(nrxn), self%rdesc(nrxn), __STAT__ )
+
+!     Read the reactions
+!     ------------------
+      do i=1,nrxn
+         call get_line ( gmiConfig, 3, str_arr, item_count, retcode )
+         select case( retcode )
+           case( RC_END_OF_FILE  )
+             _FAIL(TRIM(Iam)//': early EOF in file '//TRIM(rcfile))
+           case( RC_END_OF_TABLE )
+             _FAIL(TRIM(Iam)//': table too short '//TRIM(table_name)//' in file '//TRIM(rcfile))
+           case( RC_DATA_LINE    )
+             _ASSERT(item_count==3, TRIM(Iam)//': fewer than 3 entries in '//TRIM(table_name)//' in file '//TRIM(rcfile))
+             self%rname(i) = str_arr(1)
+             READ(           str_arr(2),*,IOSTAT=rc) self%rmult(i)
+             _ASSERT(rc==0, TRIM(Iam)//': Bad scaling factor for rxn '//TRIM(str_arr(1))//' in file '//TRIM(rcfile)//': '//TRIM(str_arr(2)))
+             self%rdesc(i) = str_arr(3)
+         end select
+      end do
+
+      IF( MAPL_AM_I_ROOT() ) THEN
+        PRINT*,'stOX reactions>>>'
+        do i=1,self%stOX_rxn_count
+          PRINT*,i,TRIM(self%rname(i)), self%rmult(i), TRIM(self%rdesc(i))
+        end do
+        PRINT*,'stOX reactions<<<'
+      END IF
+
+
+
+      call ESMF_ConfigGetAttribute(gmiConfig, importRestartFile, &
+     &                label   = "importRestartFile:",            &
      &                default = ' ', rc=STATUS )
       VERIFY_(STATUS)
 
@@ -262,7 +322,7 @@ CONTAINS
       ! Advection related variables
       !------------------------------
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_grav_set, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%do_grav_set, &
      &           label="do_grav_set:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
@@ -270,11 +330,11 @@ CONTAINS
       ! Emission related variables
       !------------------------------
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_synoz, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%do_synoz, &
      &           label="do_synoz:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_semiss_inchem, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%do_semiss_inchem, &
      &           label="do_semiss_inchem:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
@@ -282,65 +342,65 @@ CONTAINS
       ! Diagnostics related variables
       !------------------------------
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_diag, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%pr_diag, &
      &           label="pr_diag:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%verbose, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%verbose, &
      &           label="verbose:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_surf_emiss, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%pr_surf_emiss, &
      &           label="pr_surf_emiss:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_emiss_3d, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%pr_emiss_3d, &
      &           label="pr_emiss_3d:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qqjk, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%pr_qqjk, &
      &           label="pr_qqjk:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_qqjk_reset, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%do_qqjk_reset, &
      &           label="do_qqjk_reset:", default=.true., rc=STATUS)
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, self%pr_nc_period, &
+      call ESMF_ConfigGetAttribute(gmiConfig, self%pr_nc_period, &
      &                label   = "pr_nc_period:", &
      &                default = -1.0d0, rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_ftiming, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%do_ftiming, &
      &               label="do_ftiming:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%rd_restart, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%rd_restart, &
      &               label="rd_restart:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qj_o3_o1d, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%pr_qj_o3_o1d, &
      &               label="pr_qj_o3_o1d:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_qj_opt_depth, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%pr_qj_opt_depth, &
      &               label="pr_qj_opt_depth:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_smv2, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%pr_smv2, &
      &               label="pr_smv2:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%pr_const, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%pr_const, &
      &               label="pr_const:", default=.false., rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_org, &
+      call ESMF_ConfigGetAttribute(gmiConfig, self%metdata_name_org, &
      &                label   = "metdata_name_org:", &
      &                default = 'GMAO', rc=STATUS )
       VERIFY_(STATUS)
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, self%metdata_name_model, &
+      call ESMF_ConfigGetAttribute(gmiConfig, self%metdata_name_model, &
      &                label   = "metdata_name_model:", &
      &                default = 'GEOS-5', rc=STATUS )
 
@@ -349,7 +409,7 @@ CONTAINS
       ! Chemistry Related Variables
       !----------------------------
 
-      call ESMF_ConfigGetAttribute(gmiConfigFile, value=self%do_qqjk_inchem, &
+      call ESMF_ConfigGetAttribute(gmiConfig, value=self%do_qqjk_inchem, &
      &           label="do_qqjk_inchem:", default=.false., rc=STATUS)
       VERIFY_(STATUS)
 
@@ -469,14 +529,15 @@ CONTAINS
 ! ----------------------------------------------------------
 
       CALL InitializeSpcConcentration(self%SpeciesConcentration,              &
-                     self%gmiGrid, gmiConfigFile, NSP, NMF, NCHEM,            &
+                     self%gmiGrid, gmiConfig, NSP, NMF, NCHEM,                &
                      loc_proc)
 
       CALL InitializeChemistry(self%Chemistry, self%gmiGrid,                  &
-                     gmiConfigFile, loc_proc, NSP, self%pr_diag,              &
+                     gmiConfig, loc_proc, NSP, self%pr_diag,                  &
                      self%pr_qqjk, self%do_qqjk_inchem, self%pr_smv2,         &
                      rootProc, tdt)
 
+  CALL ESMF_ConfigDestroy(gmiConfig, __RC__ )
   IF(self%pr_qqjk .AND. .NOT. self%do_qqjk_inchem) THEN
    IF(MAPL_AM_I_ROOT()) THEN
     PRINT *,TRIM(IAm)//": Initializing reaction rate bundles"
@@ -540,6 +601,56 @@ CONTAINS
     self%mapSpecies(:) = speciesReg_for_CCM(lchemvar, NSP, bgg%reg%vname, bxx%reg%vname )
 
   RETURN
+
+   CONTAINS
+
+!     -------------------
+!     GET_LINE
+!     Advance one line and then try to read <expected_entries> items
+!     Retcode will be set to one of these values:
+!       RC_END_OF_FILE    - cannot advance a line
+!       RC_END_OF_TABLE   - first item is '::'
+!       RC_DATA_LINE      - at least one entry has been put into str_arr
+!     Note that ESMF automatically skips over blank lines and comment lines
+!     -------------------
+      subroutine get_line ( cf, expected_entries, str_arr, item_count, retcode )
+!     -------------------
+      type(ESMF_Config),           intent(inout)  :: cf
+      integer,                     intent(in)     :: expected_entries  ! read this many items
+      character(len=TOKEN_LENGTH), intent(inout)  :: str_arr(*)   ! space for one or more items
+      integer,                     intent(out)    :: item_count   ! how many were successfully read
+      integer,                     intent(out)    :: retcode      ! see possible values above
+
+      integer :: i
+
+      call ESMF_ConfigNextLine(cf, rc=rc)
+      if ( rc/=0 ) then
+        retcode = RC_END_OF_FILE
+        return
+      end if
+
+      ! Because ESMF skips over blank lines, rc should always be 0:
+      call ESMF_ConfigGetAttribute(cf, str_arr(1), rc=rc)
+      if ( rc/=0 ) then
+        retcode = RC_END_OF_FILE
+        return
+      end if
+      if ( INDEX(str_arr(1), '::' ) == 1 ) then
+        retcode = RC_END_OF_TABLE
+        return
+      end if
+
+      retcode = RC_DATA_LINE
+      item_count = 1
+      do i=2,expected_entries
+        call ESMF_ConfigGetAttribute(cf, str_arr(i), rc=rc)
+        if (rc==0) item_count = item_count + 1
+      end do
+
+      return
+
+      end subroutine get_line
+
 
   END SUBROUTINE GmiChemistry_GridCompInitialize
 
@@ -613,7 +724,7 @@ CONTAINS
 
 !  Exports not part of internal state
 !  ----------------------------------
-   REAL, POINTER, DIMENSION(:,:,:) :: O3ppmv, O3
+   REAL, POINTER, DIMENSION(:,:,:) :: O3ppmv, O3, stOX_loss
 
 !  Exports for reactions diagnostics
 !  ---------------------------------
@@ -948,6 +1059,10 @@ CONTAINS
 !EOP
 !---------------------------------------------------------------------------
 
+  INTEGER :: rxn_index
+  CHARACTER(LEN=RXN_NAME_LENGTH) :: one_name
+  REAL(KIND=DBL), allocatable :: stOX_loss_dbl(:,:,:)
+
   CHARACTER(LEN=255) :: IAm
   
   rc=0
@@ -989,7 +1104,43 @@ CONTAINS
 #include "QQK_FillExports___.h"
 #include "QQJ_FillExports___.h"
 
-   END IF
+     IF(ASSOCIATED(stOX_loss)) THEN
+       ALLOCATE(stOX_loss_dbl(i1:i2,j1:j2,1:km),__STAT__)
+
+       stOX_loss_dbl(:,:,:) = 0.0
+       do i=1,self%stOX_rxn_count
+
+         one_name = self%rname(i)
+
+         ! Assume each name is QQKnnn or QQJnnn
+         READ( one_name(4:6),*,IOSTAT=rc) rxn_index
+         _ASSERT(rc==0, TRIM(Iam)//': trouble extracting index from '//TRIM(self%rname(i)))
+
+         IF(MAPL_AM_I_ROOT( ))PRINT *,TRIM(IAm),': Add to stOX_loss from '//TRIM(one_name)//' index ',rxn_index
+
+         SELECT CASE (one_name(1:3))
+
+           CASE("QQK")
+             stOX_loss_dbl(i1:i2,j1:j2,1:km) = &
+             stOX_loss_dbl(i1:i2,j1:j2,1:km) + self%rmult(i) * gmiQQK(rxn_index)%pArray3D(i1:i2,j1:j2,km:1:-1)
+!                                                                 ^^^
+           CASE("QQJ")
+             stOX_loss_dbl(i1:i2,j1:j2,1:km) = &
+             stOX_loss_dbl(i1:i2,j1:j2,1:km) + self%rmult(i) * gmiQQJ(rxn_index)%pArray3D(i1:i2,j1:j2,km:1:-1)
+!                                                                 ^^^
+           CASE DEFAULT
+             _ASSERT(.FALSE., TRIM(Iam)//': reaction must be QQK or QQJ : '//TRIM(one_name))
+
+         END SELECT
+
+       end do
+
+       stOX_loss = stOX_loss_dbl
+       DEALLOCATE( stOX_loss_dbl, __STAT__ )
+
+     END IF  ! stOX_loss is needed
+
+   END IF  ! QQJ and QQK
 
   RETURN
  END SUBROUTINE FillExports
@@ -1184,6 +1335,8 @@ CONTAINS
    CALL MAPL_GetPointer(expChem,    O3ppmv,     'O3PPMV', RC=STATUS)
    VERIFY_(STATUS)
    CALL MAPL_GetPointer(expChem,        O3,         'O3', RC=STATUS)
+   VERIFY_(STATUS)
+   CALL MAPL_GetPointer(expChem, stOX_loss,  'stOX_loss', RC=STATUS)
    VERIFY_(STATUS)
 
 #include "Reactions_GetPointer___.h"

--- a/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChem_GridCompClassMod.F90
@@ -1099,6 +1099,10 @@ CONTAINS
 #include "QJ_FillExports___.h"
 #include "QK_FillExports___.h"
 
+   IF(ASSOCIATED(stOX_loss)) THEN
+     _ASSERT(self%pr_qqjk, TRIM(Iam)//': to compute stOX_loss, set GMI pr_qqjk = TRUE')
+   END IF
+
    IF(self%pr_qqjk) THEN
 
 #include "QQK_FillExports___.h"

--- a/GMIchem_GridComp/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChemistry/StratTrop_HFC_S/GMI_GridComp.rc
@@ -428,3 +428,33 @@ PSC_Max_P_hPa: 175
 Condensed_HNO3_limit: 25
 # Upper limit for HCl [real, ppbv]
 HCl_limit: 5.0
+
+stOX_loss_reactions::
+# loss of O3, O1D or NO2
+  QQJ002  1.0   'O3 + hv = O + O2'
+  QQJ006  1.0   'NO2 + hv = NO + O'
+  QQK002  1.0   'O + O3 = 2 O2'
+  QQK004  1.0   'O1D + O2 = O + O2'
+  QQK005  2.0   'O1D + O3 = 2 O2'
+  QQK006  2.0   'O1D + O3 = 2 O + O2'
+  QQK007  1.0   'H2O + O1D = 2 OH'
+  QQK008  1.0   'H2 + O1D = H + OH'
+  QQK027  1.0   'O3 + OH = HO2 + O2'
+  QQK028  1.0   'HO2 + O3 = 2 O2 + OH'
+  QQK029  2.0   'NO2 + O3 = NO3 + O2'
+  QQK050  1.0   'N + NO2 = N2O + O'
+  QQK051  1.0   'NO2 + O = NO + O2'
+  QQK053  1.0   'NO2 + OH = HNO3'
+  QQK057  1.0   'HO2 + NO2 = HNO4'
+  QQK063  1.0   'NO2 + NO3 = N2O5'
+  QQK164  0.7   'IALD + O3 =  0.12 CH2O +  0.28 GLYC +  0.20 GLYX +  0.20 HAC +  0.20 HCOOH +  0.60 MGLY +  0.30 O3 +  0.10 OH'
+  QQK184  0.9   'ISOP + O3 =  0.90 CH2O +  0.05 CO +  0.06 HO2 +  0.39 MACR +  0.16 MVK +  0.10 O3 +  0.27 OH +  0.07 PRPE'
+  QQK193  0.8   'MACR + O3 =  0.70 CH2O +  0.20 CO +  0.28 HO2 +  0.80 MGLY +  0.20 O3 +  0.22 OH'
+  QQK204  1.0   'MAO3 + NO2 = PMN'
+  QQK214  1.0   'MCO3 + NO2 = PAN'
+  QQK230  0.8   'MVK + O3 =  0.04 ALD2 +  0.80 CH2O +  0.05 CO +  0.06 HO2 +  0.82 MGLY +  0.20 O3 +  0.08 OH'
+  QQK250  1.0   'O3 + PRPE =  0.50 ALD2 +  0.54 CH2O +  0.42 CO +  0.06 H2 +  0.30 HO2 +  0.31 MO2 +  0.14 OH'
+  QQK273  1.0   'NO2 + RCO3 = PPN'
+  QQK324  1.0   'NO2 =  0.50 HNO2 +  0.50 HNO3'
+  QQK331  1.0   'O3 + SO2 = H2SO4'
+::

--- a/GMIchem_GridComp/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
+++ b/GMIchem_GridComp/GMI_GridComp/GmiChemistry/StratTrop_Orig/GMI_GridComp.rc
@@ -413,3 +413,31 @@ PSC_Max_P_hPa: 175
 Condensed_HNO3_limit: 25
 # Upper limit for HCl [real, ppbv]
 HCl_limit: 5.0
+
+stOX_loss_reactions::
+# loss of O3, O1D or NO2
+  QQJ002  1.0   'O3 + hv = O + O2'
+  QQJ006  1.0   'NO2 + hv = NO + O'
+  QQK002  1.0   'O + O3 = 2 O2'
+  QQK004  1.0   'O1D + O2 = O + O2'
+  QQK005  2.0   'O1D + O3 = 2 O2'
+  QQK006  2.0   'O1D + O3 = 2 O + O2'
+  QQK007  1.0   'H2O + O1D = 2 OH'
+  QQK008  1.0   'H2 + O1D = H + OH'
+  QQK027  1.0   'O3 + OH = HO2 + O2'
+  QQK028  1.0   'HO2 + O3 = 2 O2 + OH'
+  QQK029  2.0   'NO2 + O3 = NO3 + O2'
+  QQK050  1.0   'NO2 + O = NO + O2'
+  QQK052  1.0   'NO2 + OH = HNO3'
+  QQK056  1.0   'HO2 + NO2 = HNO4'
+  QQK062  1.0   'NO2 + NO3 = N2O5'
+  QQK150  0.7   'IALD + O3 =  0.12 CH2O +  0.28 GLYC +  0.20 GLYX +  0.20 HAC +  0.20 HCOOH +  0.60 MGLY +  0.30 O3 +  0.10 OH'
+  QQK170  0.9   'ISOP + O3 =  0.90 CH2O +  0.05 CO +  0.06 HO2 +  0.39 MACR +  0.16 MVK +  0.10 O3 +  0.27 OH +  0.07 PRPE'
+  QQK179  0.8   'MACR + O3 =  0.70 CH2O +  0.20 CO +  0.28 HO2 +  0.80 MGLY +  0.20 O3 +  0.22 OH'
+  QQK190  1.0   'MAO3 + NO2 = PMN'
+  QQK200  1.0   'MCO3 + NO2 = PAN'
+  QQK216  0.8   'MVK + O3 =  0.04 ALD2 +  0.80 CH2O +  0.05 CO +  0.06 HO2 +  0.82 MGLY +  0.20 O3 +  0.08 OH'
+  QQK235  1.0   'O3 + PRPE =  0.50 ALD2 +  0.54 CH2O +  0.42 CO +  0.06 H2 +  0.30 HO2 +  0.31 MO2 +  0.14 OH'
+  QQK259  1.0   'NO2 + RCO3 = PPN'
+  QQK310  1.0   'NO2 =  0.50 HNO2 +  0.50 HNO3'
+::

--- a/GMIchem_GridComp/GMIchem_GridCompMod.F90
+++ b/GMIchem_GridComp/GMIchem_GridCompMod.F90
@@ -987,6 +987,15 @@ CONTAINS
                                                        RC=STATUS  )
     VERIFY_(STATUS)
 
+    CALL MAPL_AddExportSpec(GC,                                         &
+        SHORT_NAME         = 'stOX_loss',                               &
+        LONG_NAME          = 'loss to apply to strat OX tracer',        &
+        UNITS              = 'mole m-3 s-1',                            &
+        DIMS               = MAPL_DimsHorzVert,                         &
+        VLOCATION          = MAPL_VLocationCenter,                      &
+                                                       RC=STATUS  )
+    VERIFY_(STATUS)
+
 #include "GMICHEM_ExportSpec___.h"
 #include "Deposition_ExportSpec___.h"
 #include "Reactions_ExportSpec___.h"

--- a/Shared/Chem_Base/Runtime_RegistryMod.F90
+++ b/Shared/Chem_Base/Runtime_RegistryMod.F90
@@ -134,7 +134,7 @@ CONTAINS
    call ESMF_ConfigLoadFile(cf, rcfile, rc=rc)
    _ASSERT(rc==0, TRIM(Iam)//': Cannot load RC file '//TRIM(rcfile))
 
-   call ESMF_ConfigGetDim(cf, nq, nx, label=table_name, rc=rc)
+   call ESMF_ConfigGetDim(cf, nq, nx, label=TRIM(table_name), rc=rc)
    _ASSERT(rc==0, TRIM(Iam)//': Cannot get dims for table '//TRIM(table_name)//' in '//TRIM(rcfile))
 
    this%primary_count = 0
@@ -144,7 +144,7 @@ CONTAINS
    this%nq = nq
    allocate ( this%vname(nq), this%vunits(nq), this%vtitle(nq), __STAT__ )
 
-   call ESMF_ConfigFindLabel(cf, table_name, rc=rc)
+   call ESMF_ConfigFindLabel(cf, TRIM(table_name), rc=rc)
    _ASSERT(rc==0, TRIM(Iam)//': Cannot find '//TRIM(table_name)//' in file '//TRIM(rcfile))
 
    do i=1,nq
@@ -189,7 +189,7 @@ CONTAINS
 !     -------------------
       type(ESMF_Config),           intent(inout)  :: cf
       integer,                     intent(in)     :: expected_entries  ! read this many items
-      character(len=TOKEN_LENGTH), intent(out)    :: str_arr(*)   ! space for one or more items
+      character(len=TOKEN_LENGTH), intent(inout)  :: str_arr(*)   ! space for one or more items
       integer,                     intent(out)    :: item_count   ! how many were successfully read
       integer,                     intent(out)    :: retcode      ! see possible values above
 

--- a/Shared/Chem_Shared/Lightning_mod.F90
+++ b/Shared/Chem_Shared/Lightning_mod.F90
@@ -35,7 +35,7 @@ use, intrinsic :: iso_fortran_env, only: REAL64
    PUBLIC :: read_flash_source
    PUBLIC :: read_lightning_config
    PUBLIC :: update_lightning_ratio
-   PUBLIC :: HEMCO_FlashRate       ! Had been called from MOIST to provide a secondard version of LFR
+   PUBLIC :: HEMCO_FlashRate       ! Had been called from MOIST to provide a secondary version of LFR
 
    ! Enumerated values, along with matching strings
    integer, parameter, public    :: FLASH_SOURCE_MOIST      = 1   ! values also serve as indices into flashSourceNames
@@ -50,7 +50,7 @@ use, intrinsic :: iso_fortran_env, only: REAL64
 
 
    PRIVATE :: MOIST_FlashRate
-   PRIVATE ::  DALE_FlashRate ! fields passed are vertically flipped from GEOS orientation 
+   PRIVATE ::   FIT_FlashRate ! fields passed are vertically flipped from GEOS orientation 
    PRIVATE :: LOPEZ_FlashRate
    PRIVATE :: partition
    PRIVATE :: readLightRatioGlobalData
@@ -85,7 +85,7 @@ use, intrinsic :: iso_fortran_env, only: REAL64
 !  flashrate (or strokerate) and NOx from lightning in the Earth's atmosphere.
 !  The routines for calculation flashrate / stroke rate are:
 ! 
-!     DALE_FlashRate - adapted from the offline GMI-CTM model (Dale Allen)
+!      FIT_FlashRate - adapted from the offline GMI-CTM model (Dale Allen)
 !    MOIST_FlashRate - adapted from MOIST / CTM cinderalla component
 !    HEMCO_FlashRate - GEOS-Chem's flashrate calculation 
 !    LOPEZ_FlashRate (WARNING: this routine is producing invalid results!)
@@ -454,7 +454,7 @@ subroutine getLightning (GC, ggState, CLOCK, &
      ALLOCATE (flashRateDale (IM,JM), stat=STATUS)
 
 
-     call DALE_FlashRate (cldmas0, 0.0d0, ratioLocal, ratioGlobalLight, midLatAdj, &
+     call FIT_FlashRate (cldmas0, 0.0d0, ratioLocal, ratioGlobalLight, midLatAdj, &
           5.0d0, FIT_flashFactor, flashRateDale)
 
      ! flashRateDale has units  [flashes / gridbox / sec]
@@ -1180,12 +1180,12 @@ end subroutine read_lightning_config
 !-------------------------------------------------------------------------
 !BOP
 !
-! !ROUTINE: DALE_FlashRate
+! !ROUTINE: FIT_FlashRate   (previously called DALE_FlashRate)
 
 !
 ! !INTERFACE:
 !
-    subroutine DALE_FlashRate (cldmas, threshold, ratio_local, ratio_global, midlatAdj, &
+    subroutine FIT_FlashRate (cldmas, threshold, ratio_local, ratio_global, midlatAdj, &
          desired_g_N_prod_rate, FIT_flashFactor, flashrate)
 
 ! !USES
@@ -1265,7 +1265,7 @@ end subroutine read_lightning_config
       deallocate(cldmas_local)
       return
 
-    end subroutine DALE_FlashRate
+    end subroutine FIT_FlashRate
 !EOP
 
 !==========================================================================

--- a/TR_GridComp/TR_ExtData.rc
+++ b/TR_GridComp/TR_ExtData.rc
@@ -40,16 +40,8 @@ TR_regionMask2              NA        N    V          -                none     
 HTAP2_REGION_MASK_COASTAL_MOD  NA     N    V          -                none      none      region_map        ExtData/g5chem/sfc/HTAP2.region_map_modified_coastlines.x720_y360.nc4
 # In case GMI is not running; this is a temporary fix:
 OX_TR                    'none'       N    N          -                none      none      NA                /dev/null
-QQK007                   'none'       N    N          -                none      none      NA                /dev/null
-QQK027                   'none'       N    N          -                none      none      NA                /dev/null
-QQK028                   'none'       N    N          -                none      none      NA                /dev/null
+stOX_loss                'none'       N    N          -                none      none      NA                /dev/null
 DD_OX                    'none'       N    N          -                none      none      NA                /dev/null
-QQK005                   'none'       N    N          -                none      none      NA                /dev/null
-QQK235                   'none'       N    N          -                none      none      NA                /dev/null
-QQK170                   'none'       N    N          -                none      none      NA                /dev/null
-QQK216                   'none'       N    N          -                none      none      NA                /dev/null
-QQK179                   'none'       N    N          -                none      none      NA                /dev/null
-QQK150                   'none'       N    N          -                none      none      NA                /dev/null
 #
 # -------------|--------------|-----|----|----|---|----------------------|--------|-----------|------------------|----------------------   
 %%

--- a/TR_GridComp/TR_ExtData.yaml
+++ b/TR_GridComp/TR_ExtData.yaml
@@ -78,24 +78,6 @@ Exports:
     variable: region_map
   OX_TR:
     collection: /dev/null
-  QQK005:
-    collection: /dev/null
-  QQK007:
-    collection: /dev/null
-  QQK027:
-    collection: /dev/null
-  QQK028:
-    collection: /dev/null
-  QQK150:
-    collection: /dev/null
-  QQK170:
-    collection: /dev/null
-  QQK179:
-    collection: /dev/null
-  QQK216:
-    collection: /dev/null
-  QQK235:
-    collection: /dev/null
   SRC_2D_CH3I:
     collection: TR_unity.x144_y91.nc
     linear_transformation:
@@ -180,6 +162,8 @@ Exports:
     regrid: VOTE
     sample: TR_sample_1
     variable: REGION_MASK
+  stOX_loss:
+    collection: /dev/null
 
 Derived:
   SRC_2D_CO_ANZ:

--- a/TR_GridComp/TR_GridComp---stOX.rc
+++ b/TR_GridComp/TR_GridComp---stOX.rc
@@ -10,7 +10,7 @@
 # ---------------------------
 
   src_mode: model_field
-  src_field_name: OX
+  src_field_name: OX_TR
   src_add: FALSE
 
 # SOURCE - Horizontal coverage: all  |  lat_zone  |  latlon_box

--- a/TR_GridComp/TR_GridCompMod.F90
+++ b/TR_GridComp/TR_GridCompMod.F90
@@ -832,29 +832,9 @@ CONTAINS
         RESTART            = MAPL_RestartSkip,                             &
                                                        __RC__  )
 
-! Adapted these from Reactions_ExportSpec___.h
-
-     call MAPL_AddImportSpec(GC,                                           &
-        SHORT_NAME         = 'QQK007',                                     &
-        LONG_NAME          = 'reaction_rate: H2O + O1D = 2 OH',            &
-        UNITS              = 'mole m-3 s-1',                               &
-        DIMS               = MAPL_DimsHorzVert,                            &
-        VLOCATION          = MAPL_VLocationCenter,                         &
-        RESTART            = MAPL_RestartSkip,                             &
-                                                       __RC__  )
-
-     call MAPL_AddImportSpec(GC,                                           &
-        SHORT_NAME         = 'QQK027',                                     &
-        LONG_NAME          = 'reaction_rate: O3 + OH = HO2 + O2',          &
-        UNITS              = 'mole m-3 s-1',                               &
-        DIMS               = MAPL_DimsHorzVert,                            &
-        VLOCATION          = MAPL_VLocationCenter,                         &
-        RESTART            = MAPL_RestartSkip,                             &
-                                                       __RC__  )
-
-     call MAPL_AddImportSpec(GC,                                           &
-        SHORT_NAME         = 'QQK028',                                     &
-        LONG_NAME          = 'reaction_rate: HO2 + O3 = 2 O2 + OH',        &
+    call MAPL_AddImportSpec(GC,                                            &
+        SHORT_NAME         = 'stOX_loss',                                  &
+        LONG_NAME          = 'loss to apply to strat OX tracer',           &
         UNITS              = 'mole m-3 s-1',                               &
         DIMS               = MAPL_DimsHorzVert,                            &
         VLOCATION          = MAPL_VLocationCenter,                         &
@@ -870,59 +850,6 @@ CONTAINS
         RESTART            = MAPL_RestartSkip,                             &
                                                        __RC__  )
 
-     call MAPL_AddImportSpec(GC,                                           &
-        SHORT_NAME         = 'QQK005',                                     &
-        LONG_NAME          = 'reaction_rate: O1D + O3 = 2 O2',             &
-        UNITS              = 'mole m-3 s-1',                               &
-        DIMS               = MAPL_DimsHorzVert,                            &
-        VLOCATION          = MAPL_VLocationCenter,                         &
-        RESTART            = MAPL_RestartSkip,                             &
-                                                       __RC__  )
-
-     call MAPL_AddImportSpec(GC,                                                                                                                      &
-        SHORT_NAME         = 'QQK235',                                                                                                                &
-        LONG_NAME          = 'reaction_rate: O3 + PRPE = 0.50 ALD2 + 0.54 CH2O + 0.42 CO + 0.06 H2 + 0.30 HO2 + 0.31 MO2 + 0.14 OH',                  &
-        UNITS              = 'mole m-3 s-1',                                                                                                          &
-        DIMS               = MAPL_DimsHorzVert,                                                                                                       &
-        VLOCATION          = MAPL_VLocationCenter,                                                                                                    &
-        RESTART            = MAPL_RestartSkip,                                                                                                        &
-                                                       __RC__  )
-
-     call MAPL_AddImportSpec(GC,                                                                                                                      &
-        SHORT_NAME         = 'QQK170',                                                                                                                &
-        LONG_NAME          = 'reaction_rate: ISOP + O3 = 0.90 CH2O + 0.05 CO + 0.06 HO2 + 0.39 MACR + 0.16 MVK + 0.10 O3 + 0.27 OH + 0.07 PRPE',      &
-        UNITS              = 'mole m-3 s-1',                                                                                                          &
-        DIMS               = MAPL_DimsHorzVert,                                                                                                       &
-        VLOCATION          = MAPL_VLocationCenter,                                                                                                    &
-        RESTART            = MAPL_RestartSkip,                                                                                                        &
-                                                       __RC__  )
-
-     call MAPL_AddImportSpec(GC,                                                                                                                      &
-        SHORT_NAME         = 'QQK216',                                                                                                                &
-        LONG_NAME          = 'reaction_rate: MVK + O3 = 0.04 ALD2 + 0.80 CH2O + 0.05 CO + 0.06 HO2 + 0.82 MGLY + 0.20 O3 + 0.08 OH',                  &
-        UNITS              = 'mole m-3 s-1',                                                                                                          &
-        DIMS               = MAPL_DimsHorzVert,                                                                                                       &
-        VLOCATION          = MAPL_VLocationCenter,                                                                                                    &
-        RESTART            = MAPL_RestartSkip,                                                                                                        &
-                                                       __RC__  )
-
-     call MAPL_AddImportSpec(GC,                                                                                                                      &
-        SHORT_NAME         = 'QQK179',                                                                                                                &
-        LONG_NAME          = 'reaction_rate: MACR + O3 = 0.70 CH2O + 0.20 CO + 0.28 HO2 + 0.80 MGLY + 0.20 O3 + 0.22 OH',                             &
-        UNITS              = 'mole m-3 s-1',                                                                                                          &
-        DIMS               = MAPL_DimsHorzVert,                                                                                                       &
-        VLOCATION          = MAPL_VLocationCenter,                                                                                                    &
-        RESTART            = MAPL_RestartSkip,                                                                                                        &
-                                                       __RC__  )
-
-     call MAPL_AddImportSpec(GC,                                                                                                                      &
-        SHORT_NAME         = 'QQK150',                                                                                                                &
-        LONG_NAME          = 'reaction_rate: IALD + O3 = 0.12 CH2O + 0.28 GLYC + 0.20 GLYX + 0.20 HAC + 0.20 HCOOH + 0.60 MGLY + 0.30 O3 + 0.10 OH',  &
-        UNITS              = 'mole m-3 s-1',                                                                                                          &
-        DIMS               = MAPL_DimsHorzVert,                                                                                                       &
-        VLOCATION          = MAPL_VLocationCenter,                                                                                                    &
-        RESTART            = MAPL_RestartSkip,                                                                                                        &
-                                                       __RC__  )
 ! END IF
 
 !! --------------------------------------
@@ -3395,16 +3322,8 @@ CONTAINS
    real, pointer, dimension(:,:,:) ::  src_field
    real, pointer, dimension(:,:)   ::  src_ext_2d  ! For getting ExtData pointer
    real, pointer, dimension(:,:,:) ::  src_ext_3d  ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_A    ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_B    ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_C    ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_D    ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_E    ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_F    ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_G    ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_H    ! For getting ExtData pointer
-   real, pointer, dimension(:,:,:) ::  imp_3d_I    ! For getting ExtData pointer
-   real, pointer, dimension(:,:)   ::  imp_2d_A    ! For getting ExtData pointer
+   real, pointer, dimension(:,:,:) ::  stOX_loss   ! For getting ExtData pointer
+   real, pointer, dimension(:,:)   ::  dd_OX       ! For getting ExtData pointer
 
    real, pointer, dimension(:,:,:) ::  st_export_3d   ! For settling diagnostic
    real, pointer, dimension(:,:)   ::  st_export_2d   ! For settling diagnostic (col total)
@@ -4263,18 +4182,10 @@ CONTAINS
 !            We trust that the fields have been exported from the source GC, connected to TR,
 !            and imported by TR.  Otherwise these calls will fail:
 
-!            These should all be in terms of mole/m3/s
-             call MAPL_GetPointer( impChem,  imp_3d_A, 'QQK007', __RC__ )
-             call MAPL_GetPointer( impChem,  imp_3d_B, 'QQK027', __RC__ )
-             call MAPL_GetPointer( impChem,  imp_3d_C, 'QQK028', __RC__ )
-             call MAPL_GetPointer( impChem,  imp_3d_D, 'QQK005', __RC__ )
-             call MAPL_GetPointer( impChem,  imp_3d_E, 'QQK235', __RC__ )
-             call MAPL_GetPointer( impChem,  imp_3d_F, 'QQK170', __RC__ )
-             call MAPL_GetPointer( impChem,  imp_3d_G, 'QQK216', __RC__ )
-             call MAPL_GetPointer( impChem,  imp_3d_H, 'QQK179', __RC__ )
-             call MAPL_GetPointer( impChem,  imp_3d_I, 'QQK150', __RC__ )
+!            This should be in terms of mole/m3/s
+             call MAPL_GetPointer( impChem,  stOX_loss,   'stOX_loss',    __RC__ )
 !            This is in terms of kg/m2/s
-             call MAPL_GetPointer( impChem,  imp_2d_A, 'DD_OX' , __RC__ )
+             call MAPL_GetPointer( impChem,  dd_OX,       'DD_OX',        __RC__ )
 !            This is in terms of kg/m3
              call MAPL_GetPointer ( impChem, airdens,     'AIRDENS',      __RC__ )
              call MAPL_GetPointer ( impChem, airdens_dry, 'AIRDENS_DRYP', __RC__ )
@@ -4284,7 +4195,7 @@ CONTAINS
 !             call MAPL_GetPointer( expChem,  exp_3d_B, 'TR_DIAG_B', __RC__ )
   
 !            Convert kg m-2 s-1 to mole/mole/s  where denominator is moles of moist air
-             dep_term = ((imp_2d_A/MAPL_O3MW)/ dZ(:,:,km)) / (             &
+             dep_term = ((dd_OX/MAPL_O3MW)/ dZ(:,:,km)) / (                &
                             (one - Q(:,:,km))*airdens(:,:,km)/MAPL_AIRMW + &
                                    Q(:,:,km) *airdens(:,:,km)/MAPL_H2OMW   &
                                                              )
@@ -4307,10 +4218,8 @@ CONTAINS
 
 !            force computation to be done in double-precision
 !            and guard against division by zero and convert from mole/m3/s to mole/mole/s  where denominator is moles of moist air
-             sum_term = ( DBLE(imp_3d_A) + DBLE(imp_3d_B) + DBLE(imp_3d_C) + DBLE(imp_3d_D) + DBLE(imp_3d_E) &
-                        + DBLE(imp_3d_F) + DBLE(imp_3d_G) + DBLE(imp_3d_H) + DBLE(imp_3d_I) ) / ( &
-                              1.0D3 * ( (one-Q)*airdens/MAPL_AIRMW +                              &
-                                             Q *airdens/MAPL_H2OMW   )                          )
+             sum_term = DBLE(stOX_loss) / ( 1.0D3 * ( (one-Q)*airdens/MAPL_AIRMW +   &
+                                                           Q *airdens/MAPL_H2OMW   ) )
 
 !            Compute chemical loss tendency if needed
              call MAPL_GetPointer( expChem, cl_export_3d,     'CLtend_'//TRIM(spec%name), __RC__ )


### PR DESCRIPTION
This PR is zero-diff for all cases, except the TR species stOX.
GMI now exports a loss term for OX, to be used by TR; the previous implementation required TR to know the QQK reaction rate numbering scheme, which was dependent on the version of GMI mechanism being run. The new approach is much cleaner.