### PR TITLE
GEOS-Chem 14.5.1 and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added Cloud-J subdirectory and CMake updates for Cloud-J repository
 - Added HETP subdirectory and CMake updates for new HETP submodule
+- Copy GEOS-Chem *.yaml and *.yml files to build directory
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added Cloud-J subdirectory and CMake updates for Cloud-J repository
+- Added HETP subdirectory and CMake updates for HETP repository
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added Cloud-J subdirectory and CMake updates for Cloud-J repository
-- Added HETP subdirectory and CMake updates for HETP repository
+- Added HETP subdirectory and CMake updates for new HETP submodule
 
 ### Removed
 
 ### Changed
 - Removed variable WLI from HEMCO grid comp module for compatibility with HEMCO v3.8
 - Updating CMakeLists in GEOSCHEMchem to copy all rc and yaml files to install/etc needed to run GEOS with GEOS-Chem
+- Updated subroutine call in HEMCO_GridCompMod.F90 for compatibility with HEMCO 3.10.1
+- Updated CMakeLists.txt for Cloud-J for compatibility with Cloud-J 8.0.1
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 esma_set_this ()
 
-esma_add_subdirectories(Shared GOCART Cloud-J)
+esma_add_subdirectories(Shared GOCART Cloud-J HETP)
 
 set (alldirs
   GEOSpchem_GridComp

--- a/Cloud-J/CMakeLists.txt
+++ b/Cloud-J/CMakeLists.txt
@@ -6,12 +6,12 @@ set (MODEL_GEOSCHEM TRUE) # Will need to rework to use with GMI instead
 set (MAPL_ESMF TRUE)
 
 set (srcs
-   ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_sub_mod.F90
    ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_cmn_mod.F90
    ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_error_mod.F90
-   ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_init_mod.F90
+   ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_fjx_osa_mod.F90
    ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_fjx_sub_mod.F90
-   ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_osa_sub_mod.F90
+   ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_init_mod.F90
+   ${CMAKE_CURRENT_SOURCE_DIR}/${cloud_j_dir}/src/Core/cldj_sub_mod.F90
    )
 
 # placeholder for excluding files from build

--- a/GEOSCHEMchem_GridComp/CMakeLists.txt
+++ b/GEOSCHEMchem_GridComp/CMakeLists.txt
@@ -76,7 +76,7 @@ endif ()
 
 esma_add_library (${this}
    SRCS ${srcs}
-   DEPENDENCIES MAPL MAPL_cfio_r4 Chem_Base Chem_Shared HEMCO Cloud-J
+   DEPENDENCIES MAPL MAPL_cfio_r4 Chem_Base Chem_Shared HEMCO Cloud-J HETP
                 OpenMP::OpenMP_Fortran esmf NetCDF::NetCDF_Fortran
    )
 

--- a/HEMCO_GridComp/HEMCO_GridCompMod.F90
+++ b/HEMCO_GridComp/HEMCO_GridCompMod.F90
@@ -807,6 +807,7 @@ CONTAINS
     REAL(ESMF_KIND_R8)              :: s_r8
 
     INTEGER                         :: HCRC
+    INTEGER                         :: LUN
 
     ! For MAPL/ESMF error handling (defined Iam and STATUS)
     __Iam__('HEMCOinit_ (GEOS_EmisGridComp.F90)') 
@@ -820,7 +821,7 @@ CONTAINS
     ! ------------------------------------------------------------------
 
     IF ( MAPL_Am_I_Root() ) THEN
-       CALL HCO_LogFile_Open( Inst%HcoConfig%Err, RC = HCRC )
+       CALL HCO_LogFile_Open( Inst%HcoConfig%Err, .true., HCRC, LUN )
        _ASSERT(HCRC==HCO_SUCCESS,'needs informative message')
     ENDIF
 

--- a/HETP/CMakeLists.txt
+++ b/HETP/CMakeLists.txt
@@ -1,0 +1,12 @@
+esma_set_this ()
+
+esma_mepo_style(HETP hetp_dir)
+
+set (srcs
+   ${CMAKE_CURRENT_SOURCE_DIR}/${hetp_dir}/src/Core/hetp_mod.F90
+   ${CMAKE_CURRENT_SOURCE_DIR}/${hetp_dir}/src/Core/mach_hetp_mod.F90
+   )
+
+esma_add_library (${this}
+   SRCS ${srcs}
+   )


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Describe the update

This PR is for compatibility with GEOS-Chem 14.5.1 and its dependencies. Changes include:

-  Add HETP subdirectory to store new submodule HETP (https://github.com/geoschem/HETerogeneous-vectorized-or-Parallel). CMake files are included in the HETP subdirectory to use for the build.
- Update Cloud-J CMake file for new filenames used in Cloud-J version 8.0.1.
- Update call to open HEMCO log within HEMCO_GridCompMod.F90 for compatibility with HEMCO 3.10.1.  

Note that the HETP submodule is not included in this PR because it will be cloned during the mepo stage when building GEOSgcm.

### Related PRs

- https://github.com/GEOS-ESM/geos-chem/pull/24
- https://github.com/GEOS-ESM/HEMCO/pull/17
- https://github.com/GEOS-ESM/Cloud-J/pull/2

Once this and the HEMCO, GEOS-Chem, and Cloud-J PRs are merged into `geos/latest_gcc` then I will create a PR to update `.gitmodules` in GEOSgcm.