### PR TITLE
Added CARMA pfast parameterization

### DIFF
--- a/CARMAchem_GridComp/CARMA/source/base/Makefile
+++ b/CARMAchem_GridComp/CARMA/source/base/Makefile
@@ -16,7 +16,7 @@ setupcoag.o smallconc.o step.o supersat.o vaporp.o vertadv.o \
 vertdif.o vertical.o versol.o rhopart.o psolve.o zeromicro.o \
 nsubsteps.o setupgrow.o setupgkern.o setupnuc.o growevapl.o microfast.o \
 gsolve.o actdropl.o freezglaerl_murray2010.o growp.o downgxfer.o \
-gasexchange.o melticel.o upgxfer.o freezdropl.o \
+gasexchange.o melticel.o upgxfer.o freezdropl.o pfastdmdt.o \
 downgevapply.o evapp.o evap_poly.o evap_mono.o \
 evap_ingrp.o tsolve.o miess.o vaporp_h2o_buck1981.o \
 vaporp_h2o_murphy2005.o maxconc.o setupbdif.o setupvf_std.o \
@@ -157,6 +157,9 @@ growp.o : growp.F90 carma_globaer.h carma_mod.mod carmastate_mod.mod carma_types
 	$(FORTRAN) $(FFLAGS) -c $<
 
 gsolve.o : gsolve.F90 carma_globaer.h carma_mod.mod carmastate_mod.mod carma_types_mod.mod carma_constants_mod.mod carma_enums_mod.mod carma_precision_mod.mod 
+	$(FORTRAN) $(FFLAGS) -c $<
+
+pfastdmdt.o : pfastdmdt.F90 carma_globaer.h carma_mod.mod carmastate_mod.mod carma_types_mod.mod carma_constants_mod.mod carma_enums_mod.mod carma_precision_mod.mod 
 	$(FORTRAN) $(FFLAGS) -c $<
 
 fractal_meanfield_mod.o : fractal_meanfield_mod.F90 carma_globaer.h carma_mod.mod carmastate_mod.mod carma_types_mod.mod carma_constants_mod.mod carma_enums_mod.mod carma_precision_mod.mod adgaquad_mod.mod lusolvec_mod.mod 

--- a/CARMAchem_GridComp/CARMA/source/base/carma_enums_mod.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/carma_enums_mod.F90
@@ -118,6 +118,7 @@ module carma_enums_mod
   integer, public, parameter :: RC_ERROR          = -1  !! Failure
   integer, public, parameter :: RC_WARNING        = 1   !! Warning
   integer, public, parameter :: RC_WARNING_RETRY  = 2   !! Warning, Retry Suggested
+  integer, public, parameter :: RC_WARNING_PFAST  = 3   !! Warning, Parameterization Suggested
 
 
   !  Define values of symbols used to specify horizontal & vertical grid type.

--- a/CARMAchem_GridComp/CARMA/source/base/carma_globaer.h
+++ b/CARMAchem_GridComp/CARMA/source/base/carma_globaer.h
@@ -145,6 +145,7 @@
 #define do_print_init carma%f_do_print_init
 #define do_step       carma%f_do_step
 #define do_substep    carma%f_do_substep
+#define do_pfast      carma%f_do_pfast
 #define do_thermo     carma%f_do_thermo
 #define do_vdiff      carma%f_do_vdiff
 #define do_vtran      carma%f_do_vtran

--- a/CARMAchem_GridComp/CARMA/source/base/carma_mod.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/carma_mod.F90
@@ -333,7 +333,7 @@ contains
   !!  @version Feb-2009 
   !!  @author  Chuck Bardeen 
   subroutine CARMA_Initialize(carma, rc, do_cnst_rlh, do_coag, do_detrain, do_fixedinit, &
-      do_grow, do_incloud, do_explised, do_print_init, do_substep, do_thermo, do_vdiff, &
+          do_grow, do_incloud, do_explised, do_print_init, do_substep, do_pfast, do_thermo, do_vdiff, &
       do_vtran, do_drydep, vf_const, minsubsteps, maxsubsteps, maxretries, conmax, &
       do_pheat, do_pheatatm, dt_threshold, cstick, gsticki, gstickl, tstick, do_clearsky, &
       do_partialinit)
@@ -348,6 +348,7 @@ contains
     logical, intent(in), optional       :: do_incloud    !! do incloud growth and coagulation?
     logical, intent(in), optional       :: do_explised   !! do sedimentation with substepping
     logical, intent(in), optional       :: do_substep    !! do substepping
+    logical, intent(in), optional       :: do_pfast      !! do parameterized microfast
     logical, intent(in), optional       :: do_print_init !! do prinit initializtion information
     logical, intent(in), optional       :: do_thermo     !! do thermodynamics
     logical, intent(in), optional       :: do_vdiff      !! do Brownian diffusion
@@ -384,6 +385,7 @@ contains
     carma%f_do_pheatatm   = .FALSE.
     carma%f_do_print_init = .FALSE.
     carma%f_do_substep    = .FALSE.
+    carma%f_do_pfast      = .FALSE.
     carma%f_do_thermo     = .FALSE.
     carma%f_do_vdiff      = .FALSE.
     carma%f_do_vtran      = .FALSE.
@@ -408,6 +410,7 @@ contains
     if (present(do_pheatatm))   carma%f_do_pheatatm   = do_pheatatm
     if (present(do_print_init)) carma%f_do_print_init = (do_print_init .and. carma%f_do_print)
     if (present(do_substep))    carma%f_do_substep    = do_substep
+    if (present(do_pfast))      carma%f_do_pfast      = do_pfast
     if (present(do_thermo))     carma%f_do_thermo     = do_thermo
     if (present(do_vdiff))      carma%f_do_vdiff      = do_vdiff
     if (present(do_vtran))      carma%f_do_vtran      = do_vtran 

--- a/CARMAchem_GridComp/CARMA/source/base/carma_types_mod.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/carma_types_mod.F90
@@ -353,6 +353,7 @@ module carma_types_mod
     !   do_print_init If .true. then do print initializtion info          {init}
     !   do_step     if .true. then varstepping succeeded                  {init}
     !   do_substep  if .true. then use substepping                        {init}
+    !   do_pfast    if .true. then use microfast parameterization         {init}
     !   do_thermo   if .true. then do solve thermodynamic equation        {init}
     !   do_vdiff    If .true. then do Brownian diffusion                  {init}
     !   do_vtran    If .true. then do vertical transport                  {init}
@@ -394,6 +395,7 @@ module carma_types_mod
     logical                                       :: f_do_print_init
     logical                                       :: f_do_step
     logical                                       :: f_do_substep
+    logical                                       :: f_do_pfast
     logical                                       :: f_do_thermo
     logical                                       :: f_do_cnst_rlh
     logical, allocatable, dimension(:,:)          :: f_if_nuc       !(NELEM,NELEM)

--- a/CARMAchem_GridComp/CARMA/source/base/freezaerl_koop2000.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/freezaerl_koop2000.F90
@@ -75,8 +75,9 @@ subroutine freezaerl_koop2000(carma, cstate, iz, rc)
   real(kind=f)                         :: fkelv
   real(kind=f)                         :: fkelvi
 
-
-  rc = RC_OK
+  ! PAC: Assuming success inside of a subroutine is a problem, any errors
+  !       are erased by this.
+  !rc = RC_OK
   
   !  Aerosol freezing limited to T < 240K
   if (t(iz) <= 240._f) then

--- a/CARMAchem_GridComp/CARMA/source/base/freezaerl_mohler2010.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/freezaerl_mohler2010.F90
@@ -76,7 +76,9 @@ subroutine freezaerl_mohler2010(carma, cstate, iz, rc)
   real(kind=f)                         :: fkelvi
 
 
-  rc = RC_OK
+  ! PAC: Assuming success inside of a subroutine is a problem, any errors
+  !       are erased by this.
+  !rc = RC_OK
   
   !  Aerosol freezing limited to T < 240K
   if (t(iz) <= 240._f) then

--- a/CARMAchem_GridComp/CARMA/source/base/freezglaerl_murray2010.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/freezglaerl_murray2010.F90
@@ -60,7 +60,9 @@ subroutine freezglaerl_murray2010(carma, cstate, iz, rc)
   real(kind=f)                         :: ssi, ssiold
   
   ! Assume success.
-  rc = RC_OK
+  ! PAC: Assuming success inside of a subroutine is a problem, any errors
+  !       are erased by this.
+  !rc = RC_OK
 
   ! Loop over particle groups.
   do igroup = 1,NGROUP

--- a/CARMAchem_GridComp/CARMA/source/base/gsolve.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/gsolve.F90
@@ -64,7 +64,7 @@ subroutine gsolve(carma, cstate, iz, previous_ice, previous_liquid, scale_thresh
 
     if (gc(iz,igas) < 0.0_f) then
       if (do_substep) then
-        if (nretries == maxretries) then 
+        if (nretries == maxretries .and. .not. do_pfast) then 
           if (do_print) write(LUNOPRT,1) trim(gasname(igas)), iz, lat, lon, gc(iz,igas), gasprod(igas), &
             supsati(iz,igas), supsatl(iz,igas), t(iz)
           if (do_print) write(LUNOPRT,2) gcl(iz,igas), supsatiold(iz,igas), supsatlold(iz,igas), told(iz), d_gc(iz,igas), d_t(iz)

--- a/CARMAchem_GridComp/CARMA/source/base/microfast.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/microfast.F90
@@ -151,14 +151,17 @@ subroutine microfast(carma, cstate, iz, scale_threshold, rc)
     call downgevapply(carma, cstate, iz, rc)
     if (rc < RC_OK) return
 
+    ! If this is a parameterized timestep, scale bin values to prevent gas overshoot
+    if (rc == RC_WARNING_PFAST) call pfastdmdt(carma, cstate, iz, rc)
+
     call gsolve(carma, cstate, iz, previous_ice, previous_liquid, scale_threshold, rc)
-    if (rc /=RC_OK) return
+    if (rc /= RC_OK .and. rc /= RC_WARNING_PFAST) return
   endif
 
   ! Update temperature if thermal processes requested
   if (do_thermo) then
     call tsolve(carma, cstate, iz, scale_threshold, rc)
-    if (rc /= RC_OK) return
+    if (rc /= RC_OK .and. rc /= RC_WARNING_PFAST) return
   endif
 
   !  Update saturation ratios

--- a/CARMAchem_GridComp/CARMA/source/base/pfastdmdt.F90
+++ b/CARMAchem_GridComp/CARMA/source/base/pfastdmdt.F90
@@ -1,0 +1,68 @@
+! Include shortname defintions, so that the F77 code does not have to be modified to
+! reference the CARMA structure.
+#include "carma_globaer.h"
+
+!!  This routine normalizes dmdt as to not make gas concentration go negative.
+!!
+!! @author Parker Case
+!! @version Mar-2024
+subroutine pfastdmdt(carma, cstate, iz, rc)
+
+  ! types
+  use carma_precision_mod
+  use carma_enums_mod
+  use carma_constants_mod
+  use carma_types_mod
+  use carmastate_mod
+  use carma_mod
+
+  implicit none
+
+  type(carma_type), intent(in)         :: carma       !! the carma object
+  type(carmastate_type), intent(inout) :: cstate      !! the carma state object
+  integer, intent(in)                  :: iz          !! z index
+  integer, intent(inout)               :: rc          !! return code, negative indicates failure
+
+  ! Local declarations
+  real(kind=f)  :: rvap
+  real(kind=f)  :: gc_cgs
+  real(kind=f)  :: gc_target
+  real(kind=f)  :: scalefactor
+  integer       :: igroup
+  integer       :: ielem
+  integer       :: igas
+  integer       :: ibin
+
+  do igroup = 1,NGROUP
+
+    ielem = ienconc(igroup)     ! element of particle number concentration
+
+    igas = igrowgas(ielem)      ! condensing gas
+
+    if ((itype(ielem) == I_VOLATILE) .and. (igas /= 0)) then
+
+      ! Calculate vapor pressures.
+      call vaporp(carma, cstate, iz, igas, rc)
+
+      ! Define gas constant for this gas
+      rvap = RGAS / gwtmol(igas)
+
+      ! Current gas concentration
+      gc_cgs = gc(iz,igas) / (zmet(iz)*xmet(iz)*ymet(iz))
+
+      ! Gas concentration at equilibrium
+      gc_target = pvapl(iz,igas) / (rvap * t(iz))
+
+      ! Determine total mass added to bins in implicit timestep
+      scalefactor = sum((pc(iz,:,ielem) - pcl(iz,:,ielem))*rmass(:,igroup))/(gc_cgs - gc_target)
+
+      ! Loop through bins and apply correction
+      do ibin = 1,NBIN
+        pc(iz,ibin,ielem) = pcl(iz,ibin,ielem) + (pc(iz,ibin,ielem) - pcl(iz,ibin,ielem)) / scalefactor
+      end do
+    end if
+
+  end do
+
+  return
+end

--- a/CARMAchem_GridComp/CARMA_GridComp.F90
+++ b/CARMAchem_GridComp/CARMA_GridComp.F90
@@ -977,7 +977,7 @@ CONTAINS
 !  Fill the internal state with direct gas species from GMI
 !  Expectation is species are in VMR and needed in MMR for CARMA
 !  -----------
-   if(trim(reg%sulfuric_acid_source) == 'full_field' .and. reg%NGAS > 0) then
+   if(reg%sulfuric_acid_source(1:10) == 'full_field' .and. reg%NGAS > 0) then
     do igas = 1, reg%NGAS
      n  = nCARMAbegin + reg%NBIN*reg%NELEM - 1 + igas
      gasname = ESMF_UtilStringUpperCase(reg%gasname(igas))
@@ -1399,7 +1399,7 @@ endif
 !  Return the updated gas species to GMI from the internal state
 !  Expectation is species are in MMR and needed in VMR for GMI
 !  -----------
-   if(trim(reg%sulfuric_acid_source) == 'full_field' .and. reg%NGAS > 0) then
+   if(reg%sulfuric_acid_source(1:10) == 'full_field' .and. reg%NGAS > 0) then
     do igas = 1, reg%NGAS
      n  = nCARMAbegin + reg%NBIN*reg%NELEM - 1 + igas
      gasname = ESMF_UtilStringUpperCase(reg%gasname(igas))

--- a/CARMAchem_GridComp/CARMAchem_GridCompMod.F90
+++ b/CARMAchem_GridComp/CARMAchem_GridCompMod.F90
@@ -748,7 +748,7 @@ CONTAINS
         end if
        
         ! attach the aerosol optics method
-        call ESMF_MethodAdd(aero, label='aerosol_optics', userRoutine=aerosol_optics, __RC__)
+        call ESMF_MethodAdd(aero, label='run_aerosol_optics', userRoutine=aerosol_optics, __RC__)
 
     end if
 


### PR DESCRIPTION
Added CARMA pfast parameterization in order to speed up CARMA sulfate aerosols in high-nucleation environments (i.e. near surface emissions). 

All changes here are contained to CARMA.

Tested to be backward compatible–old model setups using CARMA will still run with zero diff if using this updated version.