### PR TITLE
Updates to remove Python2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Slight refactoring of LOPEZ lightning scheme, minor numerical difference
 - Renamed lightning option 'usePreconCape' to 'useImportedCape' in order to cover both GCM and CTM
+- Moved from `f2py2` to `f2py3` to enable removal of Python 2 support
 
 ### Fixed
 ### Deprecated

--- a/Shared/Chem_Base/CMakeLists.txt
+++ b/Shared/Chem_Base/CMakeLists.txt
@@ -22,10 +22,10 @@ ecbuild_add_executable(TARGET gogo.x SOURCES gogo.F90 LIBS ${this})
 include_directories (${esma_include}/${this})
 
 if (USE_F2PY)
-   find_package(F2PY2)
-   if (F2PY2_FOUND)
-      add_f2py2_module(MieObs_ SOURCES MieObs_py.F90
-         DESTINATION lib/Python2
+   find_package(F2PY3)
+   if (F2PY3_FOUND)
+      add_f2py3_module(MieObs_ SOURCES MieObs_py.F90
+         DESTINATION lib/Python
          LIBRARIES Chem_Base MAPL GMAO_mpeu ${ESMF_LIBRARY}
          INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
          USE_MPI USE_NETCDF


### PR DESCRIPTION
It is time to remove `f2py2` support (aka Python2 support) in GEOS. This PR is one of a series where we convert `f2py2` builds to `f2py3`.

Note: There might be more needed Python2 → Python3 changes in scripts that _use_ this `f2py3` module, but I can say that the modules *build* so `f2py3` has no issue.