### PR TITLE
Relocate CF custom files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added CF-specific resource files to the set copied from geos-chem into etc/ during build.
+- Moved those same CF-specific resource files to reside under GEOSCHEMchem_GridComp/run/.
 
 ### Removed
 ### Changed

--- a/GEOSCHEMchem_GridComp/CMakeLists.txt
+++ b/GEOSCHEMchem_GridComp/CMakeLists.txt
@@ -118,8 +118,8 @@ file (GLOB resource_files1 CONFIGURE_DEPENDS
       "@geos-chem/run/GEOS/geos*.yml"
       "@geos-chem/run/GEOS/geos*.yaml"
       "@geos-chem/run/GEOS/GEOS*.yaml"
-      "@geos-chem/run/GEOS/CF.*.yaml"
       "@geos-chem/run/shared/species*.yml"
+      "run/CF.*"
       )
 
 install(

--- a/GEOSCHEMchem_GridComp/run/CF.CA2G_GridComp_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.CA2G_GridComp_ExtData.yaml
@@ -1,0 +1,278 @@
+Collections:
+  CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+  CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+  CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+  CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+  CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+  CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+  CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+  CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+  CA2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4:
+    template: ExtData/chemistry/MERRAero/v0.0.0/L72/dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+  CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4:
+    template: ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+  CA2G_qfed2.emis_bc.006.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_bc.006.%y4%m2%d2.nc4
+    valid_range: "2014-12-01T12:00/2021-11-01T12:00"
+  CA2G_qfed2.emis_oc.006.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_oc.006.%y4%m2%d2.nc4
+    valid_range: "2014-12-01T12:00/2021-11-01T12:00"
+  CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_bc.061.%y4%m2%d2.nc4
+    valid_range: "2021-11-01T12:00/2025-01-01"
+  CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_oc.061.%y4%m2%d2.nc4
+    valid_range: "2021-11-01T12:00/2025-01-01"
+
+Samplings:
+  CA2G_sample_0:
+    extrapolation: clim
+  CA2G_sample_1:
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  CA2G_sample_2:
+    extrapolation: clim
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+
+Exports:
+  BC_AIRCRAFT:
+    collection: CA2G_BC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: bc_aviation
+  BC_ANTEBC1:
+    collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: bc_nonenergy
+  BC_ANTEBC2:
+    collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: bc_energy
+  BC_AVIATION_CDS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: bc_aviation
+  BC_AVIATION_CRS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: bc_aviation
+  BC_AVIATION_LTO:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: bc_aviation
+  BC_BIOFUEL:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: biofuel
+  BC_BIOMASS:
+    - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_bc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_bc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+  BC_SHIP:
+    collection: CA2G_BC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: bc_shipping
+  BRC_AIRCRAFT:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: none
+  BRC_ANTEBRC1:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: anteoc1
+  BRC_ANTEBRC2:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: anteoc2
+  BRC_AVIATION_CDS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: oc_aviation
+  BRC_AVIATION_CRS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: oc_aviation
+  BRC_AVIATION_LTO:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: oc_aviation
+  BRC_BIOFUEL:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: biofuel
+  BRC_BIOMASS:
+    - {starting: "2014-12-01T12:00", collection: CA2G_qfed2.emis_oc.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+    - {starting: "2021-11-01T12:00", collection: CA2G_qfed2.emis_oc.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: CA2G_sample_1, variable: biomass}
+  BRC_SHIP:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: oc_ship
+  BRC_TERPENE:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: terpene
+  OC_AIRCRAFT:
+    collection: CA2G_OC-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: oc_aviation
+  OC_ANTEOC1:
+    collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: oc_nonenergy
+  OC_ANTEOC2:
+    collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: oc_energy
+  OC_AVIATION_CDS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: oc_aviation
+  OC_AVIATION_CRS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: oc_aviation
+  OC_AVIATION_LTO:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: oc_aviation
+  OC_BIOFUEL:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: biofuel
+  OC_BIOMASS:
+    collection: /dev/null
+    linear_transformation:
+      - 0.0
+      - 0.778
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: biomass
+  OC_SHIP:
+    collection: CA2G_OC-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: CA2G_sample_1
+    variable: oc_shipping
+  climBCDP001:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: BCDP001
+  climBCDP002:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: BCDP002
+  climBCSD001:
+    collection: /dev/null
+    sample: CA2G_sample_0
+    variable: BCSD001
+  climBCSD002:
+    collection: /dev/null
+    sample: CA2G_sample_0
+    variable: BCSD002
+  climBCSV001:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: BCSV001
+  climBCSV002:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: BCSV002
+  climBCWT001:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: BCWT001
+  climBCWT002:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: BCWT002
+  climBCphilic:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: BCphilic
+  climBCphobic:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: BCphobic
+  climOCDP001:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: OCDP001
+  climOCDP002:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: OCDP002
+  climOCSD001:
+    collection: /dev/null
+    sample: CA2G_sample_0
+    variable: OCSD001
+  climOCSD002:
+    collection: /dev/null
+    sample: CA2G_sample_0
+    variable: OCSD002
+  climOCSV001:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: OCSV001
+  climOCSV002:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: OCSV002
+  climOCWT001:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: OCWT001
+  climOCWT002:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: OCWT002
+  climOCphilic:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: OCphilic
+  climOCphobic:
+    collection: CA2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: CA2G_sample_0
+    variable: OCphobic
+  pSOA_ANTHRO_VOC:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: biofuel
+  pSOA_BIOB_VOC:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: CA2G_sample_2
+    variable: biofuel
+

--- a/GEOSCHEMchem_GridComp/run/CF.CH4_GridComp.rc
+++ b/GEOSCHEMchem_GridComp/run/CF.CH4_GridComp.rc
@@ -1,0 +1,49 @@
+#
+#  CH4 main resource file defining the particular instances.
+#
+# ------------------|-------|------------
+#       Region      | Tag   |   Masking
+# ------------------|-------|------------
+#  All instances    | full  | -1
+# ------------------|-------|------------
+# The instances are defined in Chem_Registry.rc, not here
+
+# Which components/instances should be combined to for total CH4?
+CH4_total_components: CH4total
+
+# Instance CH4xxx will get emissions from a variable called emis_CH4xxx in ExtData by default. However, for some
+# composite instances such as CH4microbial, there is no separate emis_CH4microbial. For those instances, list
+# the variables (from ExtData) that should be summed to calculate emissions. In case the ExtData entry for tracer
+# XXX is emis_XXX, there is no need for an entry here, that is the default.
+emissions.CH4total: emis_CH4fossil emis_CH4wetland emis_CH4agwaste emis_CH4biofuel emis_CH4fire emis_CH4onat
+
+# -------------------------------------------------------------------------------------------
+# The keys below apply to all CH4 tags, unless overridden by a tag specific key. For example, if DEBUG is false,
+# to turn it on just for CH4wetland,
+# DEBUG.CH4wetland: T
+# Similarly, say do_chemistry is turned on. Then to turn it off for CH4fire,
+# do_chemistry.CH4fire: F
+
+# Indicate regions using a comma-delimited list of integers.
+# To activate all land boxes, use -1, or all or global (not case sensitive)
+# -------------------------------------------------------------------------------------------
+CH4_regions_indices: -1
+
+# Largest solar zenith angle (degrees) allowed as daytime
+# -------------------------------------------------------------------------------------------
+solar_ZA_cutoff: 94.00
+
+# Run-time debug switch to print additional stuff
+# -------------------------------------------------------------------------------------------
+DEBUG: F
+
+# Turn chemistry on in the model to simulate oxidation by OH, Cl and O1D
+# -------------------------------------------------------------------------------------------
+do_chemistry: T
+
+# -------------------------------------------------------------------------------------------
+# The keys below apply to CH4 emission variables defined in ExtData. E.g., emis_CH4fire, no matter which
+# instance it is added to, must always have PBL injection turned on.
+
+emis_CH4fire.diurnal_fire: T
+emis_CH4fire.pbl_injection: T

--- a/GEOSCHEMchem_GridComp/run/CF.CH4_GridComp_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.CH4_GridComp_ExtData.yaml
@@ -1,0 +1,89 @@
+Collections:
+  EDGAR-2024:
+    template: /discover/nobackup/projects/gmao/geos_carb/sbasu1/fluxes/CH4/2024.1/EDGAR_2024/EDGAR-2024-emis_ch4.x3600_y1800.%y4%m2.nc
+    valid_range: "2000-01-01T00:00/2024-12-01T00:00"
+  LPJ-EOSIM:
+    template: /discover/nobackup/projects/gmao/geos_carb/sbasu1/fluxes/CH4/2024.1/LPJ/LPJ-emis_ch4.x720_y360.%y4%m2.nc
+    valid_range: "2000-01-01T00:00/2025-01-01T00:00"
+  Other_natural:
+    template: /discover/nobackup/projects/gmao/geos_carb/sbasu1/fluxes/CH4/2024.1/misc/ONat-emis_ch4.x360_y180.%y4%m2.nc
+    valid_range: "2000-01-01T00:00/2029-12-31T00:00"
+  QFED-NRT-CH4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_ch4.061.%y4%m2%d2.nc4
+    valid_range: "2000-02-24T12:00/2029-01-01T12:00"
+  GMI_oxidants:
+    template: /discover/nobackup/bweir/fluxes/CH4/gmi_oxidants_v1.x144_y91_z72.t12.2006.nc
+  TRANSCOM.region_mask.CH4: # not used
+    template: /discover/nobackup/bweir/fluxes/masks/transcom.region_mask.x576_y361.2006.nc
+
+Samplings:
+  CH4_sample_0:
+    time_interpolation: False
+  CH4_sample_0_clim: # for treating 2024 emissions as climatology from 2025 onwards
+    time_interpolation: False
+    extrapolation: clim
+    source_time: "2024-01-01T00:00/2024-12-01T00:00"
+#  CH4_sample_0_persist: # for treating 2024 emissions as climatology from 2025 onwards
+#    time_interpolation: False
+#    extrapolation: clim
+#    source_time: "2024-01-01T00:00/2024-01-01T00:00"
+  CH4_sample_1:
+    extrapolation: clim
+  CH4_sample_2:
+    extrapolation: persist_closest
+  CH4_sample_12z:
+    time_interpolation: False
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  CH4_sample_12z_clim:
+    time_interpolation: False
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+    extrapolation: clim
+    source_time: "2024-01-01T12:00/2024-12-31T12:00"
+
+Exports:
+  CH4_cl:
+    collection: GMI_oxidants
+    sample: CH4_sample_1
+    variable: cl
+  CH4_o1d:
+    collection: GMI_oxidants
+    sample: CH4_sample_1
+    variable: o1d
+  CH4_oh:
+    collection: GMI_oxidants
+    sample: CH4_sample_1
+    variable: oh
+  CH4_regionMask: # not used
+    collection: TRANSCOM.region_mask.CH4
+    regrid: VOTE
+    sample: CH4_sample_2
+    variable: REGION_MASK
+  emis_CH4null:
+    collection: /dev/null
+  emis_CH4agwaste:
+    - {starting: "2000-01-01T00:00", collection: EDGAR-2024, regrid: CONSERVE, sample: CH4_sample_0, variable: ch4_agwaste}
+    - {starting: "2024-12-01T00:00", collection: EDGAR-2024, regrid: CONSERVE, sample: CH4_sample_0_clim, variable: ch4_agwaste, linear_transformation: [0.0, 1.0]}
+  emis_CH4biofuel:
+    - {starting: "2000-01-01T00:00", collection: EDGAR-2024, regrid: CONSERVE, sample: CH4_sample_0, variable: ch4_biofuel}
+    - {starting: "2024-12-01T00:00", collection: EDGAR-2024, regrid: CONSERVE, sample: CH4_sample_0_clim, variable: ch4_biofuel, linear_transformation: [0.0, 1.0]}
+  emis_CH4fossil:
+    - {starting: "2000-01-01T00:00", collection: EDGAR-2024, regrid: CONSERVE, sample: CH4_sample_0, variable: ch4_fossil}
+    - {starting: "2024-12-01T00:00", collection: EDGAR-2024, regrid: CONSERVE, sample: CH4_sample_0_clim, variable: ch4_fossil, linear_transformation: [0.0, 1.0]}
+  emis_CH4fire:
+    collection: QFED-NRT-CH4
+    regrid: CONSERVE
+    sample: CH4_sample_12z
+    variable: biomass
+    linear_transformation: [0.0, 1.1175]
+  emis_CH4onat:
+    collection: Other_natural
+    regrid: CONSERVE
+    sample: CH4_sample_0
+    variable: ch4_onat
+  emis_CH4wetland:
+    - {starting: "2000-01-01T00:00", collection: LPJ-EOSIM, regrid: CONSERVE, sample: CH4_sample_0, variable: ch4_wetlands}
+    - {starting: "2025-01-01T00:00", collection: LPJ-EOSIM, regrid: CONSERVE, sample: CH4_sample_0_clim, variable: ch4_wetlands, linear_transformation: [0.0, 1.0]}

--- a/GEOSCHEMchem_GridComp/run/CF.CO2_GridComp.rc
+++ b/GEOSCHEMchem_GridComp/run/CF.CO2_GridComp.rc
@@ -1,0 +1,50 @@
+#
+# Resource file for CO2 parameters. 
+#
+
+number_CO2_bins:      1 
+CO2_regions_indices: -1 1 2 5
+
+# Run year-specific CMS emissions (0 runs climatological monthly mean emissions, 1 runs CMS)
+# ------------------------------------------------------------------------------------------
+CMS_EMIS: 1
+
+# Biosphere drawdown enhancement factor used for climatological emissions.
+# Range: < 0 invalid, < 1 reduce sink, 1 neutral, > 1 enhance sink.
+# ------------------------------------------------------------------------
+Biosphere_drawdown_factor: 1.
+
+# Run-time debug switch (0 off, 1 on)
+# -----------------------------------
+DEBUG: 0
+
+
+
+# Deprecated options
+# ------------------
+# NOTES: 1) The filename variables are all unused because they are now read from
+# CO2_GridComp_ExtData.rc.  However, some versions of the CO2 GridComp require
+# these fields to be present in this file and have a time wildcard (here %y4).
+#
+# 2) The emissions factors are read and applied.  However, scale factors can be
+# specified in CO2_GridComp_ExtData.rc, so for clarity, we now apply them there.
+
+CO2_regions: name_set_in_extdata_rc
+
+CO2_biomass_emission_filename: name_set_in_extdata_rc_%y4
+CO2_biomass_emission_factor: 1.
+
+CO2_fossilfuel_emissions_filename: name_set_in_extdata_rc_%y4
+CO2_fossilfuel_emissions_factor: 1.
+
+CO2_biosphere_emissions_filename: name_set_in_extdata_rc_%y4
+CO2_ocean_emissions_filename: name_set_in_extdata_rc_%y4
+
+CMS_biomass_emission_filename: name_set_in_extdata_rc_%y4
+CMS_biomass_emission_factor: 1.
+
+CMS_fossilfuel_emissions_filename: name_set_in_extdata_rc_%y4
+CMS_fossilfuel_emissions_factor: 1.
+
+CMS_biosphere_emissions_filename: name_set_in_extdata_rc_%y4
+CMS_ocean_emissions_filename: name_set_in_extdata_rc_%y4

--- a/GEOSCHEMchem_GridComp/run/CF.CO2_GridComp_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.CO2_GridComp_ExtData.yaml
@@ -1,0 +1,100 @@
+Collections:
+  MiCASA-v1-3hrly: # "days since 1980-01-01", points to 0z of a given day
+#   template: /css/gmao/geos_carb/share/MiCASA/v1/netcdf/3hrly/%y4/%m2/MiCASA_v1_flux_x3600_y1800_3hrly_%y4%m2%d2.nc4
+    template: /discover/nobackup/projects/gmao/geos_carb/share/MiCASA/v1/netcdf/3hrly/%y4/%m2/MiCASA_v1_flux_x3600_y1800_3hrly_%y4%m2%d2.nc4
+    valid_range: "2001-01-01/2024-12-31"
+  MiCASA-v1-daily: # "days since 1980-01-01", points to 0z of a given day
+#   template: /css/gmao/geos_carb/share/MiCASA/v1/netcdf/daily/%y4/%m2/MiCASA_v1_flux_x3600_y1800_daily_%y4%m2%d2.nc4
+    template: /discover/nobackup/projects/gmao/geos_carb/share/MiCASA/v1/netcdf/daily/%y4/%m2/MiCASA_v1_flux_x3600_y1800_daily_%y4%m2%d2.nc4
+    valid_range: "2001-01-01/2024-12-31"
+  MiCASA-vNRT-3hrly: # "days since 1980-01-01", points to 0z of a given day
+#   template: /css/gmao/geos_carb/share/MiCASA/vNRT/netcdf/3hrly/%y4/%m2/MiCASA_vNRT_flux_x3600_y1800_3hrly_%y4%m2%d2.nc4
+    template: /discover/nobackup/projects/gmao/geos_carb/share/MiCASA/vNRT/netcdf/3hrly/%y4/%m2/MiCASA_vNRT_flux_x3600_y1800_3hrly_%y4%m2%d2.nc4
+    valid_range: "2024-10-01/3000-12-31"
+  MiCASA-vNRT-daily: # "days since 1980-01-01", points to 0z of a given day
+#   template: /css/gmao/geos_carb/share/MiCASA/vNRT/netcdf/daily/%y4/%m2/MiCASA_vNRT_flux_x3600_y1800_daily_%y4%m2%d2.nc4
+    template: /discover/nobackup/projects/gmao/geos_carb/share/MiCASA/vNRT/netcdf/daily/%y4/%m2/MiCASA_vNRT_flux_x3600_y1800_daily_%y4%m2%d2.nc4
+    valid_range: "2024-10-01/3000-12-31"
+  ODIAC-v2023: # "days since 1980-01-01", points to 0z on the 1st of each month
+#   template: /css/gmao/geos_carb/share/ODIAC/v2023/converted/odiac2023_x3600_y1800_monthly_%y4.nc4
+    template: /discover/nobackup/projects/gmao/geos_carb/share/ExtData/v2024/CO2/ODIAC/odiac2023_x3600_y1800_monthly_%y4.nc4
+    valid_range: "2000-01-01/2022-12-01"
+  AOML-monthly: # "days since 1980-01-01", points to 0z on the 1st of each month
+    template: /discover/nobackup/projects/gmao/geos_carb/share/ExtData/v2024/CO2/AOML/aoml23_v1_x360_y180_monthly_%y4.nc4
+  TRANSCOM.region_mask.CO2:
+    template: /discover/nobackup/projects/gmao/geos_carb/share/ExtData/v2024/transcom.region_mask.x576_y361.2006.nc
+
+Samplings:
+  CO2_sample_12z:
+    time_interpolation: False
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  CO2_sample_0z:
+    time_interpolation: False
+    update_frequency: PT24H
+    update_reference_time: '0'
+  CO2_persist_2022: # for treating 2022 emissions as climatology in successive years
+    time_interpolation: False
+    extrapolation: clim
+    source_time: "2022-01-01T00:00/2022-12-01T00:00"
+
+Exports:
+  CO2_CMS_NEP:
+    - starting: "2001-01-01T00:00"
+      collection: MiCASA-v1-3hrly
+      regrid: CONSERVE
+      variable: NEE
+      sample: {time_interpolation: False}
+    - starting: "2025-01-01T00:00"
+      collection: MiCASA-vNRT-3hrly
+      regrid: CONSERVE
+      variable: NEE
+      sample: {time_interpolation: False}
+  CO2_MiCASA_FIRE:
+    - starting: "2001-01-01T00:00"
+      collection: MiCASA-v1-daily
+      regrid: CONSERVE
+      sample: CO2_sample_0z
+      variable: FIRE
+    - starting: "2025-01-01T00:00"
+      collection: MiCASA-vNRT-daily
+      regrid: CONSERVE
+      sample: CO2_sample_0z
+      variable: FIRE
+  CO2_MiCASA_FUEL:
+    - starting: "2001-01-01T00:00"
+      collection: MiCASA-v1-daily
+      regrid: CONSERVE
+      sample: CO2_sample_0z
+      variable: FUEL
+    - starting: "2025-01-01T00:00"
+      collection: MiCASA-vNRT-daily
+      regrid: CONSERVE
+      sample: CO2_sample_0z
+      variable: FUEL
+  CO2_CMS_FF:
+    - starting: "2000-01-01T00:00"
+      collection: ODIAC-v2023
+      regrid: CONSERVE
+      sample: {time_interpolation: False}
+      variable: fossil
+    - starting: "2022-12-01T00:00"
+      collection: ODIAC-v2023
+      regrid: CONSERVE
+      sample: CO2_persist_2022
+      variable: fossil
+  CO2_CMS_OCN:
+    collection: AOML-monthly
+    regrid: CONSERVE
+    sample: {time_interpolation: False}
+    variable: exchange
+  CO2_regionMask:
+    collection: TRANSCOM.region_mask.CO2
+    regrid: VOTE
+    sample: {extrapolation: persist_closest}
+    variable: REGION_MASK
+
+Derived:
+  CO2_CMS_BIOMASS:
+    function: "CO2_MiCASA_FIRE+CO2_MiCASA_FUEL"

--- a/GEOSCHEMchem_GridComp/run/CF.Chem_Registry.rc
+++ b/GEOSCHEMchem_GridComp/run/CF.Chem_Registry.rc
@@ -1,0 +1,428 @@
+#------------------------------------------------------------------------
+#BOP
+#
+# !RESOURCE: AeroChem_Registry --- AeroChem Registry
+# 
+# !HELP:
+#
+#  The Chemistry Registry resource file is used to control basic
+#  properties of the GOCART and StratChem Grid Components. 
+#  Specifically, it
+#
+#    - selects which constituents to simulate
+#    - selects the number of bins for each constituent
+#    - specifies variable names and units for each constituent
+#
+#  NOTES: The water vapor and ozone tracers are not really being used
+#         in GEOS-5. They are still kept for compatibility with GEOS-4.
+#
+#         StratChem can be run with Full or Reduced equation sets.
+#         When running Full,    the string SC_f should be changed to SC.
+#         When running Reduced, the string SC_r should be changed to SC.
+#         This will be automatically done by stratchem_setup script.
+#
+#         XX lists contain non-transported species for GMI and StratChem.
+#         When running GMI, the string XX_GMI should be changed to XX.
+#         When running StratChem, the string XX_SC should be changed to XX.
+#         This will be automatically done by the setup scripts.
+#
+# !REVISION HISTORY:
+#
+#  27May2005  da Silva  Added variable tables for SU/BC/OC.
+#  19dec2005  da Silva  Changed volume mixing ratio units to 'mol mol-1'
+#  10Feb2006  Hayashi   Added analysis update frequency
+#  27Jul2006  da Silva  No more analysis frequencies; added GMI/PChem (GEOS-5)
+#
+#-----------------------------------------------------------------------
+#EOP
+
+                        # &Label Active Constituents
+
+# Whether to include the constituent in the simulation
+# ----------------------------------------------------
+doing_H2O: no   # water vapor (must always ON for fvGCM)
+doing_O3:  no   # ozone (must be always ON for fvGCM in DAS mode)
+doing_CO:  no   # &YesNo Include carbon monoxide?
+doing_CO2: yes  # &YesNo Include carbon dioxide?
+doing_DU:  no   # &YesNo Include mineral dust?
+doing_SS:  no   # &YesNo Include sea salt?
+doing_SU:  no   # &YesNo Include sulfates?
+doing_CFC: no   # &YesNo Include CFCs?
+doing_BC:  no   # &YesNo Include black carbon?
+doing_OC:  no   # &YesNo Include organic carbon?
+doing_BRC: no   # &YesNo Include brown carbon?
+doing_NI:  no   # &YesNo Include nitrate?
+doing_Rn:  no   # &YesNo include Radon?
+doing_CH4: yes  # &YesNo include Methane?
+doing_SC:  no   # &YesNo Include stratospheric chemistry?
+doing_XX:  no   # &YesNo generic tracer
+doing_PC:  yes  # parameterized chemistry (GEOS-5)
+doing_OCS: no   # ACHEM chemistry (OCS)
+
+# You can select the number of bins (e.g., particle size)
+# for each of the constituents. Note nbins>1 may not be
+# supported by some constituents
+# ----------------------------------------------------
+nbins_H2O:      1   # water vapor
+nbins_O3:       1   # ozone
+nbins_CO:      10   # carbon monoxide
+nbins_CO2:      1   # carbon dioxide
+nbins_DU:       5   # mineral dust
+nbins_SS:       5   # sea salt
+nbins_SU:       4   # sulfates
+nbins_CFC:      2   # CFCs
+nbins_BC:       2   # black carbon
+nbins_OC:       2   # organic carbon
+nbins_BRC:      2   # brown carbon
+nbins_NI:       5   # nitrate
+nbins_Rn:       1   # radon
+nbins_CH4:      1   # methane
+nbins_SC_f:    52   # stratospheric chemistry (full)
+nbins_XX_SC_f: 18   # stratchem (full) non-transported species
+nbins_SC_r:    33   # stratospheric chemistry (reduced)
+nbins_XX_SC_r: 37   # stratchem (reduced) non-transported species
+nbins_PC:       1   # parameterized chemistry (GEOS-5)
+nbins_OCS:      1   # ACHEM chemistry (OCS)
+
+# Units for each constituent
+# --------------------------
+units_H2O: 'kg kg-1'     # water vapor
+units_O3:  'kg kg-1'     # ozone
+units_CO:  'mol mol-1'   # carbon monoxide
+units_CO2: 'mol mol-1'   # carbon dioxide
+units_DU:  'kg kg-1'     # mineral dust
+units_SS:  'kg kg-1'     # sea salt
+units_SU:  'kg kg-1'     # sulfates
+units_CFC: 'mol mol-1'   # CFCs
+units_BC:  'kg kg-1'     # black carbon
+units_OC:  'kg kg-1'     # organic carbon
+units_BRC: 'kg kg-1'     # brown carbon
+units_NI:  'kg kg-1'     # nitrate
+units_Rn:  'mol mol-1'   # radon
+units_CH4: 'mol mol-1'   # methane
+units_SC:  'mol mol-1'   # stratospheric chemistry
+units_XX:  'mol mol-1'   # generic tracer
+units_PC:  'kg kg-1'     # parameterized chemistry (GEOS-5)
+units_OCS: 'kg kg-1'     # ACHEM chemistry (OCS)
+
+# Variable names to override defaults.  Optional.  Name and Units must 
+# be 1 token. Long names can be more than one token.
+# --------------------------------------------------------------------
+
+variable_table_O3::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Parameterized ozone
+::
+
+variable_table_CO::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+CO         'mol mol-1'  Carbon Monoxide (All Sources)
+COBBAE     'mol mol-1'  CO Asia and Europe Biomass Burning
+COBBNA     'mol mol-1'  CO North America Biomass Burning
+COBBLA     'mol mol-1'  CO Central and South America Biomass Burning
+COBBAF     'mol mol-1'  CO Africa Biomass Burning
+COBBGL     'mol mol-1'  CO Global Biomass Burning
+CONBAS     'mol mol-1'  CO Asia Non-Biomass Burning
+CONBNA     'mol mol-1'  CO North American Non-Biomass Burning
+CONBEU     'mol mol-1'  CO European Non-Biomass Burning
+CONBGL     'mol mol-1'  CO Global Non-Biomass Burning
+::
+
+variable_table_CO2::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+CO2        'mol mol-1'  Carbon Dioxide (All Sources)
+::
+
+variable_table_CFC::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+CFC12S    'mol mol-1'   Stratospheric CFC-12 (CCl2F2)
+CFC12T    'mol mol-1'   Tropospheric CFC-12 (CCl2F2)
+::
+
+variable_table_SU::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+DMS        'kg kg-1'    Dimethylsulphide
+SO2        'kg kg-1'    Sulphur dioxide
+SO4        'kg kg-1'    Sulphate aerosol
+MSA        'kg kg-1'    Methanesulphonic acid
+DMSv       'kg kg-1'    Dimethylsulphide (volcanic)
+SO2v       'kg kg-1'    Sulphur dioxide (volcanic)
+SO4v       'kg kg-1'    Sulphate aerosol (volcanic)
+MSAv       'kg kg-1'    Methanesulphonic acid (volcanic)
+::
+
+variable_table_BC::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+BCphobic   'kg kg-1'    Hydrophobic Black Carbon 
+BCphilic   'kg kg-1'    Hydrophilic Black Carbon
+::
+
+variable_table_OC::
+
+# Name         Units        Long Name
+# -----        ------       --------------------------------
+OCphobic       'kg kg-1'    Hydrophobic Organic Carbon (Particulate Matter)
+OCphilic       'kg kg-1'    Hydrophilic Organic Carbon (Particulate Matter)
+OCphobicbbbo   'kg kg-1'    Hydrophobic Organic Carbon (Boreal Biomass Burning, Particulate Matter)
+OCphilicbbbo   'kg kg-1'    Hydrophilic Organic Carbon (Boreal Biomass Burning, Particulate Matter)
+OCphobicbbnb   'kg kg-1'    Hydrophobic Organic Carbon (Non-Boreal Biomass Burning, Particulate Matter)
+OCphilicbbnb   'kg kg-1'    Hydrophilic Organic Carbon (Non-Boreal Biomass Burning, Particulate Matter)
+::
+
+variable_table_BRC::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+BRCphobic  'kg kg-1'    Hydrophobic Brown Carbon (Particulate Matter)
+BRCphilic  'kg kg-1'    Hydrophilic Brown Carbon (Particulate Matter)
+::
+
+variable_table_RN::
+
+# Name         Units        Long Name
+# -----        ------       --------------------------------
+Rn             'mol mol-1'  Global radon
+::
+
+variable_table_CH4::
+
+# Name         Units        Long Name
+# -----        ------       --------------------------------
+CH4total       'mol mol-1'  Total methane
+::
+
+variable_table_NI::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+NH3        'kg kg-1'    Ammonia (NH3, gas phase)
+NH4a       'kg kg-1'    Ammonium ion (NH4+, aerosol phase)
+NO3an1     'kg kg-1'    Nitrate size bin 001
+NO3an2     'kg kg-1'    Nitrate size bin 002
+NO3an3     'kg kg-1'    Nitrate size bin 003
+::
+
+variable_table_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2 
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3  
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2        'mol mol-1'  Lat-depedent CO2  
+SF6        'mol mol-1'  Sulfur hexafluoride
+AOADAYS     days        Age-of-air
+::
+
+variable_table_XX_SC_f::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+variable_table_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+OX         'mol mol-1'  Stratospheric odd oxygen
+NOX        'mol mol-1'  Odd nitrogen
+HNO3       'mol mol-1'  Nitric acid
+N2O5       'mol mol-1'  Dinitrogen pentoxide
+HO2NO2     'mol mol-1'  Peroxynitric acid
+CLONO2     'mol mol-1'  Chlorine nitrate
+CLX        'mol mol-1'  Odd chlorine
+HCL        'mol mol-1'  Hydrochloric acid
+HOCL       'mol mol-1'  Hypochlorous acid
+H2O2       'mol mol-1'  Hydrogen peroxide
+BRX        'mol mol-1'  Odd bromine
+N2O        'mol mol-1'  Nitrous oxide
+CL2        'mol mol-1'  Molecular chlorine
+OCLO       'mol mol-1'  Chlorine dioxide
+BRCL       'mol mol-1'  Bromine chloride
+HBR        'mol mol-1'  Hydrogen bromide
+BRONO2     'mol mol-1'  Bromine nitrate
+CH4        'mol mol-1'  Methane
+HOBR       'mol mol-1'  Hypobromous acid
+CH3OOH     'mol mol-1'  Methyl hydroperoxide
+CO         'mol mol-1'  Carbon monoxide
+HNO3COND   'mol mol-1'  Condensed nitric acid
+CFC11      'mol mol-1'  CFC-11 (CCl3F)
+CFC12      'mol mol-1'  CFC-12 (CCl2F2)
+CFC113     'mol mol-1'  CFC-113 (CCl2FCClF2)
+HCFC22     'mol mol-1'  HCFC-22 (CHClF2)
+CCL4       'mol mol-1'  Carbon tetrachloride
+CH3CCL3    'mol mol-1'  Methyl chloroform
+CH3CL      'mol mol-1'  Methyl chloride
+CH3BR      'mol mol-1'  Methyl bromide
+H1301      'mol mol-1'  Halon 1301 (CBrF3)
+H1211      'mol mol-1'  Halon 1211 (CBrClF2)
+AOADAYS    days         Age-of-air
+::
+
+variable_table_XX_SC_r::
+
+# Name     Units        Long Name
+# -----    ------       --------------------------------
+O3CHEM     'mol mol-1'  Ozone from chemistry
+O3P        'mol mol-1'  Atomic oxygen in the ground state
+O1D        'mol mol-1'  Atomic oxygen in the first excited state
+N          'mol mol-1'  Atomic nitrogen
+NO         'mol mol-1'  Nitric oxide
+NO2        'mol mol-1'  Nitrogen dioxide
+NO3        'mol mol-1'  Nitrogen trioxide
+HATOMIC    'mol mol-1'  Atomic hydrogen
+OH         'mol mol-1'  Hydroxyl radical
+HO2        'mol mol-1'  Hydroperoxyl radical
+CL         'mol mol-1'  Atomic chlorine
+CLO        'mol mol-1'  Chlorine monoxide
+BRO        'mol mol-1'  Bromine monoxide
+BR         'mol mol-1'  Atomic bromine
+CL2O2      'mol mol-1'  Dichlorine peroxide
+CH2O       'mol mol-1'  Formaldehyde
+CH3O2      'mol mol-1'  Methyl peroxide
+CFC114     'mol mol-1'  CFC-114 (C2Cl2F4)
+CFC115     'mol mol-1'  CFC-115 (C2ClF5)
+HCFC141B   'mol mol-1'  HCFC-141b (CH3CCl2F)
+HCFC142B   'mol mol-1'  HCFC-142b (CH3CClF2)
+H1202      'mol mol-1'  Halon 1202 (CBrF3)
+H2402      'mol mol-1'  Halon 2402 (C2Br2F4)
+CHBR3      'mol mol-1'  Bromoform
+CH2BR2     'mol mol-1'  Dibromomethane
+CH2BRCL    'mol mol-1'  CH2BRCL
+CHBRCL2    'mol mol-1'  CHBRCL2
+CHBR2CL    'mol mol-1'  CHBR2CL
+HFC23      'mol mol-1'  CHF3
+HFC32      'mol mol-1'  CH2F2
+HFC125     'mol mol-1'  CHF2CF3
+HFC134A    'mol mol-1'  CH2FCF3
+HFC143A    'mol mol-1'  CF3CH3
+HFC152A    'mol mol-1'  CH2CHF2
+CO2        'mol mol-1'  Lat-depedent CO2
+SF6        'mol mol-1'  Sulfur hexafluoride
+RO3OX      "none"       Ozone-to-odd oxygen ratio
+::
+
+#........................................................................
+
+#               -------------------
+#               Not Implemented Yet
+#               -------------------
+
+# Whether to advect the constituent
+# ---------------------------------
+advect_H2O: yes  # water vapor 
+advect_O3:  yes  # ozone 
+advect_CO:  yes  # carbon monoxide
+advect_CO2: yes  # carbon dioxide
+advect_DU:  yes  # mineral dust
+advect_SS:  yes  # sea salt
+advect_SU:  yes  # sulfates
+advect_CFC: yes  # CFCs
+advect_BC:  yes  # black carbon
+advect_OC:  yes  # organic carbon
+advect_BRC: yes  # brown carbon
+advect_NI:  yes  # nitrate
+advect_Rn:  yes  # radon
+advect_CH4: yes  # methane
+advect_SC:  yes  # stratospheric chemistry
+advect_XX:  no   # generic tracer
+advect_PC:  yes  # parameterized chemistry (GEOS-5)
+advect_OCS: yes  # ACHEM chemistry (OCS)
+
+# Whether to diffuse the constituent
+# ----------------------------------
+diffuse_H2O: yes  # water vapor 
+diffuse_O3:  yes  # ozone 
+diffuse_CO:  yes  # carbon monoxide
+diffuse_CO2: yes  # carbon dioxide
+diffuse_DU:  yes  # mineral dust
+diffuse_SS:  yes  # sea salt
+diffuse_SU:  yes  # sulfates
+diffuse_CFC: yes  # CFCs
+diffuse_BC:  yes  # black carbon
+diffuse_OC:  yes  # organic carbon
+diffuse_BRC: yes  # brown carbon
+diffuse_NI:  yes  # nitrate
+diffuse_Rn:  yes  # radon
+diffuse_CH4: yes  # methane
+diffuse_SC:  yes  # stratospheric chemistry
+diffuse_XX:  yes  # generic tracer
+diffuse_PC:  yes  # parameterized chemistry (GEOS-5)
+diffuse_OCS: yes  # ACHEM chemistry (OCS)
+

--- a/GEOSCHEMchem_GridComp/run/CF.DU2G_GridComp_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.DU2G_GridComp_ExtData.yaml
@@ -1,0 +1,170 @@
+Collections:
+  DU2G__gldas-fao.soil_category.x1152_y721_t1.nc4:
+    template: ExtData/chemistry/DUST/v0.0.0/sfc/_gldas-fao.soil_category.x1152_y721_t1.nc4
+  DU2G__gldas-fao.soil_texture.x1152_y721_t1.nc4:
+    template: ExtData/chemistry/DUST/v0.0.0/sfc/_gldas-fao.soil_texture.x1152_y721_t1.nc4
+  DU2G_arlems-roughness.x1151_y720_t1.nc4:
+    template: ExtData/chemistry/DUST/v0.0.0/sfc/arlems-roughness.x1151_y720_t1.nc4
+  DU2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4:
+    template: ExtData/chemistry/MERRAero/v0.0.0/L72/dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+  DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4:
+    template: ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+  DU2G_gocart.dust_source.v5a.x1152_y721.nc:
+    template: ExtData/chemistry/DUST/v0.0.0/sfc/gocart.dust_source.v5a.x1152_y721.nc
+  DU2G_qvi.006.%y4.nc4:
+    template: ExtData/chemistry/NDVI/v1.0.r3/sfc/qvi.006.%y4.nc4
+  DU2G_veg20.x1152_y721_t1.nc4:
+    template: ExtData/chemistry/DUST/v0.0.0/sfc/veg20.x1152_y721_t1.nc4
+
+Samplings:
+  DU2G_sample_0:
+    extrapolation: persist_closest
+  DU2G_sample_1:
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  DU2G_sample_2:
+    extrapolation: clim
+
+Exports:
+  DU_CLAY:
+    collection: DU2G__gldas-fao.soil_texture.x1152_y721_t1.nc4
+    regrid: CONSERVE
+    sample: DU2G_sample_0
+    variable: clay
+  DU_GVF:
+    collection: DU2G_qvi.006.%y4.nc4
+    regrid: CONSERVE
+    sample: DU2G_sample_1
+    variable: gvf
+  DU_SAND:
+    collection: DU2G__gldas-fao.soil_texture.x1152_y721_t1.nc4
+    regrid: CONSERVE
+    sample: DU2G_sample_0
+    variable: sand
+  DU_SILT:
+    collection: DU2G__gldas-fao.soil_texture.x1152_y721_t1.nc4
+    regrid: CONSERVE
+    sample: DU2G_sample_0
+    variable: silt
+  DU_SRC:
+    collection: DU2G_gocart.dust_source.v5a.x1152_y721.nc
+    regrid: CONSERVE
+    sample: DU2G_sample_0
+    variable: du_src
+  DU_TEXTURE:
+    collection: DU2G__gldas-fao.soil_category.x1152_y721_t1.nc4
+    regrid: VOTE
+    sample: DU2G_sample_0
+    variable: texture
+  DU_VEG:
+    collection: DU2G_veg20.x1152_y721_t1.nc4
+    regrid: VOTE
+    sample: DU2G_sample_0
+    variable: domveg
+  DU_Z0:
+    collection: DU2G_arlems-roughness.x1151_y720_t1.nc4
+    regrid: CONSERVE
+    sample: DU2G_sample_0
+    variable: roughness
+  climDUDP001:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUDP001
+  climDUDP002:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUDP002
+  climDUDP003:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUDP003
+  climDUDP004:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUDP004
+  climDUDP005:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUDP005
+  climDUSD001:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSD001
+  climDUSD002:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSD002
+  climDUSD003:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSD003
+  climDUSD004:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSD004
+  climDUSD005:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSD005
+  climDUSV001:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSV001
+  climDUSV002:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSV002
+  climDUSV003:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSV003
+  climDUSV004:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSV004
+  climDUSV005:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUSV005
+  climDUWT001:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUWT001
+  climDUWT002:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUWT002
+  climDUWT003:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUWT003
+  climDUWT004:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUWT004
+  climDUWT005:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: DUWT005
+  climdu001:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: du001
+  climdu002:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: du002
+  climdu003:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: du003
+  climdu004:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: du004
+  climdu005:
+    collection: DU2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: DU2G_sample_2
+    variable: du005
+

--- a/GEOSCHEMchem_GridComp/run/CF.GAAS_GridComp.rc
+++ b/GEOSCHEMchem_GridComp/run/CF.GAAS_GridComp.rc
@@ -1,0 +1,60 @@
+#
+# GAAS Grid Component Resource File.
+#
+# !REVISION HISTORY:
+#
+#  07dec2010  da Silva  First version.
+#
+#-----------------------------------------------------------------------------
+   
+#                           -----------------
+#                             Miscellaneous
+#                           -----------------
+
+           single_channel:  550.  # Single channel to analyze
+eps_for_log_transform_aod:  0.01 
+                  verbose: .TRUE.
+              monitor_gcc: .TRUE.
+              monitor_g2g: .FALSE.
+
+             CoresPerNode:  8     # Will be reset in SetServices with value from main CF
+
+
+
+#                        -------------------
+#                         File Name Templates
+#                        -------------------
+aodbias_internal_restart:     aodbias_internal_restart.nc
+aodbias_internal_checkpoint:  aodbias_internal_checkpoint.nc
+
+
+#                          -------------------
+#                            MIE PARAMETERS
+#                          -------------------
+
+# Common MODIS/MISR channels
+### NUM_BANDS: 4
+### BANDS: 470.E-9  550.E-9 660.E-9   870.E-9
+
+NUM_BANDS: 1
+    BANDS: 550.E-9
+
+DU_OPTICS: ExtData/PIESA/x/optics_DU.v15_3.nc
+SS_OPTICS: ExtData/PIESA/x/optics_SS.v3_3.nc
+SU_OPTICS: ExtData/PIESA/x/optics_SU.v1_3.nc
+OC_OPTICS: ExtData/PIESA/x/optics_OC.v1_3.nc
+BC_OPTICS: ExtData/PIESA/x/optics_BC.v1_3.nc
+BRC_OPTICS: ExtData/PIESA/x/optics_BRC.v1_5.nc
+NI_OPTICS: ExtData/PIESA/x/optics_NI.v2_5.nc
+
+#                         --------------
+#                          LDE Parameters
+#                         --------------
+
+top_vertical_layer: 36 # k = 36, p ~ 72 hPa
+
+number_of_ensemble_members: 100
+      stencil_radius_in_km: 1000.
+          aod_weight_delta: 0.5
+
+#.

--- a/GEOSCHEMchem_GridComp/run/CF.GAAS_GridComp_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.GAAS_GridComp_ExtData.yaml
@@ -1,0 +1,33 @@
+Collections:
+  GAAS_d5294_geosit_jan18.aod_a.sfc.%y4%m2%d2_%h2%n2z.nc4:
+    template: /home/dao_ops/d5294_geosit_jan18/run/.../archive/chem/Y%y4/M%m2/d5294_geosit_jan18.aod_a.sfc.%y4%m2%d2_%h2%n2z.nc4
+    freq: PT3H
+  GAAS_d5294_geosit_jan18.aod_f.sfc.%y4%m2%d2_%h2%n2z.nc4:
+    template: /home/dao_ops/d5294_geosit_jan18/run/.../archive/chem/Y%y4/M%m2/d5294_geosit_jan18.aod_f.sfc.%y4%m2%d2_%h2%n2z.nc4
+    freq: PT3H
+  GAAS_d5294_geosit_jan18.aod_k.sfc.%y4%m2%d2_%h2%n2z.nc4:
+    template: /home/dao_ops/d5294_geosit_jan18/run/.../archive/chem/Y%y4/M%m2/d5294_geosit_jan18.aod_k.sfc.%y4%m2%d2_%h2%n2z.nc4
+    freq: PT3H
+
+Samplings:
+  GAAS_sample_0:
+    update_offset: PT>>>DT<<<S
+    exact: True
+
+Exports:
+  aod_a:
+    collection: GAAS_d5294_geosit_jan18.aod_a.sfc.%y4%m2%d2_%h2%n2z.nc4
+    sample: GAAS_sample_0
+    variable: AOD
+    fail_on_missing_file: false
+  aod_f:
+    collection: GAAS_d5294_geosit_jan18.aod_f.sfc.%y4%m2%d2_%h2%n2z.nc4
+    sample: GAAS_sample_0
+    variable: AOD
+    fail_on_missing_file: false
+  aod_k:
+    collection: GAAS_d5294_geosit_jan18.aod_k.sfc.%y4%m2%d2_%h2%n2z.nc4
+    sample: GAAS_sample_0
+    variable: AOD
+    fail_on_missing_file: false
+

--- a/GEOSCHEMchem_GridComp/run/CF.GEOSachem_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.GEOSachem_ExtData.yaml
@@ -1,0 +1,138 @@
+Collections:
+  GEOSachem_CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+  GEOSachem_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4:
+    template: ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
+  GEOSachem_GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4:
+    template: ExtData/chemistry/GEIA/v0.0.0/sfc/GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4
+  GEOSachem_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
+    template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+  GEOSachem_SOAG.emiss.x144_y91_t12.1990.nc4:
+    template: ExtData/chemistry/CAM/v0.0.0/sfc/SOAG.emiss.x144_y91_t12.1990.nc4
+  GEOSachem_edgar-v42.emis_nh3.anthropogenic.x1152_y721.19700703T12z_20200703T00z.nc4:
+    template: ExtData/chemistry/MERRA2/v0.0.0/sfc/edgar-v42.emis_nh3.anthropogenic.x1152_y721.19700703T12z_20200703T00z.nc4
+  GEOSachem_htap-v2.2.emis_so2.aviation_cds.x3600_y1800_t12.2010.nc4:
+    template: ExtData/chemistry/HTAP/v2.2/sfc/htap-v2.2.emis_so2.aviation_cds.x3600_y1800_t12.2010.nc4
+  GEOSachem_htap-v2.2.emis_so2.aviation_crs.x3600_y1800_t12.2010.nc4:
+    template: ExtData/chemistry/HTAP/v2.2/sfc/htap-v2.2.emis_so2.aviation_crs.x3600_y1800_t12.2010.nc4
+  GEOSachem_htap-v2.2.emis_so2.aviation_lto.x3600_y1800_t12.2010.nc4:
+    template: ExtData/chemistry/HTAP/v2.2/sfc/htap-v2.2.emis_so2.aviation_lto.x3600_y1800_t12.2010.nc4
+  GEOSachem_htap-v2.2.emis_so2.ships.x3600_y1800_t12.2010.nc4:
+    template: ExtData/chemistry/HTAP/v2.2/sfc/htap-v2.2.emis_so2.ships.x3600_y1800_t12.2010.nc4
+  GEOSachem_htapv2.2.emisso2.elevated.x3600y1800t12.2017.integrate.nc4:
+    template: ExtData/chemistry/HTAP/v2.2/sfc/htapv2.2.emisso2.elevated.x3600y1800t12.2017.integrate.nc4
+  GEOSachem_htapv2.2.emisso2.surface.x3600y1800t12.2017.integrate.nc4:
+    template: ExtData/chemistry/HTAP/v2.2/sfc/htapv2.2.emisso2.surface.x3600y1800t12.2017.integrate.nc4
+  GEOSachem_qfed2.emis_co.006.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_co.006.%y4%m2%d2.nc4
+    valid_range:  "2014-12-01T12:00/2021-11-01T12:00"
+  GEOSachem_qfed2.emis_nh3.006.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.006.%y4%m2%d2.nc4
+    valid_range:  "2014-12-01T12:00/2021-11-01T12:00"
+  GEOSachem_qfed2.emis_so2.006.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.006.%y4%m2%d2.nc4
+    valid_range:  "2014-12-01T12:00/2021-11-01T12:00"
+  GEOSachem_qfed2.emis_co.061.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_co.061.%y4%m2%d2.nc4
+    valid_range:  "2021-11-01T12:00/2025-01-01"
+  GEOSachem_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
+    valid_range:  "2021-11-01T12:00/2025-01-01"
+  GEOSachem_qfed2.emis_so2.061.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.061.%y4%m2%d2.nc4
+    valid_range:  "2021-11-01T12:00/2025-01-01"
+
+Samplings:
+  GEOSachem_sample_0:
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  GEOSachem_sample_1:
+    extrapolation: clim
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  GEOSachem_sample_2:
+    extrapolation: clim
+
+Exports:
+  CO_BF_VOC:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: emcobf
+  CO_BIOMASS_VOC:
+    - {starting: "2014-12-01T12:00",collection: GEOSachem_qfed2.emis_co.006.%y4%m2%d2.nc4,regrid: CONSERVE,sample: GEOSachem_sample_0,variable: biomass}
+    - {starting: "2021-11-01T12:00",collection: GEOSachem_qfed2.emis_co.061.%y4%m2%d2.nc4,regrid: CONSERVE,sample: GEOSachem_sample_0,variable: biomass}
+  CO_FS_VOC:
+    collection: GEOSachem_CO-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: GEOSachem_sample_0
+    variable: co
+  DMS_CONC_OCEAN:
+    collection: GEOSachem_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
+    linear_transformation:
+      - 0.0
+      - 1.0e-06
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: conc
+  H2O2:
+    collection: GEOSachem_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    variable: h2o2
+  NH3_EMIS:
+    collection: GEOSachem_edgar-v42.emis_nh3.anthropogenic.x1152_y721.19700703T12z_20200703T00z.nc4
+    regrid: CONSERVE
+    variable: emi_nh3
+  NH3_EMIS_FIRE:
+    - {starting: "2014-12-01T12:00",collection: GEOSachem_qfed2.emis_nh3.006.%y4%m2%d2.nc4,regrid: CONSERVE,sample: GEOSachem_sample_0,variable: biomass}
+    - {starting: "2021-11-01T12:00",collection: GEOSachem_qfed2.emis_nh3.061.%y4%m2%d2.nc4,regrid: CONSERVE,sample: GEOSachem_sample_0,variable: biomass}
+  NH3_EMIS_OCEAN:
+    collection: GEOSachem_GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: emiss_ocn
+  NO3:
+    collection: GEOSachem_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    variable: no3
+  OH:
+    collection: GEOSachem_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    variable: oh
+  SO2_EMIS_AIRCRAFT_CDS:
+    collection: GEOSachem_htap-v2.2.emis_so2.aviation_cds.x3600_y1800_t12.2010.nc4
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: so2_aviation
+  SO2_EMIS_AIRCRAFT_CRS:
+    collection: GEOSachem_htap-v2.2.emis_so2.aviation_crs.x3600_y1800_t12.2010.nc4
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: so2_aviation
+  SO2_EMIS_AIRCRAFT_LTO:
+    collection: GEOSachem_htap-v2.2.emis_so2.aviation_lto.x3600_y1800_t12.2010.nc4
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: so2_aviation
+  SO2_EMIS_ENERGY:
+    collection: GEOSachem_htapv2.2.emisso2.elevated.x3600y1800t12.2017.integrate.nc4
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: sanl2
+  SO3_EMIS_FIRE:
+    - {starting: "2014-12-01T12:00",collection: GEOSachem_qfed2.emis_so3.006.%y4%m2%d2.nc4,regrid: CONSERVE,sample: GEOSachem_sample_0,variable: biomass}
+    - {starting: "2021-11-01T12:00",collection: GEOSachem_qfed2.emis_so3.061.%y4%m2%d2.nc4,regrid: CONSERVE,sample: GEOSachem_sample_0,variable: biomass}
+  SO2_EMIS_NONENERGY:
+    collection: GEOSachem_htapv2.2.emisso2.surface.x3600y1800t12.2017.integrate.nc4
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: sanl1
+  SO2_EMIS_SHIPPING:
+    collection: GEOSachem_htap-v2.2.emis_so2.ships.x3600_y1800_t12.2010.nc4
+    regrid: CONSERVE
+    sample: GEOSachem_sample_1
+    variable: so2_ship
+  SOAG_EMIS:
+    collection: GEOSachem_SOAG.emiss.x144_y91_t12.1990.nc4
+    sample: GEOSachem_sample_2
+    variable: soag
+

--- a/GEOSCHEMchem_GridComp/run/CF.NI2G_GridComp_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.NI2G_GridComp_ExtData.yaml
@@ -1,0 +1,95 @@
+Collections:
+  NI2G_ARCTAS.region_mask.x540_y361.2008.nc:
+    template: ExtData/chemistry/Masks/v0.0.0/sfc/ARCTAS.region_mask.x540_y361.2008.nc
+  NI2G_GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4:
+    template: ExtData/chemistry/GEIA/v0.0.0/sfc/GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4
+  NI2G_GEOS.fp.asm.inst3_3d_aer_Nv.%y4%m2%d2_%h2%n2.V01.nc4:
+    template: /discover/nobackup/projects/gmao/gmao_ops/pub/fp/das/Y%y4/M%m2/D%d2/GEOS.fp.asm.inst3_3d_aer_Nv.%y4%m2%d2_%h2%n2.V01.nc4
+  NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
+    template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+  NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+  NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.006.%y4%m2%d2.nc4
+    valid_range: "2014-12-01T12:00/2021-11-01T12:00"
+  NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_nh3.061.%y4%m2%d2.nc4
+    valid_range: "2021-11-01T12:00/2025-01-01"
+
+Samplings:
+  NI2G_sample_0:
+    time_interpolation: False
+  NI2G_sample_1:
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  NI2G_sample_2:
+    extrapolation: clim
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  NI2G_sample_3:
+    extrapolation: persist_closest
+
+Exports:
+  EMI_NH3_AG:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: NI2G_sample_2
+    variable: nh3_emis
+  EMI_NH3_BB:
+    - {starting: "2014-12-01T12:00", collection: NI2G_qfed2.emis_nh3.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
+    - {starting: "2021-11-01T12:00", collection: NI2G_qfed2.emis_nh3.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: NI2G_sample_1, variable: biomass}
+  EMI_NH3_EN:
+    collection: NI2G_NH3-em-anthro_CMIP_CEDS_gn.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: NI2G_sample_1
+    variable: nh3
+  EMI_NH3_IN:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: NI2G_sample_2
+    variable: nh3_emis
+  EMI_NH3_OC:
+    collection: NI2G_GEIA.emis_NH3.ocean.x576_y361.t12.20080715_12z.nc4
+    regrid: CONSERVE
+    sample: NI2G_sample_2
+    variable: emiss_ocn
+  EMI_NH3_RE:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: NI2G_sample_2
+    variable: nh3_emis
+  EMI_NH3_TR:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: NI2G_sample_2
+    variable: nh3_emis
+  NITRATE_HNO3:
+    collection: NI2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    linear_transformation:
+      - 0.0
+      - 0.2
+    sample: NI2G_sample_1
+    variable: hno3
+  NI_regionMask:
+    collection: NI2G_ARCTAS.region_mask.x540_y361.2008.nc
+    regrid: VOTE
+    sample: NI2G_sample_3
+    variable: REGION_MASK
+  climNO3an1:
+    collection: NI2G_GEOS.fp.asm.inst3_3d_aer_Nv.%y4%m2%d2_%h2%n2.V01.nc4
+    regrid: CONSERVE
+    sample: NI2G_sample_0
+    variable: NO3AN1
+  climNO3an2:
+    collection: NI2G_GEOS.fp.asm.inst3_3d_aer_Nv.%y4%m2%d2_%h2%n2.V01.nc4
+    regrid: CONSERVE
+    sample: NI2G_sample_0
+    variable: NO3AN2
+  climNO3an3:
+    collection: NI2G_GEOS.fp.asm.inst3_3d_aer_Nv.%y4%m2%d2_%h2%n2.V01.nc4
+    regrid: CONSERVE
+    sample: NI2G_sample_0
+    variable: NO3AN3
+

--- a/GEOSCHEMchem_GridComp/run/CF.SS2G_GridComp_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.SS2G_GridComp_ExtData.yaml
@@ -1,0 +1,112 @@
+Collections:
+  SS2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4:
+    template: ExtData/chemistry/MERRAero/v0.0.0/L72/dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+  SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4:
+    template: ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+
+Samplings:
+  SS2G_sample_0:
+    extrapolation: clim
+
+Exports:
+  climSSDP001:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSDP001
+  climSSDP002:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSDP002
+  climSSDP003:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSDP003
+  climSSDP004:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSDP004
+  climSSDP005:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSDP005
+  climSSSD001:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSD001
+  climSSSD002:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSD002
+  climSSSD003:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSD003
+  climSSSD004:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSD004
+  climSSSD005:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSD005
+  climSSSV001:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSV001
+  climSSSV002:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSV002
+  climSSSV003:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSV003
+  climSSSV004:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSV004
+  climSSSV005:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSSV005
+  climSSWT001:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSWT001
+  climSSWT002:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSWT002
+  climSSWT003:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSWT003
+  climSSWT004:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSWT004
+  climSSWT005:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: SSWT005
+  climss001:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: ss001
+  climss002:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: ss002
+  climss003:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: ss003
+  climss004:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: ss004
+  climss005:
+    collection: SS2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: SS2G_sample_0
+    variable: ss005
+

--- a/GEOSCHEMchem_GridComp/run/CF.SU2G_GridComp_ExtData.yaml
+++ b/GEOSCHEMchem_GridComp/run/CF.SU2G_GridComp_ExtData.yaml
@@ -1,0 +1,177 @@
+Collections:
+  SU2G_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4:
+    template: ExtData/chemistry/Lana/v2011/DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
+  SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4:
+    template: ExtData/chemistry/MERRA2GMI/v0.0.0/L72/MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+  SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/L72/SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+  SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+  SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+  SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+  SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4:
+    template: ExtData/chemistry/CEDS/v2021-04-21-revised/sfc/SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+  SU2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4:
+    template: ExtData/chemistry/MERRAero/v0.0.0/L72/dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+  SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4:
+    template: ExtData/chemistry/MERRAero/v0.0.0/sfc/dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+  SU2G_qfed2.emis_so2.006.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.006.%y4%m2%d2.nc4
+    valid_range: "2014-12-01T12:00/2021-11-01T12:00"
+  SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4:
+    template: ExtData/chemistry/QFED/vNRT/sfc/0.1/Y%y4/M%m2/qfed2.emis_so2.061.%y4%m2%d2.nc4
+    valid_range: "2021-11-01T12:00/2025-01-01"
+
+Samplings:
+  SU2G_sample_0:
+    extrapolation: clim
+  SU2G_sample_1:
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+  SU2G_sample_2:
+    extrapolation: clim
+    update_frequency: PT24H
+    update_offset: PT12H
+    update_reference_time: '0'
+
+Exports:
+  SU_AIRCRAFT:
+    collection: SU2G_SO2-em-AIR-anthro_input4MIPs_emissions_CMIP_CEDS-2021-04-21_gn__aviation.x576_y361_z72_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_1
+    variable: so2_aviation
+  SU_ANTHROL1:
+    collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_nonenergy.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_1
+    variable: so2_nonenergy
+  SU_ANTHROL2:
+    collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_energy.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_1
+    variable: so2_energy
+  SU_AVIATION_CDS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: so2_aviation
+  SU_AVIATION_CRS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: so2_aviation
+  SU_AVIATION_LTO:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: so2_aviation
+  SU_BIOMASS:
+    - {starting: "2014-12-01T12:00", collection: SU2G_qfed2.emis_so2.006.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
+    - {starting: "2021-11-01T12:00", collection: SU2G_qfed2.emis_so2.061.%y4%m2%d2.nc4, linear_transformation: [0.0, 0.778], regrid: CONSERVE, sample: SU2G_sample_1, variable: biomass}
+  SU_DMSO:
+    collection: SU2G_DMSclim_sfcconcentration.x360_y181_t12.Lana2011.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: conc
+  SU_H2O2:
+    collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_1
+    variable: h2o2
+  SU_NO3:
+    collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_1
+    variable: no3
+  SU_OH:
+    collection: SU2G_MERRA2_GMI.tavg24_3d_dac_Nv.x576_y361_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_1
+    variable: oh
+  SU_SHIPSO2:
+    collection: SU2G_SO2-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_1
+    variable: so2_shipping
+  SU_SHIPSO4:
+    collection: SU2G_SO4-em-anthro_CMIP_CEDS_gn_shipping.x2304_y1441_t12.%y4.nc4
+    regrid: CONSERVE
+    sample: SU2G_sample_1
+    variable: so4_shipping
+  climSO4:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nv.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SO4
+  climSUDP001:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUDP001
+  climSUDP002:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUDP002
+  climSUDP003:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUDP003
+  climSUDP004:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUDP004
+  climSUSD001:
+    collection: /dev/null
+    sample: SU2G_sample_0
+    variable: SUSD001
+  climSUSD002:
+    collection: /dev/null
+    sample: SU2G_sample_0
+    variable: SUSD002
+  climSUSD003:
+    collection: /dev/null
+    sample: SU2G_sample_0
+    variable: SUSD003
+  climSUSD004:
+    collection: /dev/null
+    sample: SU2G_sample_0
+    variable: SUSD004
+  climSUSV001:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUSV001
+  climSUSV002:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUSV002
+  climSUSV003:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUSV003
+  climSUSV004:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUSV004
+  climSUWT001:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUWT001
+  climSUWT002:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUWT002
+  climSUWT003:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUWT003
+  climSUWT004:
+    collection: SU2G_dR_MERRA-AA-r2.aer_Nx.2003_2014.2008clm.nc4
+    sample: SU2G_sample_0
+    variable: SUWT004
+  pSO2_OCS:
+    collection: /dev/null
+    regrid: CONSERVE
+    sample: SU2G_sample_2
+    variable: biofuel
+


### PR DESCRIPTION
Moved the CF custom resource files from the @geos-chem repo, to reside for now under GEOSCHEMchem_GridComp/run .
Eventually these should be removed, when the standard resource files for GOCART and GOCART2G are suitable.