### PR TITLE
Use special CF version of resource files

### DIFF
--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -1,14 +1,25 @@
 ---
+
+# Based on code from https://github.com/marketplace/actions/yaml-lint
+
 name: Yaml Lint
 
 on:
   pull_request:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+# This validation is equivalent to running on the command line:
+#   yamllint -d relaxed --no-warnings
+# and is controlled by the .yamllint.yml file
 jobs:
   validate-YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          filter: blob:none
       - id: yaml-lint
         name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
@@ -17,7 +28,7 @@ jobs:
           format: colored
           config_file: .yamllint.yml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: yamllint-logfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ after October 2021. For earlier changes, consult file ChangeLog.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - working on a CF release]
 ### Added
+
+- Added CF-specific resource files to the set copied from geos-chem into etc/ during build.
+
 ### Removed
 ### Changed
 ### Fixed

--- a/GEOSCHEMchem_GridComp/CMakeLists.txt
+++ b/GEOSCHEMchem_GridComp/CMakeLists.txt
@@ -117,6 +117,8 @@ file (GLOB resource_files1 CONFIGURE_DEPENDS
       "@geos-chem/run/GEOS/*.rc"
       "@geos-chem/run/GEOS/geos*.yml"
       "@geos-chem/run/GEOS/geos*.yaml"
+      "@geos-chem/run/GEOS/GEOS*.yaml"
+      "@geos-chem/run/GEOS/CF.*.yaml"
       "@geos-chem/run/shared/species*.yml"
       )
 


### PR DESCRIPTION
Adjust GEOS-Chem makefile to copy special CF version of resource files from geos-chem/run/GEOS/ to etc/, including HEMCO, GAAS, ACHEM, GOCART2G, CH4 and CO2 files.

We are bypassing feature/geoscf/develop for now.

This is in preparation for release v1.10.2+CFv2.0.1