### PR TITLE
Feature/vvalenti/gocart2g to gmi connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Added connectivity from GOCART2G aerosols to GMI chem
+
 ### Removed
 ### Changed
 ### Fixed

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -650,6 +650,39 @@ contains
 
   END IF
 
+! GOCART2G <=> GMICHEM coupling ...
+! ---------------------------------
+  IF(myState%enable_GMICHEM .AND. TRIM(providerName) == "GOCART2G") THEN
+
+! GOCART2G connections to GMICHEM
+! -------------------------------
+   IF(myState%enable_GOCART2G) &
+   CALL MAPL_AddConnectivity ( GC, &
+     SHORT_NAME  = (/ "CA.bcphobic", "CA.bcphilic" /), &
+     DST_ID=GMICHEM, SRC_ID=GOCART2G, __RC__)
+
+   CALL MAPL_AddConnectivity ( GC, &
+     SHORT_NAME  = (/ "DU" /), &
+     DST_ID=GMICHEM, SRC_ID=GOCART2G, __RC__)
+
+   CALL MAPL_AddConnectivity ( GC, &
+     SHORT_NAME  = (/ "CA.ocphobic", "CA.ocphilic" /), &
+     DST_ID=GMICHEM, SRC_ID=GOCART2G, __RC__)
+
+   CALL MAPL_AddConnectivity ( GC, &
+     SHORT_NAME  = (/ "CA.brphobic", "CA.brphilic" /), &
+     DST_ID=GMICHEM, SRC_ID=GOCART2G, __RC__)
+
+   CALL MAPL_AddConnectivity ( GC, &
+     SHORT_NAME  = (/ "SS" /), &
+     DST_ID=GMICHEM, SRC_ID=GOCART2G, __RC__)
+
+   CALL MAPL_AddConnectivity ( GC, &
+     SHORT_NAME  = (/ "DMS", "SO2", &
+                      "SO4", "MSA" /), &
+     DST_ID=GMICHEM, SRC_ID=GOCART2G, __RC__)
+  END IF
+
 ! GOCART.data <=> GMICHEM coupling ...
 ! ------------------------------------
   IF(myState%enable_GMICHEM .AND. TRIM(providerName) == "GOCART.data") THEN
@@ -866,8 +899,8 @@ contains
      END IF
 
      ! make sure we don't have inconsistent MEGAN flags
-     IF ( doMEGANviaHEMCO .eqv. .TRUE.    .AND.  &
-          doMEGANemission .eqv. .FALSE. ) THEN
+     IF ( ( doMEGANviaHEMCO .eqv. .TRUE. )    .AND.  &
+          ( doMEGANemission .eqv. .FALSE. ) ) THEN
         PRINT*,'Inconsistent GMI flags: doMEGANviaHEMCO==T, doMEGANemission==F'
         STATUS=99
         VERIFY_(STATUS)


### PR DESCRIPTION
Add connectivity from GOCART2G aerosols to GMI Chem
zero diff for PCHEM simulations 
non-zero diff for GMI simulations with GOCART2G as aero provider 