### PR TITLE
Add precip exports in Run1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved from `f2py2` to `f2py3` to enable removal of Python 2 support
 
 ### Fixed
+
+- ChemEnv now updates the precip exports (total, conv, non-conv) as part of Run1 (not just Run2).
+
 ### Deprecated
 
 


### PR DESCRIPTION
Fix a bug related to the exports from ChemEnv, specifically the fields related to precipitation.
The fields for Total Precip, Convective Precip and Non-convective Precip were being updated in Run2 but not in Run1.
This would affect any child of Chemistry that relies on these fields in Run1.
As it turns out, GMI is the only module that depends on the precip fields during Run1.
(GOCART2G, CARMA and StratChem import the fields but don't use them.)

For simulations that don't involve GMI, this PR is zero-diff.