### PR TITLE
Update CircleCI to use Orb Default Baselibs and BCs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
-# Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.13.0
-bcs_version: &bcs_version v11.00.0
+# Anchors in case we need to override the defaults from the orb
+#baselibs_version: &baselibs_version v7.14.0
+#bcs_version: &bcs_version v11.1.0
 
 orbs:
   ci: geos-esm/circleci-tools@1
@@ -18,7 +18,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: *baselibs_version
+          #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update CI to use Baselibs 7.13.0
+- Update CI to use Baselibs default from the CircleCI orb
 
 ### Fixed
 


### PR DESCRIPTION
This PR updates the CircleCI config to default to using the Baselibs in the CircleCI orb rather than explicitly specifying the versions. In most cases, this is the "best" way as a change to the orb can fix this for projects without the need for a PR.

Note that we keep commented the explicit anchors in case needed.