### PR TITLE
v12: Migrate ExtData YAMLs from GOCART

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@ GEOSCHEMchem_GridComp/geos-chem@
 /@GOCART/
 /GOCART/
 /GOCART@/
-/@GOCART2G_ExtData/
-/GOCART2G_ExtData/
-/GOCART2G_ExtData@/
+/@Aerosol_ExtData/
+/Aerosol_ExtData/
+/Aerosol_ExtData@/
 /@QuickChem/
 /QuickChem/
 /QuickChem@/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ GEOSCHEMchem_GridComp/geos-chem@
 /@GOCART/
 /GOCART/
 /GOCART@/
+/@GOCART2G_ExtData/
+/GOCART2G_ExtData/
+/GOCART2G_ExtData@/
 /@QuickChem/
 /QuickChem/
 /QuickChem@/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+
+- Added CMake for new `GOCART2G_ExtData` subrepo
+
 ### Removed
 ### Changed
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 esma_set_this ()
 
-esma_add_subdirectories(Shared GOCART TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM GOCART2G_ExtData)
+esma_add_subdirectories(Shared GOCART TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM Aerosol_ExtData)
 
 set (alldirs
   GEOSpchem_GridComp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 esma_set_this ()
 
-esma_add_subdirectories(Shared GOCART TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM)
+esma_add_subdirectories(Shared GOCART TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM GOCART2G_ExtData)
 
 set (alldirs
   GEOSpchem_GridComp
@@ -9,7 +9,6 @@ set (alldirs
   DNA_GridComp
   HEMCO_GridComp
   RRG
-  GOCART2G_ExtData
   )
 
 set (srcs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set (alldirs
   DNA_GridComp
   HEMCO_GridComp
   RRG
+  GOCART2G_ExtData
   )
 
 set (srcs
@@ -16,7 +17,7 @@ set (srcs
   GEOS_ChemEnvGridComp.F90
   )
 
-# Note: GOCART_GridComp is added specifically as it is not longer
+# Note: GOCART_GridComp is added specifically as it is no longer
 #       automatically a dependence through alldirs
 esma_add_library (${this}
   SRCS ${srcs}


### PR DESCRIPTION
This PR migrates the GOCART2G and ACHEM ExtData YAML files from the GOCART repo to the new Aerosol_ExtData repo.

These files are based on those in [GOCART v2.6.2](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.6.2) (aka GOCART `develop` as of 2026-Mar-17) and [ACHEM v1.0.1](https://github.com/GEOS-ESM/ACHEM/releases/tag/v1.0.1)

So, this is essentially based on GEOSgcm v12

This to fully use this PR, changes are needed in:

* GEOSgcm: https://github.com/GEOS-ESM/GEOSgcm/pull/1046
* GEOSchem_GridComp: https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/312
* GOCART: https://github.com/GEOS-ESM/GOCART/pull/395
* Aerosol_ExtData: https://github.com/GEOS-ESM/Aerosol_ExtData/pull/1
* ACHEM: https://github.com/GEOS-ESM/ACHEM/pull/11

All are on the `feature/v12-move-extdata-yaml` branch.

Testing shows these changes are zero-diff to GEOSgcm v12 with GOCART v2.6.2 (see https://github.com/GEOS-ESM/GEOSgcm/pull/1030). It will of course be non-zero-diff to older v12 models.

Obviously, this will need tags in all the non-fixture repos.