### PR TITLE
Fix ESMF_VMGet call in GAAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix a bug in GAAS where it gets the VM (global instead of the correct current)
+
 ## [1.13.1] - 2023-04-24
 
 ### Added

--- a/GAAS_GridComp/LDE_Mod.F90
+++ b/GAAS_GridComp/LDE_Mod.F90
@@ -130,7 +130,7 @@ CONTAINS
 
 !    Get VM for later
 !    ----------------
-     call ESMF_VMGetGlobal(self%VM,__RC__)
+     call ESMF_VMGetCurrent(self%VM,__RC__)
 
 !    Set Ensemble indices on root PE
 !    -------------------------------


### PR DESCRIPTION
As discovered by Eric Hackert at NAS and diagnosed by @atrayano, GAAS should be using `ESMF_VMGetCurrent` not `ESMF_VMGetGlobal`. In some ways of running GEOS, the Global VM might not just be the model PEs but also some ioserver PEs and more. 

Then, later when you `call MAPL_CommsBcast` on that VM, well, not all might answer back and you lock.