### PR TITLE
Deactivate non-ported components on release/MAPL-v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,36 @@
 esma_set_this ()
 
-esma_add_subdirectories(Shared GOCART TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM)
+# Keep Shared (Chem_Base, Chem_Shared) and GOCART (for GOCART2G_GridComp).
+# Remaining subdirs not yet ported to MAPL3 - restore each when ported:
+esma_add_subdirectories(Shared GOCART)
+# esma_add_subdirectories(Shared GOCART TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM)
 
-set (alldirs
-  GEOSpchem_GridComp
-  GEOSCHEMchem_GridComp
-  H2O_GridComp
-  DNA_GridComp
-  HEMCO_GridComp
-  RRG
-  )
+# Temporarily bypass GEOSchem top-level library: GEOS_ChemGridComp.F90
+# USE-s non-ported components. Restore the block below when all SUBCOMPONENTS
+# are ported to MAPL3.
 
-set (srcs
-  GEOS_ChemGridComp.F90
-  GEOS_ChemEnvGridComp.F90
-  )
+# set (alldirs
+#   GEOSpchem_GridComp     # not yet ported to MAPL3 - restore when ported
+#   GEOSCHEMchem_GridComp  # not yet ported to MAPL3 - restore when ported
+#   H2O_GridComp           # not yet ported to MAPL3 - restore when ported
+#   DNA_GridComp           # not yet ported to MAPL3 - restore when ported
+#   HEMCO_GridComp         # not yet ported to MAPL3 - restore when ported
+#   RRG                    # not yet ported to MAPL3 - restore when ported
+#   )
+
+# set (srcs
+#   GEOS_ChemGridComp.F90
+#   GEOS_ChemEnvGridComp.F90
+#   )
 
 # Note: GOCART_GridComp is added specifically as it is not longer
 #       automatically a dependence through alldirs
-esma_add_library (${this}
-  SRCS ${srcs}
-  SUBCOMPONENTS ${alldirs}
-  DEPENDENCIES MAPL Chem_Shared Chem_Base GOCART_GridComp GOCART2G_GridComp TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM RRG ESMF::ESMF)
+# esma_add_library (${this}
+#   SRCS ${srcs}
+#   SUBCOMPONENTS ${alldirs}
+#   DEPENDENCIES MAPL Chem_Shared Chem_Base GOCART_GridComp GOCART2G_GridComp TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM RRG ESMF::ESMF)
 
-install(
-   FILES GEOS_ChemGridComp.rc ChemEnv_ExtData.rc  ChemEnv.rc ChemEnv_ExtData.yaml
-   DESTINATION etc
-   )
+# install(
+#    FILES GEOS_ChemGridComp.rc ChemEnv_ExtData.rc  ChemEnv.rc ChemEnv_ExtData.yaml
+#    DESTINATION etc
+#    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 esma_set_this ()
 
-# Keep Shared (Chem_Base, Chem_Shared) and GOCART (for GOCART2G_GridComp).
-# Remaining subdirs not yet ported to MAPL3 - restore each when ported:
-esma_add_subdirectories(Shared GOCART)
+# Only GOCART is needed on release/MAPL-v3 (for GOCART2G_GridComp).
+# Shared (Chem_Base, Chem_Shared, HEMCO) is not required by any ported component.
+# Restore subdirs as components are ported to MAPL3.
+esma_add_subdirectories(GOCART)
 # esma_add_subdirectories(Shared GOCART TR GMI StratChem MAM MATRIX CARMA GAAS ACHEM)
 
 # Temporarily bypass GEOSchem top-level library: GEOS_ChemGridComp.F90


### PR DESCRIPTION
## Summary

- Builds only the `GOCART` subdir (for `GOCART2G_GridComp`, `DU2G_GridComp`, `SS2G_GridComp`)
- Comments out `Shared` (Chem_Base, Chem_Shared, HEMCO) and all other subdirs — not needed by any ported component
- Bypasses the `GEOSchem_GridComp` top-level library (`GEOS_ChemGridComp.F90` uses non-ported subcomponents)

## Context

Part of the MAPL3 flip work tracked in GEOS-ESM/GEOSchem_GridComp#313. Only components already ported to MAPL3 are compiled on `release/MAPL-v3`.