### PR TITLE
Remove WLI export for compatibility with GEOS-Chem 14.2.0 and HEMCO 3.7.0

### DIFF
--- a/HEMCO_GridComp/HEMCO_GridCompMod.F90
+++ b/HEMCO_GridComp/HEMCO_GridCompMod.F90
@@ -1320,7 +1320,6 @@ CONTAINS
     CALL HCO_Imp2Ext ( HcoState, ExtState%U10M     , 'U10M'     , __RC__ )
     CALL HCO_Imp2Ext ( HcoState, ExtState%V10M     , 'V10M'     , __RC__ )
     CALL HCO_Imp2Ext ( HcoState, ExtState%ALBD     , 'ALBVF'    , __RC__ )
-    CALL HCO_Imp2Ext ( HcoState, ExtState%WLI      ,  'LWI'     , __RC__ )
     CALL HCO_Imp2Ext ( HcoState, ExtState%T2M      , 'T2M'      , __RC__ )
     CALL HCO_Imp2Ext ( HcoState, ExtState%TSKIN    , 'TS'       , __RC__ )
     CALL HCO_Imp2Ext ( HcoState, ExtState%GWETTOP  , 'WET1'     , __RC__ )


### PR DESCRIPTION
This PR updates `HEMCO_GridCompMod.F90` for compatibility with [GEOS-Chem](https://github.com/GEOS-ESM/geos-chem) 14.2.0 and [HEMCO](https://github.com/GEOS-ESM/HEMCO) 3.7.0. Those versions deprecate the WLI state variable in HEMCO.

**This update breaks backwards compatibility with GEOS-Chem and HEMCO and must be merged at the same time as the following two PRs:**
- https://github.com/GEOS-ESM/HEMCO/pull/10
- https://github.com/GEOS-ESM/geos-chem/pull/2

See discussion at https://github.com/GEOS-ESM/geos-chem/pull/2