### PR TITLE
added gmi-g2g connectivity for HNO3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to specify RATS providers individually, including for CO2 (via CO2_PROVIDER)
 - Added SO4REFF connectivity from CARMA to GMI
 - Added connectivity (OH, H2O2, NO3) from GMI to GOCART
+-Added connectivity (HNO3) from GMI to GOCART
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+
+- Added connectivity (HNO3) from GMI to GOCART
+
 ### Removed
 ### Changed
 ### Fixed
@@ -39,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to specify RATS providers individually, including for CO2 (via CO2_PROVIDER)
 - Added SO4REFF connectivity from CARMA to GMI
 - Added connectivity (OH, H2O2, NO3) from GMI to GOCART
--Added connectivity (HNO3) from GMI to GOCART
 
 ### Removed
 

--- a/GEOS_ChemGridComp.F90
+++ b/GEOS_ChemGridComp.F90
@@ -787,8 +787,8 @@ contains
     !  ... For GOCART::SU,NI
     !  ---------------------
     CALL MAPL_AddConnectivity ( GC, &
-         SRC_NAME  = (/ "OH  ", "H2O2", "NO3 " /), &
-         DST_NAME  = (/ "GMI_OH  ", "GMI_H2O2", "GMI_NO3 " /), &
+         SRC_NAME  = (/ "OH  ", "H2O2", "NO3 ", "HNO3" /), &
+         DST_NAME  = (/ "GMI_OH  ", "GMI_H2O2", "GMI_NO3 ", "GMI_HNO3" /), &
          DST_ID=GOCART2G, SRC_ID=GMICHEM, __RC__)
 
    END IF


### PR DESCRIPTION
Added connectivity for nitric acid HNO3 for gmi-gocart2g coupling.
Related to gocart2g implementation of the coupling: https://github.com/GEOS-ESM/GOCART/pull/373