### PR TITLE
fix LAI import, the 3rd dimension is not model levels, so need to use…

### DIFF
--- a/TR_GridComp/TR_GridCompMod.F90
+++ b/TR_GridComp/TR_GridCompMod.F90
@@ -1079,8 +1079,9 @@ CONTAINS
            SHORT_NAME = 'TR_VEG_FRAC',                               &
            LONG_NAME  = 'vegetation_fraction',                       &
 !          UNITS      = '1',                                         &
-           DIMS       = MAPL_DimsHorzVert,                           &
-           VLOCATION  = MAPL_VLocationCenter,                        &
+           DIMS       = MAPL_DimsHorzOnly,                           &
+           VLOCATION  = MAPL_VLocationNone,                          &
+           UNGRIDDED_DIMS = [72],                                    &
            RESTART    = MAPL_RestartSkip,                            &
                                                          __RC__ )
 
@@ -1088,8 +1089,9 @@ CONTAINS
            SHORT_NAME = 'TR_LAI_FRAC',                               &
            LONG_NAME  = 'leaf_area_index',                           &
 !          UNITS      = '1',                                         &
-           DIMS       = MAPL_DimsHorzVert,                           &
-           VLOCATION  = MAPL_VLocationCenter,                        &
+           DIMS       = MAPL_DimsHorzOnly,                           &
+           VLOCATION  = MAPL_VLocationNone,                          &
+           UNGRIDDED_DIMS = [72],                                    &
            RESTART    = MAPL_RestartSkip,                            &
                                                          __RC__ )
 


### PR DESCRIPTION
Several uses found that when running with 137 or 181 levels ExtData2G was crashing when processing a few files needed by TR. It turns out TR had two imports that were declared as MAPL_DimsHorzVert/MAPL_VLocationCenter

However, the 3rd dimension in that file did not represent model levels, the fact the file was 72 was because at the time the user new they could get a 3d field by doing that, so should not change with the number of model levels. The corresponding import spec should also have been fixed so that when the # of model levels increased the import field did not change the 3rd dimension size.

This PR change two import fields in TR to used ungridded dimensions commensurate with the input file (72) so that when the model level changes these fields stay 72 levels.