### PR TITLE
Persist emissions after 2019 using ExtData2G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+-Connectivity added between GOCART2G and HEMCO for anthropogenic OC, BC, SO2, SO4, and NH3 in GEOS_ChemGridComp.F90. These species are now added in HEMCOgocart2g* files with diurnal and day of week scaling implemented.
+-ExtData2G is used to persist anthropogenic emissions for the year 2019 after the available emissions data set ends.
 ### Removed
 ### Changed
 ### Fixed

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -805,7 +805,7 @@ contains
 ! ---------------
   IF( myState%enable_HEMCO .AND. myState%enable_GOCART2G ) THEN
    CALL MAPL_AddConnectivity ( GC, &
-    SHORT_NAME  = (/ 'OC_ISOPRENE', 'OC_MTPA    ', 'OC_MTPO    ', 'OC_LIMO    ', 'SU_ANTHROL1', 'SU_ANTHROL2', 'SU_SHIPSO2', 'OC_ANTEOC1', 'OC_ANTEOC2', 'OC_SHIP', 'BC_ANTEBC1', 'BC_ANTEBC2', 'BC_SHIP','EMI_NH3_EN', 'SU_SHIPSO4'/), &
+    SHORT_NAME  = (/ 'OC_ISOPRENE', 'OC_MTPA    ', 'OC_MTPO    ', 'OC_LIMO    ', 'SU_ANTHROL1', 'SU_ANTHROL2', 'SU_SHIPSO2 ', 'OC_ANTEOC1 ', 'OC_ANTEOC2 ', 'OC_SHIP    ', 'BC_ANTEBC1 ', 'BC_ANTEBC2 ', 'BC_SHIP    ','EMI_NH3_EN ', 'SU_SHIPSO4 '/), &
     SRC_ID=HEMCO, DST_ID=GOCART2G, __RC__)
   END IF
 

--- a/HEMCO_GridComp/HEMCOgocart2g_ExtData.yaml
+++ b/HEMCO_GridComp/HEMCOgocart2g_ExtData.yaml
@@ -163,35 +163,35 @@ Exports:
     variable: OCPI
   GOCART_BC_ANTEBC1:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: bc_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample:HEMCOgocart2g_sample_3, variable: bc_nonenergy} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample:HEMCOgocart2g_sample_3, variable: bc_nonenergy}
   GOCART_BC_ANTEBC2:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: bc_energy}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: bc_energy} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: bc_energy}
   GOCART_BC_SHIP:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: bc_shipping}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: bc_shipping} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: bc_shipping}
   GOCART_OC_ANTEOC1:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: oc_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_nonenergy} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_nonenergy}
   GOCART_OC_ANTEOC2:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, variable: oc_energy}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_energy} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_energy}
   GOCART_OC_SHIP:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: oc_shipping}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_shipping} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_shipping}
   GOCART_SU_ANTHROL1:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: so2_nonenergy}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_nonenergy} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_nonenergy}
   GOCART_SU_ANTHROL2:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: so2_energy}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_energy} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_energy}
   GOCART_EMI_NH3_EN:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: nh3}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: nh3} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: nh3}
   GOCART_SU_SHIPSO2:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: so2_shipping}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_shipping} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_shipping}
   GOCART_SU_SHIPSO4:
     - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: so4_shipping}
-    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so4_shipping} 
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so4_shipping}
 

--- a/HEMCO_GridComp/HEMCOgocart2g_ExtData.yaml
+++ b/HEMCO_GridComp/HEMCOgocart2g_ExtData.yaml
@@ -7,26 +7,37 @@ Collections:
     template: ExtData/chemistry/HEMCO/v0.0.0/sfc/NVOC.geos.1x1.esmf.nc
   HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
   HEMCOgocart2g_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
     template: ExtData/chemistry/CEDS/v2021-04-21/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+    valid_range: "1979-01-15T12:00/2019-12-15T12:00"
 
 Samplings:
   HEMCOgocart2g_sample_0:
@@ -39,6 +50,11 @@ Samplings:
     update_frequency: PT24H
     update_offset: PT12H
     update_reference_time: '0'
+  HEMCOgocart2g_sample_3:
+    extrapolation: clim
+    update_frequency: P1M
+    update_reference_time: '0'
+    source_time: "2019-01-15T12:00/2019-12-15T00:00:00"
 
 Exports:
   CLM4_PFT_BARE:
@@ -146,58 +162,36 @@ Exports:
     sample: HEMCOgocart2g_sample_1
     variable: OCPI
   GOCART_BC_ANTEBC1:
-    collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: bc_nonenergy
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: bc_nonenergy}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample:HEMCOgocart2g_sample_3, variable: bc_nonenergy} 
   GOCART_BC_ANTEBC2:
-    collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: bc_energy
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: bc_energy}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: bc_energy} 
   GOCART_BC_SHIP:
-    collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: bc_shipping
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: bc_shipping}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: bc_shipping} 
   GOCART_OC_ANTEOC1:
-    collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: oc_nonenergy
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: oc_nonenergy}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_nonenergy} 
   GOCART_OC_ANTEOC2:
-    collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: oc_energy
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, variable: oc_energy}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_energy} 
   GOCART_OC_SHIP:
-    collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: oc_shipping
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: oc_shipping}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: oc_shipping} 
   GOCART_SU_ANTHROL1:
-    collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: so2_nonenergy
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: so2_nonenergy}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_nonenergy} 
   GOCART_SU_ANTHROL2:
-    collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: so2_energy
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: so2_energy}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_energy} 
   GOCART_EMI_NH3_EN:
-    collection: HEMCOgocart2g_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: nh3
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: nh3}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: nh3} 
   GOCART_SU_SHIPSO2:
-    collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: so2_shipping
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: so2_shipping}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so2_shipping} 
   GOCART_SU_SHIPSO4:
-    collection: HEMCOgocart2g_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
-    regrid: CONSERVE
-    sample: HEMCOgocart2g_sample_2
-    variable: so4_shipping
+    - {starting: "1979-01-15T12:00", collection: HEMCOgocart2g_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, sample: HEMCOgocart2g_sample_2, regrid: CONSERVE, variable: so4_shipping}
+    - {starting: "2019-12-15T12:00", collection: HEMCOgocart2g_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4, regrid: CONSERVE, sample: HEMCOgocart2g_sample_3, variable: so4_shipping} 
 


### PR DESCRIPTION
HEMCOgocart2g_ExtData.yaml was modified to add a rule for the anthropogenic emissions to persist the year 2019 once the dataset ends, closing #250. This eliminates the need for duplicate emissions files after the year 2019.  