### PR TITLE
Add connectivity from GMI to ACHEM (4 fields)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Connectivity from GMI to ACHEM (4 fields)
+
 ### Removed
+
 ### Changed
+
 ### Fixed
 
 ## [1.13.1] - 2023-04-24

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -604,6 +604,13 @@ contains
         DST_NAME  = (/'O3P      ', 'OHSTRAT  ', 'O3       ', 'OCS_JRATE'/), &
         DST_ID = ACHEM, SRC_ID = STRATCHEM, __RC__  )
   ENDIF
+
+  IF(myState%enable_GMICHEM .AND. myState%enable_ACHEM) then
+   CALL MAPL_AddConnectivity ( GC, &
+        SRC_NAME  = (/'O        ', 'OH       ', 'OX       ', 'OCS_JRATE'/), &
+        DST_NAME  = (/'O3P      ', 'OHSTRAT  ', 'O3       ', 'OCS_JRATE'/), &
+        DST_ID = ACHEM, SRC_ID = GMICHEM, __RC__  )
+  ENDIF
  
 
 ! GOCART <=> ACHEM (OCS CHEMISTRY)


### PR DESCRIPTION
Provide O3P, OHSTRAT, O3 and OCS_JRATE from GMI for ACHEM.
Note: OCS_JRATE requires GMI release v1.1.1 or later