### PR TITLE
Add HETP to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ GEOSCHEMchem_GridComp/geos-chem@
 Cloud-J/@Cloud-J
 Cloud-J/Cloud-J
 Cloud-J/Cloud-J@
+HETP/@HETP
+HETP/HETP
+HETP/HETP@

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Cloud-J subdirectory and CMake updates for Cloud-J repository
 - Added HETP subdirectory and CMake updates for new HETP submodule
 - Copy GEOS-Chem *.yaml and *.yml files to build directory
+- Added HETP to .gitignore
 
 ### Removed
 


### PR DESCRIPTION
Add HETP to .gitignore. HETP is an external module used by GEOS-Chem (version 14.5 onwards).