### PR TITLE
Update CEDS emissions for CO in achem (R21C)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,10 @@ version: 2.1
 
 # Anchors to prevent forgetting to update a version
 baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v10.22.3
+# NOTE: The new version number is needed because R21C now
+# needs a new NRL file. Rather than try and back port it
+# to a v10 bcs, we just up the version for this PR
+bcs_version: &bcs_version v11.3.0
 
 orbs:
   ci: geos-esm/circleci-tools@1
@@ -21,5 +24,6 @@ workflows:
           baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
+          fixture_branch: R21C
           mepodevelop: true
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+-The filepath for anthropogenic emissions of CO used by achem was changed. Note the previous version of the emissions has an incorrect seasonal cycle.
 ### Removed
 ### Changed
 ### Fixed

--- a/GEOSachem_GridComp/AMIP.20C/GEOSachem_ExtData.rc
+++ b/GEOSachem_GridComp/AMIP.20C/GEOSachem_ExtData.rc
@@ -44,7 +44,7 @@ SOAG_EMIS              'm-2 s-1'            Y        N               0          
 # CO emissions for VOC
 CO_BIOMASS_VOC         'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     biomass      ExtData/chemistry/HFED/v1.0/Y%y4/hfed.emis_co.x576_y361_t14.%y4.nc4
 CO_BF_VOC              'kg m-2 s-1'         Y        Y     %y4-%m2-%d2t12:00:00Z   none none     emcobf       /dev/null
-CO_FS_VOC              'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     co           ExtData/chemistry/CEDS/v2021-04-21/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+CO_FS_VOC              'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     co           ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
 
 # Photolysis rates
 #jH2O2                 's-1'                Y        N               0             none none     jH2O2        ExtData/chemistry/GMI/v0.0.0/L72/Y2008/gmi_jh2o2.x144_y91_z72.2008%m2.nc4

--- a/GEOSachem_GridComp/AMIP/GEOSachem_ExtData.rc
+++ b/GEOSachem_GridComp/AMIP/GEOSachem_ExtData.rc
@@ -44,7 +44,7 @@ SOAG_EMIS              'm-2 s-1'            Y        N               0          
 # CO emissions for VOC
 CO_BIOMASS_VOC         'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     biomass       ExtData/chemistry/QFED/v2.6r1/sfc/0.1/Y%y4/M%m2/qfed2.emis_co.061.%y4%m2%d2.nc4
 CO_BF_VOC              'kg m-2 s-1'         Y        Y     %y4-%m2-%d2t12:00:00Z   none none     emcobf        /dev/null
-CO_FS_VOC              'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     co            ExtData/chemistry/CEDS/v2021-04-21/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+CO_FS_VOC              'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     co            ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
 
 # Photolysis rates
 #jH2O2                 's-1'                Y        N               0             none none     jH2O2         ExtData/chemistry/GMI/v0.0.0/L72/Y2008/gmi_jh2o2.x144_y91_z72.2008%m2.nc4

--- a/GEOSachem_GridComp/AMIP/GEOSachem_ExtData.yaml
+++ b/GEOSachem_GridComp/AMIP/GEOSachem_ExtData.yaml
@@ -1,6 +1,6 @@
 Collections:
   GEOSachem_CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
   GEOSachem_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4:
     template: ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
   GEOSachem_GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4:

--- a/GEOSachem_GridComp/GEOSachem_ExtData.rc
+++ b/GEOSachem_GridComp/GEOSachem_ExtData.rc
@@ -44,7 +44,7 @@ SOAG_EMIS              'm-2 s-1'            Y        N               0          
 # CO emissions for VOC
 CO_BIOMASS_VOC         'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     biomass       ExtData/chemistry/QFED/v2.5r1-nrt/sfc/0.1/Y%y4/M%m2/qfed2.emis_co.006.%y4%m2%d2.nc4
 CO_BF_VOC              'kg m-2 s-1'         Y        Y     %y4-%m2-%d2t12:00:00Z   none none     emcobf        /dev/null
-CO_FS_VOC              'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     co            ExtData/chemistry/CEDS/v2021-04-21/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+CO_FS_VOC              'kg m-2 s-1'         N        Y     %y4-%m2-%d2t12:00:00Z   none none     co            ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
 
 # Photolysis rates
 #jH2O2                 's-1'                Y        N               0             none none     jH2O2         ExtData/chemistry/GMI/v0.0.0/L72/Y2008/gmi_jh2o2.x144_y91_z72.2008%m2.nc4

--- a/GEOSachem_GridComp/GEOSachem_ExtData.yaml
+++ b/GEOSachem_GridComp/GEOSachem_ExtData.yaml
@@ -1,6 +1,6 @@
 Collections:
   GEOSachem_CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
-    template: ExtData/chemistry/CEDS/v2021-04-21/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
   GEOSachem_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4:
     template: ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
   GEOSachem_GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4:


### PR DESCRIPTION
This aligns the CO emissions used by achem to be consistent with the revised version of CEDS that is now being used by GOCART.