### PR TITLE
Temporarily make MOIST lightning scheme the default again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated GAAS_Gridcomp_Extdata.yaml in AMIP/ to avoid the model to crash when GAAS is turned on and AMIP emissions chosen.
+- Temporary fix for lightning, reverting to MOIST scheme until imports for LOPEZ are available
 
 ### Deprecated
 

--- a/ChemEnv.rc
+++ b/ChemEnv.rc
@@ -1,7 +1,7 @@
 #-----------------------
 # Settings for Lightning
 #-----------------------
-flashSource: LOPEZ       # MOIST, FIT, HEMCO, LOPEZ (default)
+flashSource: MOIST       # MOIST, FIT, HEMCO, LOPEZ (default)
 
 # for FIT only:
 ratioGlobalFile: ExtData/g5chem/x/lightning/RatioGlobal.asc


### PR DESCRIPTION
This is needed until new imports are available for the LOPEZ scheme.