### PR TITLE
Update CircleCI to Baselibs 7.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.5.0
+baselibs_version: &baselibs_version v7.7.0
 bcs_version: &bcs_version v10.22.3
 
 orbs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Instead of importing a set of QQK diagnostic fields for chemical loss of stOX, TR now imports a single field: stOX_loss
 - Moved to GitHub Actions for label enforcement
+- Update CircleCI to use Baselibs 7.7.0
 
 ### Fixed
 


### PR DESCRIPTION
This PR is needed to keep CI working with developments in MAPL and GEOSgcm_App.