### PR TITLE
Update ESMF CMake target to ESMF::ESMF

### DIFF
--- a/CARMAchem_GridComp/CMakeLists.txt
+++ b/CARMAchem_GridComp/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach (dir ${src_directories})
   list (APPEND srcs ${tmpsrcs})
 endforeach()
 
-set (dependencies Chem_Shared Chem_Base GMAO_mpeu esmf)
+set (dependencies Chem_Shared Chem_Base GMAO_mpeu ESMF::ESMF)
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies})
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CARMA/source/base>)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Removed
 ### Changed
+
+- Update ESMF CMake target to `ESMF::ESMF`
+
 ### Fixed
 ### Deprecated
 
@@ -87,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Instead of importing a set of QQK diagnostic fields for chemical loss of stOX, TR now imports a single field: stOX_loss
-- For OPS configuration: removal of links, change of QFED paths from vNRT/ to v2.5r1-nrt/ 
+- For OPS configuration: removal of links, change of QFED paths from vNRT/ to v2.5r1-nrt/
 - For AMIP configuration: update of QFED from v2.5r1 to v2.6r1 (most recent collection)
 - Moved to GitHub Actions for label enforcement
 - Update CircleCI to use Baselibs 7.7.0
@@ -135,7 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updates to emissions from galactic cosmic rays in GMI
 - Minor improvement to Runtime_Registry module.
-- Broke away the GMI contents from Chem_Registry.rc, into a separate file 
+- Broke away the GMI contents from Chem_Registry.rc, into a separate file
 
 ## [1.10.1] - 2022-08-30
 
@@ -191,7 +194,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix YAML typo in `GEOSachem_GridComp/GEOSachem_ExtData.yaml`
 
-## [1.9.4] - 2022-05-31 
+## [1.9.4] - 2022-05-31
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set (srcs
 esma_add_library (${this}
   SRCS ${srcs}
   SUBCOMPONENTS ${alldirs}
-  DEPENDENCIES MAPL Chem_Shared Chem_Base GOCART_GridComp GOCART2G_GridComp TR GMI StratChem esmf)
+  DEPENDENCIES MAPL Chem_Shared Chem_Base GOCART_GridComp GOCART2G_GridComp TR GMI StratChem ESMF::ESMF)
 
 install(
    FILES GEOS_ChemGridComp.rc ChemEnv_ExtData.rc  ChemEnv.rc ChemEnv_ExtData.yaml

--- a/DNA_GridComp/CMakeLists.txt
+++ b/DNA_GridComp/CMakeLists.txt
@@ -4,7 +4,7 @@ set (srcs
   DNA_GridCompMod.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)
 target_compile_definitions (${this} PRIVATE MAPL_MODE GEOS5)
 
 set (resource_files

--- a/GEOSCHEMchem_GridComp/CMakeLists.txt
+++ b/GEOSCHEMchem_GridComp/CMakeLists.txt
@@ -17,7 +17,7 @@ set (src_directories
    ${geos_chem_dir}/KPP/fullchem
    ${geos_chem_dir}/GeosCore
    ${geos_chem_dir}/Interfaces/GCHP
-   ${geos_chem_dir}/Interfaces/GEOS  
+   ${geos_chem_dir}/Interfaces/GEOS
    ${geos_chem_dir}/ObsPack
   )
 include_directories (${geos_chem_dir}/Headers)
@@ -77,7 +77,7 @@ endif ()
 esma_add_library (${this}
    SRCS ${srcs}
    DEPENDENCIES MAPL MAPL_cfio_r4 Chem_Base Chem_Shared HEMCO
-                OpenMP::OpenMP_Fortran esmf NetCDF::NetCDF_Fortran
+                OpenMP::OpenMP_Fortran ESMF::ESMF NetCDF::NetCDF_Fortran
    )
 
 target_compile_definitions(${this} PRIVATE

--- a/GEOSachem_GridComp/CMakeLists.txt
+++ b/GEOSachem_GridComp/CMakeLists.txt
@@ -27,7 +27,7 @@ set (srcs
 esma_add_library (
   ${this}
   SRCS ${srcs}
-  DEPENDENCIES Chem_Shared MAPL GMAO_mpeu esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES Chem_Shared MAPL GMAO_mpeu ESMF::ESMF NetCDF::NetCDF_Fortran
   )
 target_compile_definitions (${this} PRIVATE MAPL_MODE GEOS5)
 set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${PP})

--- a/GEOSpchem_GridComp/CMakeLists.txt
+++ b/GEOSpchem_GridComp/CMakeLists.txt
@@ -2,4 +2,4 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS GEOS_PChemGridComp.F90
-  DEPENDENCIES MAPL MAPL_cfio_r4 Chem_Base esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES MAPL MAPL_cfio_r4 Chem_Base ESMF::ESMF NetCDF::NetCDF_Fortran)

--- a/HEMCO_GridComp/CMakeLists.txt
+++ b/HEMCO_GridComp/CMakeLists.txt
@@ -7,7 +7,7 @@ set (srcs
 esma_add_library (
   ${this}
   SRCS ${srcs}
-  DEPENDENCIES Chem_Shared MAPL HEMCO esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES Chem_Shared MAPL HEMCO ESMF::ESMF NetCDF::NetCDF_Fortran
   )
 target_compile_definitions (${this} PRIVATE ESMF_ DEVEL GEOS_FP)
 

--- a/MAMchem_GridComp/CMakeLists.txt
+++ b/MAMchem_GridComp/CMakeLists.txt
@@ -54,7 +54,7 @@ set (srcs
   )
 
 
-set (dependencies MAPL Chem_Shared GMAO_mpeu esmf NetCDF::NetCDF_Fortran)
+set (dependencies MAPL Chem_Shared GMAO_mpeu ESMF::ESMF NetCDF::NetCDF_Fortran)
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${dependencies} SUBDIRS optics)
 target_compile_definitions (${this} PRIVATE GEOS5 MODAL_AERO MODAL_AERO_7MODE GEOS5_PORT)
 

--- a/MATRIXchem_GridComp/CMakeLists.txt
+++ b/MATRIXchem_GridComp/CMakeLists.txt
@@ -22,7 +22,7 @@ set (srcs
   MATRIXchem_GridCompMod.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES Chem_Shared MAPL esmf)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES Chem_Shared MAPL ESMF::ESMF)
 if (EXTENDED_SOURCE)
   set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${EXTENDED_SOURCE})
 endif ()

--- a/Shared/Chem_Base/CMakeLists.txt
+++ b/Shared/Chem_Base/CMakeLists.txt
@@ -14,7 +14,7 @@ set (srcs
   Chem_AodMod.F90
   Chem_SimpleBundleMod.F90
   )
-esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu MAPL GMAO_gfio_r4 esmf NetCDF::NetCDF_Fortran)
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu MAPL GMAO_gfio_r4 ESMF::ESMF NetCDF::NetCDF_Fortran)
 target_compile_definitions (${this} PRIVATE GEOS5)
 
 ecbuild_add_executable(TARGET gogo.x SOURCES gogo.F90 LIBS ${this})

--- a/Shared/Chem_Shared/CMakeLists.txt
+++ b/Shared/Chem_Shared/CMakeLists.txt
@@ -35,7 +35,7 @@ endif ()
 
 esma_add_library(${this}
    SRCS ${srcs}
-   DEPENDENCIES GMAO_mpeu MAPL Chem_Base GEOS_Shared GMAO_hermes esmf NetCDF::NetCDF_Fortran)
+   DEPENDENCIES GMAO_mpeu MAPL Chem_Base GEOS_Shared GMAO_hermes ESMF::ESMF NetCDF::NetCDF_Fortran)
 #add_definitions(-DDEBUG)
 add_definitions(-DSPMD -DFVCHEM)
 

--- a/Shared/HEMCO/CMakeLists.txt
+++ b/Shared/HEMCO/CMakeLists.txt
@@ -44,7 +44,7 @@ list (REMOVE_ITEM srcs
 
 esma_add_library (${this}
    SRCS ${srcs}
-   DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran
+   DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran
    )
 
 target_compile_definitions (${this} PRIVATE ESMF_ USE_REAL8 MODEL_GEOS)


### PR DESCRIPTION
This PR updates the ESMF CMake target to `ESMF::ESMF` which is the correct canonical target name for ESMF. This is necessary for Spack compatibility. NOTE: This requires ESMF 8.6.1 or later.