### PR TITLE
Fix GMI issue related to stOX_loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Modified TR to only import stOX_loss if loss_species == OX; without this, a GMI _ASSERT may exit the program needlessly.
+
 ## [1.10.4] - 2022-11-08
 ### Added
 ### Removed

--- a/TR_GridComp/TR_GridComp---stOX.rc
+++ b/TR_GridComp/TR_GridComp---stOX.rc
@@ -1,5 +1,5 @@
 #
-# Tracer with O3 values in stratosphere, and O3 loss applied in the troposphere
+# Tracer with OX values in stratosphere, and OX loss applied in the troposphere
 #
 
 # SHOULD THE TRACER SOURCE BE ADDED FIRST, OR THE SINK APPLIED FIRST
@@ -26,7 +26,7 @@
 # ---------------------------
 # snk_mode: none
   snk_mode: chemical_loss
-  loss_species: O3
+  loss_species: OX
 
 # SINK - Horizontal coverage:  all  |  lat_zone  |  latlon_box
 # ---------------------------


### PR DESCRIPTION
TR now imports stOX_loss only as needed. This addresses an assumption in GMI; without the fix, GMI would exit the program when stOX was not running and pr_qqjk was FALSE.
The "loss species" string of stOX has now been changed from "O3" to "OX", just for clarity.
